### PR TITLE
refactor(types): プロダクションコードのno-explicit-any 20件を適切な型に置き換え

### DIFF
--- a/src/app/api/approve/pending/route.ts
+++ b/src/app/api/approve/pending/route.ts
@@ -51,8 +51,8 @@ export async function GET() {
   // QuestDeclaration をルックアップする。approveQuestInstance と同じ
   // 照合キーを使い、親が見る +Xpt と実際の付与額を一致させる。
   const declarationKeys = quests
-    .filter((q: any) => q.reportedAt)
-    .map((q: any) => ({
+    .filter((q): q is typeof q & { reportedAt: Date } => q.reportedAt != null)
+    .map((q) => ({
       templateId: q.templateId,
       childId: q.childId,
       date: jstDateOf(q.reportedAt),
@@ -71,7 +71,7 @@ export async function GET() {
     );
   }
 
-  const enriched = quests.map((q: any) => {
+  const enriched = quests.map((q) => {
     const declaredToday = q.reportedAt
       ? declaredSet.has(`${q.templateId}|${q.childId}|${jstDateOf(q.reportedAt).toISOString()}`)
       : false;

--- a/src/app/api/parent/child-view/badges/route.ts
+++ b/src/app/api/parent/child-view/badges/route.ts
@@ -44,7 +44,7 @@ export async function GET(request: Request) {
     }),
   ]);
 
-  const unlockedMap = new Map(unlockedRecords.map((r: any) => [r.badgeId, r.unlockedAt]));
+  const unlockedMap = new Map(unlockedRecords.map((r) => [r.badgeId, r.unlockedAt]));
 
   const badges = ALL_BADGES.map((badge) => ({
     ...badge,

--- a/src/app/api/parent/child-view/monster-status/route.ts
+++ b/src/app/api/parent/child-view/monster-status/route.ts
@@ -19,7 +19,7 @@ export async function GET(request: Request) {
   if (!resolved.ok) {
     return NextResponse.json({ error: resolved.error }, { status: resolved.status });
   }
-  const child = resolved.child as any;
+  const child = resolved.child;
 
   const monthStart = monthStartJST();
   const monthEnd = monthEndJST();
@@ -41,7 +41,7 @@ export async function GET(request: Request) {
     }),
   ]);
 
-  const templateIds = Array.from(new Set((pendingQuests as any[]).map((q) => q.templateId)));
+  const templateIds = Array.from(new Set(pendingQuests.map((q) => q.templateId)));
   const declarations = templateIds.length
     ? await prisma.questDeclaration.findMany({
         where: { childId: child.id, templateId: { in: templateIds } },
@@ -52,7 +52,7 @@ export async function GET(request: Request) {
     STUDY: pendingStudyPt,
     STAMINA: pendingStaminaPt,
     LIFE: pendingLifePt,
-  } = pendingXpByCategory(pendingQuests as any[], declarations);
+  } = pendingXpByCategory(pendingQuests, declarations);
 
   const title = getStreakTitle(streakRecord?.currentStreak ?? 0);
 

--- a/src/app/api/parent/child-view/monster/route.ts
+++ b/src/app/api/parent/child-view/monster/route.ts
@@ -21,14 +21,14 @@ export async function GET(request: Request) {
   if (!resolved.ok) {
     return NextResponse.json({ error: resolved.error }, { status: resolved.status });
   }
-  const child = resolved.child as any;
+  const child = resolved.child;
 
   const pendingQuests = await prisma.questInstance.findMany({
     where: { childId: child.id, status: "REPORTED" },
     include: { template: true },
   });
 
-  const templateIds = Array.from(new Set((pendingQuests as any[]).map((q) => q.templateId)));
+  const templateIds = Array.from(new Set(pendingQuests.map((q) => q.templateId)));
   const declarations = templateIds.length
     ? await prisma.questDeclaration.findMany({
         where: { childId: child.id, templateId: { in: templateIds } },
@@ -39,7 +39,7 @@ export async function GET(request: Request) {
     STUDY: pendingStudyPt,
     STAMINA: pendingStaminaPt,
     LIFE: pendingLifePt,
-  } = pendingXpByCategory(pendingQuests as any[], declarations);
+  } = pendingXpByCategory(pendingQuests, declarations);
 
   return NextResponse.json({
     name: child.monsterName || child.name || "ぼうけんしゃ",

--- a/src/app/api/parent/child-view/quests/[id]/report-approve/route.ts
+++ b/src/app/api/parent/child-view/quests/[id]/report-approve/route.ts
@@ -80,7 +80,7 @@ export async function POST(
   };
 
   // approveQuestInstance が status=APPROVED への更新・XP付与・進化・バッジ・掲示板ログ（EVOLVED/BADGE）を一気に処理する
-  await approveQuestInstance(updatedQuest as any, stamp ?? undefined);
+  await approveQuestInstance(updatedQuest, stamp ?? undefined);
 
   // 親代理経路でも PROXY / ALL_COMPLETE 宝箱を即 UNLOCKED で生成する。
   // (2026-07-02) 全完了時に子セルフ経路と同じ ALL_COMPLETE ボーナスも出すように変更。

--- a/src/app/api/parent/child-view/quests/today/route.ts
+++ b/src/app/api/parent/child-view/quests/today/route.ts
@@ -56,7 +56,7 @@ export async function GET(request: Request) {
   });
 
   // 子供が「今日やる」宣言したテンプレートを取得し、親画面でも +1XP 反映する
-  const templateIds = Array.from(new Set(quests.map((q: any) => q.templateId)));
+  const templateIds = Array.from(new Set(quests.map((q) => q.templateId)));
   const declarationsToday = templateIds.length
     ? await prisma.questDeclaration.findMany({
         where: { childId: child.id, date: today, templateId: { in: templateIds } },
@@ -67,7 +67,7 @@ export async function GET(request: Request) {
 
   const hasDeadline = !!child.reportDeadlineTime;
   return NextResponse.json(
-    quests.map((q: any) => ({
+    quests.map((q) => ({
       ...q,
       hasDeadline,
       declaredToday: declaredTemplateIds.has(q.templateId),

--- a/src/app/api/parent/child-view/rebirth/route.ts
+++ b/src/app/api/parent/child-view/rebirth/route.ts
@@ -29,7 +29,7 @@ export async function POST(request: Request) {
   if (!resolved.ok) {
     return NextResponse.json({ error: resolved.error }, { status: resolved.status });
   }
-  const child = resolved.child as any;
+  const child = resolved.child;
 
   if (!child.rebirthPending) {
     return NextResponse.json({ error: "転生の準備ができていません" }, { status: 400 });

--- a/src/app/api/parent/child-view/treasures/status/route.ts
+++ b/src/app/api/parent/child-view/treasures/status/route.ts
@@ -51,7 +51,7 @@ export async function GET(request: Request) {
     locked,
     unlocked,
     hasPool: poolSize > 0,
-    opened: opened.map((o: any) => {
+    opened: opened.map((o) => {
       const ci = o.collectionItemId ? getCollectionItemById(o.collectionItemId) : null;
       return {
         id: o.id,

--- a/src/components/InstallPrompt.tsx
+++ b/src/components/InstallPrompt.tsx
@@ -1,13 +1,19 @@
 'use client';
 import { useEffect, useState } from 'react';
 
+// beforeinstallprompt は lib.dom に型定義が存在しないブラウザ独自イベント
+interface BeforeInstallPromptEvent extends Event {
+  prompt(): Promise<void>;
+  userChoice: Promise<{ outcome: 'accepted' | 'dismissed' }>;
+}
+
 export default function InstallPrompt() {
-  const [prompt, setPrompt] = useState<Event & { prompt: () => Promise<void>; userChoice: Promise<{ outcome: string }> } | null>(null);
+  const [prompt, setPrompt] = useState<BeforeInstallPromptEvent | null>(null);
 
   useEffect(() => {
     const handler = (e: Event) => {
       e.preventDefault();
-      setPrompt(e as any);
+      setPrompt(e as BeforeInstallPromptEvent);
     };
     window.addEventListener('beforeinstallprompt', handler);
     return () => window.removeEventListener('beforeinstallprompt', handler);

--- a/src/hooks/useMonsterStatus.ts
+++ b/src/hooks/useMonsterStatus.ts
@@ -3,6 +3,7 @@
 import { useEffect, useState } from "react";
 import { createClient } from "@/lib/supabase/client";
 import { STREAK_MILESTONES, getUnreadAchievements } from "@/lib/streakMilestones";
+import type { MonsterStatusResponse } from "@/types";
 
 export type MonsterData = {
   name: string;
@@ -37,7 +38,7 @@ type UseMonsterStatusResult = {
   unlockedAchievement: typeof STREAK_MILESTONES[number] | null;
   setUnlockedAchievement: (v: typeof STREAK_MILESTONES[number] | null) => void;
   setData: (d: MonsterData | null) => void;
-  fetchStatus: () => Promise<any>;
+  fetchStatus: () => Promise<MonsterStatusResponse | null>;
 };
 
 export function useMonsterStatus(): UseMonsterStatusResult {
@@ -47,7 +48,7 @@ export function useMonsterStatus(): UseMonsterStatusResult {
   const [reborn, setReborn] = useState(false);
   const [unlockedAchievement, setUnlockedAchievement] = useState<typeof STREAK_MILESTONES[number] | null>(null);
 
-  const fetchStatus = () =>
+  const fetchStatus = (): Promise<MonsterStatusResponse | null> =>
     fetch("/api/monster-status").then((r) => (r.ok ? r.json() : null));
 
   const checkAchievementUnlock = (currentStreak: number) => {
@@ -62,7 +63,7 @@ export function useMonsterStatus(): UseMonsterStatusResult {
     }
   };
 
-  function applyStatus(d: any) {
+  function applyStatus(d: MonsterStatusResponse) {
     setData({
       name: d.name, side: d.side ?? null, evolutionStage: d.evolutionStage, evolutionPath: d.evolutionPath ?? "",
       collectedPaths: d.collectedPaths ?? "[]",

--- a/src/lib/quests.ts
+++ b/src/lib/quests.ts
@@ -125,8 +125,8 @@ export async function ensureTodayQuests(params: {
   await cleanupStaleCarryOverInstances({ childId, templates });
 
   // carryOver タスクは既存 PENDING がある場合 upsert をスキップ（1インスタンス保証）
-  const carryOverTemplates = templates.filter((t) => (t as any).carryOver);
-  const normalTemplates = templates.filter((t) => !(t as any).carryOver);
+  const carryOverTemplates = templates.filter((t) => t.carryOver);
+  const normalTemplates = templates.filter((t) => !t.carryOver);
 
   // PENDING だけでなく REPORTED / SKIP_REPORTED も「親の承認待ちで残っているアクティブ」として扱う。
   // ここで REPORTED を見落とすと、昨日の PENDING を今日報告した直後に新しい今日 PENDING が upsert され、

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -5,3 +5,26 @@ export type Side = "DARK" | "LIGHT";
 export type Category = "STUDY" | "STAMINA" | "LIFE";
 export type MonsterPath = "STUDY" | "STAMINA" | "LIFE";
 export type QuestStatus = "PENDING" | "REPORTED" | "APPROVED" | "REJECTED" | "SKIPPED" | "SKIP_REPORTED";
+
+// /api/monster-status および /api/parent/child-view/monster-status のレスポンス形状。
+// 両ルートで返却フィールドが同一のため、フック（useMonsterStatus）側と型を共有する。
+export type MonsterStatusResponse = {
+  name: string;
+  side: Side | null;
+  evolutionStage: number;
+  evolutionPath: string;
+  collectedPaths: string;
+  studyPt: number;
+  staminaPt: number;
+  lifePt: number;
+  pendingStudyPt: number;
+  pendingStaminaPt: number;
+  pendingLifePt: number;
+  rebirthPending: boolean;
+  rebirthEggBonus: string | null;
+  currentStreak: number;
+  bestStreak: number;
+  monthlyDays: number;
+  lastAchievedDate: string | null;
+  currentTitle: { title: string; emoji: string } | null;
+};


### PR DESCRIPTION
## Summary
- Prismaコールバック引数の不要な`: any`注釈を削除（4件）、`as any`キャストをPrisma生成型・payload型で置き換え
- `BeforeInstallPromptEvent`型を局所定義、`MonsterStatusResponse`型を`src/types/index.ts`に新規追加し2つのAPIルート・フックで共有
- **特筆事項**: `src/app/api/approve/pending/route.ts` の型検査により、`reportedAt`のnull/undefined絞り込みが不完全だった箇所を発見・修正（type predicateを使ったfilterに書き換え）。挙動は既存テストで担保、元のtruthyチェックと等価であることをcode-reviewerが確認済み
- 実行時挙動・DBスキーマ・APIレスポンス形状は変更なし

Closes #20

## Test plan
- [x] `npm test` パス（180 files / 2495 tests）
- [x] `npx tsc --noEmit` 本変更起因のエラーなし
- [x] `npm run lint` プロダクションコードの no-explicit-any が20件→0件

🤖 Generated with [Claude Code](https://claude.com/claude-code)
