### PR TITLE
Claude Code サブエージェント運用フロー導入 + テスト実行を PR 時に移動

### DIFF
--- a/.claude/agents/pr-submitter.md
+++ b/.claude/agents/pr-submitter.md
@@ -28,7 +28,10 @@ model: sonnet
 4. **プッシュ**
    - `git push -u origin feature/<task-name>`
 5. **PR 作成**
-   - `gh pr create --title "..." --body "$(cat <<EOF ... EOF)"` を使う
+   - `gh pr create --base develop --head feature/<task-name> --title "..." --body-file <tmp>` を使う
+   - **base は原則 `develop`**（`main` へ直接 PR しない — `restrict-main-merge.yml` で拒否される）
+   - シェルで `gh` が PATH に無い場合はフルパス `"C:\Program Files\GitHub CLI\gh.exe"` を PowerShell から呼ぶ
+   - Body は一時ファイル（`New-TemporaryFile`）に書き出して `--body-file` で渡すのが安全（HEREDOC はシェル差で崩れる）
    - タイトルは 70 文字以内
    - Body には Summary（1〜3 箇条書き）、Test plan（チェックリスト）を含める
    - decisions.md に追記した場合は Body に「Related decision: `docs/decisions.md#<日付>`」を書く

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '24'
           cache: 'npm'
 
       - name: Install dependencies

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,27 @@
+name: Test
+
+on:
+  pull_request:
+    branches:
+      - main
+      - develop
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Generate Prisma client
+        run: npx prisma generate
+
+      - name: Run tests
+        run: npm test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,6 +9,8 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
+    env:
+      TZ: Asia/Tokyo
     steps:
       - uses: actions/checkout@v4
 

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,2 +1,0 @@
-#\!/bin/sh
-npm test


### PR DESCRIPTION
﻿## Summary
- `.claude/agents/` に 5 つのサブエージェント（policy-checker / test-writer / implementer / code-reviewer / pr-submitter）を追加し、実装フローを分業化
- `CLAUDE.md` にサブエージェント運用フロー節を追記、`docs/decisions.md` に決定理由を記録
- `.husky/pre-commit`（毎回 `npm test` を走らせていた）を削除
- `.github/workflows/test.yml` を追加し、`main` / `develop` への PR で `npm test` を実行

## Motivation
- コミット毎のテスト実行は開発リズムを止めるため、CI 側に寄せてローカルは軽量化
- サブエージェントで規約チェック・TDD・レビューの各フェーズを固定化し、CLAUDE.md の規約遵守率を上げる

## Test plan
- [x] この PR で新設した `Test` workflow が起動し `npm test` がグリーンになること
- [x] コミット時に自動でテストが走らないこと
- [x] 既存の `Restrict main branch merges` workflow は変更なし

## Related decision
- `docs/decisions.md#2026-08-08`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
