### PR TITLE
ci: PRワークフローにESLintジョブを追加（非ブロッキング）

### DIFF
--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -38,3 +38,22 @@ jobs:
           && github.event.pull_request.head.repo.full_name == github.repository
           && github.actor != 'dependabot[bot]'
         uses: davelosert/vitest-coverage-report-action@v2
+
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    # Stage 1: visualize lint results without blocking PRs. There are ~1670
+    # pre-existing errors (see #19-#23 for the cleanup plan). Flip this to
+    # false only after that debt is paid down (tracked in #24).
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: npm
+
+      - run: npm ci
+      - name: Run ESLint
+        run: npm run lint


### PR DESCRIPTION
## Summary
- issue #18 対応: `.github/workflows/pr-tests.yml` に既存 `unit` ジョブと並列で `lint` ジョブを新設
- `actions/checkout@v4` → `actions/setup-node@v4`(node 24, cache npm) → `npm ci` → `npm run lint` を実行
- 第1段階は `continue-on-error: true` で non-blocking（既存の ~1670 件の pre-existing lint エラーがあるため）。クリーンアップ完了後、#24 でブロッキング化予定

## Test plan
- [x] `npm test` パス（180 files / 2495 tests、CI設定ファイルのみの変更のためテスト対象なし・影響なしを確認）
- [ ] `npm run lint`（新設ジョブが CI 上で non-blocking に実行されることを確認）
- [x] code-reviewer による APPROVED 確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)
