### PR TITLE
feat(analytics): Vercel Speed Insights を導入

### DIFF
--- a/docs/未実装仕様書/analytics-setup.md
+++ b/docs/未実装仕様書/analytics-setup.md
@@ -95,3 +95,26 @@ Vercelにデプロイすれば自動的にダッシュボードでデータが�
 | 広告出稿時 | アトリビューション | GA4 |
 
 MVPの現段階ではVercel Analyticsで十分。過剰な計測は入れない。
+
+---
+
+## 5. Speed Insights の併用（導入済み）
+
+Web Analytics（ページビュー）とは別に、**実ユーザーのブラウザから見たページ表示速度**（Core Web Vitals: LCP / INP / CLS / TTFB / FCP）を計測するため `@vercel/speed-insights` を導入済み。
+
+| 項目 | 内容 |
+|------|------|
+| パッケージ | `@vercel/speed-insights` |
+| 費用 | Hobbyプラン: 10,000 データポイント/月まで無料 |
+| Cookie | 不要 |
+| 導入場所 | `src/app/layout.tsx` の `<body>` 末尾に `<SpeedInsights />` |
+
+### Web Analytics との使い分け
+
+| 目的 | 使うツール |
+|------|-----------|
+| どのページが見られているか | Web Analytics（未導入） |
+| ページ表示が遅くないか | Speed Insights（導入済み） |
+| API リクエスト処理が遅くないか | サーバー側 `routeLogger` の `durationMs` ログ |
+
+Speed Insights は「ページを開いてから描画が完了するまで」の遅さのみを拾える。API 往復の遅さはサーバー側ログとの突き合わせで切り分ける。

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@prisma/client": "^7.4.2",
         "@supabase/ssr": "^0.9.0",
         "@supabase/supabase-js": "^2.99.0",
+        "@vercel/speed-insights": "^2.0.0",
         "canvas-confetti": "^1.9.4",
         "next": "16.1.6",
         "pg": "^8.20.0",
@@ -3390,6 +3391,44 @@
       "os": [
         "win32"
       ]
+    },
+    "node_modules/@vercel/speed-insights": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@vercel/speed-insights/-/speed-insights-2.0.0.tgz",
+      "integrity": "sha512-jwkNcrTeafWxjmWq4AHBaptSqZiJkYU5adLC9QBSqeim0GcqDMgN5Ievh8OG1rJ6W3A4l1oiP7qr9CWxGuzu3w==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "@sveltejs/kit": "^1 || ^2",
+        "next": ">= 13",
+        "nuxt": ">= 3",
+        "react": "^18 || ^19 || ^19.0.0-rc",
+        "svelte": ">= 4",
+        "vue": "^3",
+        "vue-router": "^4"
+      },
+      "peerDependenciesMeta": {
+        "@sveltejs/kit": {
+          "optional": true
+        },
+        "next": {
+          "optional": true
+        },
+        "nuxt": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "svelte": {
+          "optional": true
+        },
+        "vue": {
+          "optional": true
+        },
+        "vue-router": {
+          "optional": true
+        }
+      }
     },
     "node_modules/@vitest/coverage-v8": {
       "version": "4.1.0",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "@prisma/client": "^7.4.2",
     "@supabase/ssr": "^0.9.0",
     "@supabase/supabase-js": "^2.99.0",
+    "@vercel/speed-insights": "^2.0.0",
     "canvas-confetti": "^1.9.4",
     "next": "16.1.6",
     "pg": "^8.20.0",

--- a/src/__tests__/speed-insights.test.ts
+++ b/src/__tests__/speed-insights.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from "vitest";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+
+describe("RootLayout: Vercel Speed Insights", () => {
+  const layoutSource = readFileSync(
+    path.resolve(__dirname, "../app/layout.tsx"),
+    "utf-8"
+  );
+
+  it("imports SpeedInsights from @vercel/speed-insights/next", () => {
+    expect(layoutSource).toMatch(/from ["']@vercel\/speed-insights\/next["']/);
+  });
+
+  it("renders <SpeedInsights /> inside the layout", () => {
+    expect(layoutSource).toMatch(/<SpeedInsights\b/);
+  });
+});

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata, Viewport } from "next";
 import { Noto_Sans_JP, Cinzel } from "next/font/google";
 import "./globals.css";
+import { SpeedInsights } from "@vercel/speed-insights/next";
 import ServiceWorkerRegistration from "@/components/ServiceWorkerRegistration";
 import IOSInstallPrompt from "@/components/IOSInstallPrompt";
 
@@ -48,6 +49,7 @@ export default function RootLayout({
         <ServiceWorkerRegistration />
         <IOSInstallPrompt />
         {children}
+        <SpeedInsights />
       </body>
     </html>
   );


### PR DESCRIPTION
## Summary
- ページ側の遅延（Core Web Vitals: LCP / INP / CLS / TTFB / FCP）を実ユーザーのブラウザから計測するため `@vercel/speed-insights` を導入
- `src/app/layout.tsx` の `<body>` 末尾に `<SpeedInsights />` を追加
- API 側の遅延はサーバーログ（`routeLogger.done` の `durationMs`）、ページ描画側は Speed Insights で切り分ける方針を `docs/未実装仕様書/analytics-setup.md` に追記

## Why
「リクエストが遅いときがある気がする」という体感の裏付けを取るため。まずページ表示側の実測値をダッシュボードで見えるようにする。Cookie 不要・PII なしなので子供向けアプリのプライバシー要件を満たす。

## Test plan
- [x] `src/__tests__/speed-insights.test.ts` を追加（TDD Red → Green）
- [x] `npm test` 全 179 files / 2491 tests パス
- [ ] Vercel にデプロイ後、Speed Insights ダッシュボードにデータが流れることを確認