### PR TITLE
ci(coverage): PRでvitestカバレッジをコメント表示

### DIFF
--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -29,6 +29,12 @@ jobs:
         run: npm run test:coverage
 
       - name: Report coverage on PR
-        # Skip on fork PRs (read-only GITHUB_TOKEN) — the action would 403 and fail the job.
-        if: always() && github.event.pull_request.head.repo.full_name == github.repository
+        # Skip when the workflow runs with a read-only GITHUB_TOKEN — the action
+        # would 403 and fail the job. Two cases:
+        #   1. PR from a fork (head repo != this repo)
+        #   2. Dependabot-triggered PRs (branch is same-repo, but GitHub still
+        #      downgrades the token to read-only unless explicitly enabled)
+        if: always()
+          && github.event.pull_request.head.repo.full_name == github.repository
+          && github.actor != 'dependabot[bot]'
         uses: davelosert/vitest-coverage-report-action@v2

--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -6,6 +6,7 @@ on:
 
 permissions:
   contents: read
+  pull-requests: write
 
 jobs:
   unit:
@@ -24,4 +25,9 @@ jobs:
       - run: npm ci
       - name: Generate Prisma client
         run: npx prisma generate
-      - run: npm test
+      - name: Run tests with coverage
+        run: npm run test:coverage
+
+      - name: Report coverage on PR
+        if: always()
+        uses: davelosert/vitest-coverage-report-action@v2

--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -29,5 +29,6 @@ jobs:
         run: npm run test:coverage
 
       - name: Report coverage on PR
-        if: always()
+        # Skip on fork PRs (read-only GITHUB_TOKEN) — the action would 403 and fail the job.
+        if: always() && github.event.pull_request.head.repo.full_name == github.repository
         uses: davelosert/vitest-coverage-report-action@v2

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "start": "next start",
     "lint": "eslint",
     "test": "vitest run",
+    "test:coverage": "vitest run --coverage",
     "test:watch": "vitest",
     "test:integration": "vitest run --config vitest.config.integration.ts",
     "test:e2e": "playwright test",

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -16,6 +16,7 @@ export default defineConfig({
         "src/**/*.test.{ts,tsx}",
         "src/__tests__/**",
         "src/**/*.d.ts",
+        "src/generated/**",
       ],
       reportOnFailure: true,
     },

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -8,6 +8,17 @@ export default defineConfig({
     setupFiles: ["./src/__tests__/setup.ts"],
     include: ["src/**/*.test.{ts,tsx}"],
     exclude: ["src/__tests__/integration/**"],
+    coverage: {
+      provider: "v8",
+      reporter: ["text", "json", "json-summary", "html"],
+      include: ["src/**/*.{ts,tsx}"],
+      exclude: [
+        "src/**/*.test.{ts,tsx}",
+        "src/__tests__/**",
+        "src/**/*.d.ts",
+      ],
+      reportOnFailure: true,
+    },
   },
   resolve: {
     alias: {


### PR DESCRIPTION
## Summary
- `npm run test:coverage`（vitest run --coverage）スクリプトを追加
- `vitest.config.ts` に v8 provider / `json-summary`・`json`・`html`・`text` レポーターを設定
- `.github/workflows/pr-tests.yml` を coverage 実行に切り替え、`davelosert/vitest-coverage-report-action@v2` で PR にカバレッジ表を投稿するように変更
- 上記アクションが PR コメントを書き込めるよう `pull-requests: write` を付与

## 変更しなかったこと
- カバレッジ閾値は設定していません（初期段階なので通知のみの緩い運用）。運用が定着してから `thresholds` 追加を検討する想定です。
- 外部サービス（Codecov 等）連携は追加していません。GitHub Actions 内で完結します。

## Test plan
- [x] ローカルで `npm run test:coverage` が成功（178 test files passed）
- [x] `coverage/coverage-summary.json` が生成されることを確認（アクションが読み取るファイル）
- [x] この PR 自体で GitHub Actions が動き、PR コメントにカバレッジ表が表示されることを確認

## 備考（TDD について）
CI/ワークフロー設定のみの変更のため、`src/__tests__/` に追加できる意味のあるテストが無く TDD の Red-Green サイクルはスキップしました。動作確認はローカルでの `npm run test:coverage` 実行と、この PR での Actions 実行結果で行います。

🤖 Generated with [Claude Code](https://claude.com/claude-code)