### PR TITLE
chore(lint): 機械的に解消できるESLintエラー29件を修正

### DIFF
--- a/e2e/auth.setup.ts
+++ b/e2e/auth.setup.ts
@@ -8,7 +8,7 @@
 import { test as setup, expect } from "./fixtures";
 import path from "path";
 import fs from "fs";
-import { AUTH_DIR, VERCEL_BASE_URL, createBrowserContext, getBypassHeaders } from "./credentials";
+import { AUTH_DIR, createBrowserContext, getBypassHeaders } from "./credentials";
 
 const CREDENTIALS_FILE = path.join(AUTH_DIR, "qa-credentials.json");
 

--- a/e2e/s3-child-login.spec.ts
+++ b/e2e/s3-child-login.spec.ts
@@ -61,7 +61,6 @@ test.describe("S3: 子供ログイン", () => {
     // ページ内で toUpperCase 変換が行われるかを確認
     const input = page.locator('input[placeholder="ABC123"]');
     await input.fill("vjzqsh");
-    const value = await input.inputValue();
     // JavaScriptによりUI上ではUpperCaseになるが、最終submitで正しく処理される
     // (実際の変換はonChange内で行われる)
     await page.fill('input[placeholder="1234"]', "0321");

--- a/e2e/s5-quest-report.spec.ts
+++ b/e2e/s5-quest-report.spec.ts
@@ -59,9 +59,6 @@ test.describe("S5: 子供クエスト完了報告", () => {
       return;
     }
 
-    // クエスト名を記録
-    const questTitle = await pendingQuest.locator("p.text-sm.font-medium").first().textContent();
-
     await pendingQuest.click();
     await expect(page.getByRole("button", { name: /クエスト完了/ })).toBeVisible({ timeout: 5000 });
 

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -12,7 +12,31 @@ const eslintConfig = defineConfig([
     "out/**",
     "build/**",
     "next-env.d.ts",
+    // Prisma generated client output (gitignored, environment-dependent).
+    "src/generated/**",
   ]),
+  {
+    // next/image を <img> でモックするのは意図的（LCP最適化の対象外）。
+    files: ["src/__tests__/**"],
+    rules: {
+      "@next/next/no-img-element": "off",
+    },
+  },
+  {
+    // Playwright の fixture が `page` / `use` という名前のため
+    // React Hook と誤検知される（e2e/fixtures.ts）。純粋な誤検知。
+    files: ["e2e/**"],
+    rules: {
+      "react-hooks/rules-of-hooks": "off",
+    },
+  },
+  {
+    // 依存パッケージ不要の CommonJS 単体スクリプト。ESM化する必然性がない。
+    files: ["scripts/**"],
+    rules: {
+      "@typescript-eslint/no-require-imports": "off",
+    },
+  },
 ]);
 
 export default eslintConfig;

--- a/scripts/convert-collection-monthly.mjs
+++ b/scripts/convert-collection-monthly.mjs
@@ -17,7 +17,7 @@
  */
 import sharp from "sharp";
 import { execSync } from "child_process";
-import { existsSync, mkdirSync, writeFileSync, readFileSync, unlinkSync } from "fs";
+import { mkdirSync, writeFileSync, unlinkSync } from "fs";
 import { join, basename, dirname } from "path";
 import { fileURLToPath } from "url";
 

--- a/src/__tests__/components/MonsterImageModal.test.tsx
+++ b/src/__tests__/components/MonsterImageModal.test.tsx
@@ -6,7 +6,6 @@ import MonsterImageModal from "@/components/MonsterImageModal";
 // next/image を img タグにモック
 vi.mock("next/image", () => ({
   default: (props: { src: string; alt: string; [key: string]: unknown }) => (
-    // eslint-disable-next-line @next/next/no-img-element
     <img src={props.src} alt={props.alt} />
   ),
 }));

--- a/src/__tests__/components/child-bottomnav-treasure-badge.test.tsx
+++ b/src/__tests__/components/child-bottomnav-treasure-badge.test.tsx
@@ -8,12 +8,10 @@ vi.mock("next/navigation", () => ({
 }));
 
 const realtimeHandlers: Record<string, (payload: unknown) => void> = {};
-let realtimeChannelKey = "";
 
 vi.mock("@/lib/supabase/client", () => ({
   createClient: () => ({
-    channel: (key: string) => {
-      realtimeChannelKey = key;
+    channel: () => {
       return {
         on: function (
           _event: string,
@@ -62,7 +60,6 @@ function buildFetch(treasureStatus: { locked: number; unlocked: number; opened?:
 beforeEach(() => {
   mockPath = "/app/child/quests";
   Object.keys(realtimeHandlers).forEach((k) => delete realtimeHandlers[k]);
-  realtimeChannelKey = "";
   localStorage.clear();
 });
 

--- a/src/__tests__/components/child-view-monster-cutscene-listener.test.tsx
+++ b/src/__tests__/components/child-view-monster-cutscene-listener.test.tsx
@@ -5,7 +5,6 @@ import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 vi.mock("next/image", () => ({
   __esModule: true,
   default: ({ src, alt }: { src: string; alt: string }) => (
-    // eslint-disable-next-line @next/next/no-img-element
     <img src={src} alt={alt} />
   ),
 }));

--- a/src/__tests__/components/child-view-quests-skip-and-cutscene.test.tsx
+++ b/src/__tests__/components/child-view-quests-skip-and-cutscene.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 import { render, screen, waitFor, act, fireEvent } from "@testing-library/react";
-import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, vi, afterEach } from "vitest";
 
 vi.mock("next/navigation", () => ({
   useParams: () => ({ childId: "child-1" }),
@@ -38,7 +38,6 @@ vi.mock("@/components/LoadingSpinner", () => ({
 vi.mock("next/image", () => ({
   __esModule: true,
   default: ({ src, alt }: { src: string; alt: string }) => (
-    // eslint-disable-next-line @next/next/no-img-element
     <img src={src} alt={alt} />
   ),
 }));

--- a/src/__tests__/components/child-view-selector-page.test.tsx
+++ b/src/__tests__/components/child-view-selector-page.test.tsx
@@ -8,7 +8,7 @@ vi.mock("next/navigation", () => ({
 
 vi.mock("next/image", () => ({
   default: (props: Record<string, unknown>) => {
-    // eslint-disable-next-line jsx-a11y/alt-text, @next/next/no-img-element
+    // eslint-disable-next-line jsx-a11y/alt-text
     return <img {...(props as { src: string; alt: string })} />;
   },
 }));

--- a/src/__tests__/integration/quest-flow.test.ts
+++ b/src/__tests__/integration/quest-flow.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeAll, afterAll, beforeEach } from "vitest";
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
 import { GET as getToday } from "@/app/api/quests/today/route";
 import { POST as reportQuest } from "@/app/api/quests/[id]/report/route";
 import { GET as getPending } from "@/app/api/approve/pending/route";

--- a/src/__tests__/lib/constants.test.ts
+++ b/src/__tests__/lib/constants.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 import { MONSTER_TABLE, MONSTER_TABLE_LIGHT, getMonsterStage, getEvolutionChildren } from "@/lib/monsters";
 import { EVOLUTION_THRESHOLDS, REBIRTH_THRESHOLD, REBIRTH_EGG_THRESHOLD, checkEvolution, getXpInfo, computeEvolutionWeights, selectEvolutionPath, applyEggBonus } from "@/lib/evolution";
 import { CATEGORY_LABEL, CATEGORY_COLOR, DAY_LABELS, TEMP_TASK_TEMPLATES, generateFamilyCode, generateChildCode } from "@/lib/categories";

--- a/src/app/api/gathering/stamp/route.ts
+++ b/src/app/api/gathering/stamp/route.ts
@@ -15,7 +15,7 @@ import { log } from "@/lib/logger";
  * Push 配信はレスポンス前に await する。1日1回の低頻度アクションなので
  * Vercel Function の終了でメッセージが落ちないことを優先（高頻度ログのような after() 化は不要）。
  */
-export async function POST(_request: Request) {
+export async function POST() {
   const user = await getCurrentUser();
   if (!user || user.role !== "CHILD") {
     return NextResponse.json({ error: "認証が必要です" }, { status: 401 });

--- a/src/components/MonsterMiniCard.tsx
+++ b/src/components/MonsterMiniCard.tsx
@@ -3,7 +3,6 @@
 import Image from "next/image";
 import Link from "next/link";
 import type { MonsterMiniData } from "@/lib/monster-mini";
-import { REBIRTH_THRESHOLD } from "@/lib/evolution";
 
 type Props = {
   data: MonsterMiniData;

--- a/src/components/child/BottomNav.tsx
+++ b/src/components/child/BottomNav.tsx
@@ -181,7 +181,6 @@ export default function BottomNav() {
     } else if (streakRef.current !== null) {
       computeBadgesCount(streakRef.current, unlockedBadgeCountRef.current);
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [pathname]);
 
   if (!shouldShowBottomNav(pathname ?? "")) return null;


### PR DESCRIPTION
## Summary
- `eslint.config.mjs` にテスト/e2e/scripts限定のoverrideを追加（プロダクションコードのルールは変更なし）
- 未使用変数・不要な `eslint-disable` ディレクティブを削除
- `npm run lint`: 1698 problems → 1670 problems（`react/no-children-prop` 8件・`no-explicit-any` 1644件は意図的に対象外、不変）

## 既知の申し送り事項（本PRでは未修正）
- `e2e/s17-task-edit-delete.spec.ts` L114 の `taskRes`（`page.request.post("/api/tasks", ...)` の戻り値）に対するアサーションが漏れている疑いがあります。作成APIが失敗していてもテストが検知できない可能性があり、実装バグの可能性があります。本PRのスコープ（機械的に解消できるlintエラーの修正）外のため意図的に未修正としています。別Issueでの対応を推奨します。

## Test plan
- [x] `npm test` パス（180 files / 2495 tests）
- [x] `npm run lint`（1698 → 1670 problems、意図的な対象外項目は不変であることを確認）
- [x] 該当機能の手動確認手順（本PRはlintエラー修正のみのため、実行時挙動の変化なし）

Closes #19

🤖 Generated with [Claude Code](https://claude.com/claude-code)
