### PR TITLE
chore: .gitignoreにPythonの__pycache__除外パターンを追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,6 @@ yarn-error.log*
 next-env.d.ts
 
 /src/generated/prisma
+
+# python (scripts/synthesize-skills.mjs 等の補助スクリプト用)
+__pycache__/

--- a/src/__tests__/gitignore.test.ts
+++ b/src/__tests__/gitignore.test.ts
@@ -1,0 +1,10 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "fs";
+import { join } from "path";
+
+describe(".gitignore", () => {
+  it("Pythonのバイトコードキャッシュ（__pycache__）を除外する", () => {
+    const content = readFileSync(join(process.cwd(), ".gitignore"), "utf-8");
+    expect(content).toMatch(/__pycache__/);
+  });
+});


### PR DESCRIPTION
## Summary
- `.gitignore` に Python の `__pycache__/` 除外パターンを追加
- `scripts/synthesize-skills.mjs` 実行時に生成される `scripts/__pycache__/` が誤ってgit管理下に入るのを防ぐ

## Test plan
- [x] `npm test` パス（180 files / 2495 tests all green）
- [x] `npm run lint`: 新規ファイル（`gitignore.test.ts`）自体はクリーン。リポジトリ全体では今回の変更と無関係な既存エラーが多数あり全体としてはFAILのまま（別issue化を推奨）
- [x] 手動確認: `.gitignore` 追記後に `scripts/__pycache__/` が `git status` の untracked 一覧から消えることを確認

Closes #15

---
🤖 issue-auto-pipeline の動作検証（Step 0-8）を兼ねたテストPRです。`/issue-picker` → TDD実装 → PR作成までの通し動作を確認しています。
