### PR TITLE
ci(e2e): Playwright の baseURL を切り替え可能にし PR 用ワークフローを追加

### DIFF
--- a/.env.test.example
+++ b/.env.test.example
@@ -5,3 +5,6 @@
 # 取得方法: Vercel ダッシュボード > プロジェクト設定 > Deployment Protection > Automation Bypass Secret
 # 参考: https://vercel.com/docs/deployment-protection#automation-bypass-protection
 VERCEL_BYPASS_SECRET=your_bypass_secret_here
+
+# Optional: E2E target URL. If omitted, the develop Vercel deployment is used.
+E2E_BASE_URL=https://adhd-git-develop-km-copepodas-projects.vercel.app

--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -1,0 +1,56 @@
+name: PR Tests
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+
+permissions:
+  contents: read
+
+jobs:
+  unit:
+    name: Unit tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - run: npm ci
+      - run: npm test
+
+  e2e:
+    name: E2E tests
+    # E2E uses repository secrets for Vercel's deployment-protection bypass.
+    # Do not expose those secrets to pull requests from forks.
+    if: github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    env:
+      VERCEL_BYPASS_SECRET: ${{ secrets.VERCEL_BYPASS_SECRET }}
+      E2E_BASE_URL: ${{ vars.E2E_BASE_URL }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - run: npm ci
+      - name: Install Playwright browser
+        run: npx playwright install --with-deps chromium
+      - name: Run E2E tests
+        run: npm run test:e2e
+
+      - name: Upload Playwright report
+        if: ${{ !cancelled() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: |
+            playwright-report/
+            test-results/
+          retention-days: 14

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -4,6 +4,10 @@ import { config } from "dotenv";
 // .env.test から E2E 専用の環境変数を読み込む
 config({ path: ".env.test" });
 
+const baseURL =
+  process.env.E2E_BASE_URL ||
+  "https://adhd-git-develop-km-copepodas-projects.vercel.app";
+
 export default defineConfig({
   testDir: "./e2e",
   fullyParallel: false,
@@ -12,7 +16,7 @@ export default defineConfig({
   workers: 1,
   reporter: "html",
   use: {
-    baseURL: "https://adhd-git-develop-km-copepodas-projects.vercel.app",
+    baseURL,
     trace: "on-first-retry",
     screenshot: "only-on-failure",
     video: "on-first-retry",


### PR DESCRIPTION
## Summary
- Playwright の baseURL を `E2E_BASE_URL` 環境変数で上書き可能に（未指定時は develop preview URL がデフォルト）
- `.env.test.example` に `E2E_BASE_URL` の設定例を追記
- PR に対して unit + e2e を回す GitHub Actions ワークフローを新設（fork PR では e2e をスキップし、secret 露出を防ぐ）

## Test plan
- [x] 既存ローカル unit tests は無影響（config 変更のみ、既存 baseURL 挙動はデフォルト値で維持）
- [ ] マージ後、次の PR で `pr-tests.yml` の unit / e2e ジョブが起動することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)