### PR TITLE
refactor(parent): childrenプロパティをchildOptionsにリネームしno-children-prop 8件を解消

### DIFF
--- a/src/__tests__/components/RegularTaskCard-pause.test.tsx
+++ b/src/__tests__/components/RegularTaskCard-pause.test.tsx
@@ -28,7 +28,7 @@ function baseTask(overrides: Record<string, unknown> = {}) {
 }
 
 describe("RegularTaskCard 一時停止ボタン", () => {
-  const children = [{ id: "child-1", reportDeadlineTime: null }];
+  const childOptions = [{ id: "child-1", reportDeadlineTime: null }];
 
   it("pausedAt=null のとき '⏸ 停止' ボタンを表示し、クリックで onTogglePause(id, true) を呼ぶ", () => {
     const onTogglePause = vi.fn();
@@ -36,7 +36,7 @@ describe("RegularTaskCard 一時停止ボタン", () => {
       <RegularTaskCard
         task={baseTask()}
         childId="child-1"
-        children={children}
+        childOptions={childOptions}
         todayDow={1}
         onEdit={() => {}}
         onDelete={() => {}}
@@ -55,7 +55,7 @@ describe("RegularTaskCard 一時停止ボタン", () => {
       <RegularTaskCard
         task={baseTask({ pausedAt: "2026-07-20T10:00:00Z" })}
         childId="child-1"
-        children={children}
+        childOptions={childOptions}
         todayDow={1}
         onEdit={() => {}}
         onDelete={() => {}}
@@ -73,7 +73,7 @@ describe("RegularTaskCard 一時停止ボタン", () => {
       <RegularTaskCard
         task={baseTask({ pausedAt: "2026-07-20T10:00:00Z" })}
         childId="child-1"
-        children={children}
+        childOptions={childOptions}
         todayDow={1}
         onEdit={() => {}}
         onDelete={() => {}}
@@ -88,7 +88,7 @@ describe("RegularTaskCard 一時停止ボタン", () => {
       <RegularTaskCard
         task={baseTask({ pausedAt: "2026-07-20T10:00:00Z", repeatDays: [0] })}
         childId="child-1"
-        children={children}
+        childOptions={childOptions}
         todayDow={1}
         onEdit={() => {}}
         onDelete={() => {}}

--- a/src/app/app/parent/(app)/tasks/page.tsx
+++ b/src/app/app/parent/(app)/tasks/page.tsx
@@ -237,7 +237,7 @@ export default function TasksPage() {
       )}
 
       <ChildSelector
-        children={children}
+        childOptions={children}
         selectedChildId={selectedChildId}
         onSelect={(id) => {
           setSelectedChildId(id);
@@ -327,7 +327,7 @@ export default function TasksPage() {
                     <PendingTaskCard
                       key={task.id}
                       task={task}
-                      children={children}
+                      childOptions={children}
                       onEdit={startEdit}
                       onApprove={handleApprove}
                       onDelete={handleDelete}
@@ -347,7 +347,7 @@ export default function TasksPage() {
                       key={task.id}
                       task={task}
                       childId={child.id}
-                      children={children}
+                      childOptions={children}
                       todayDow={todayDow}
                       onEdit={startEdit}
                       onDelete={handleDelete}
@@ -367,7 +367,7 @@ export default function TasksPage() {
                     <TemporaryTaskCard
                       key={task.id}
                       task={task}
-                      children={children}
+                      childOptions={children}
                       onDelete={handleDelete}
                       onTogglePause={handleTogglePause}
                     />

--- a/src/components/parent/ChildSelector.tsx
+++ b/src/components/parent/ChildSelector.tsx
@@ -6,16 +6,16 @@ type ChildOption = {
 };
 
 type Props = {
-  children: ChildOption[];
+  childOptions: ChildOption[];
   selectedChildId: string | null;
   onSelect: (childId: string) => void;
 };
 
-export default function ChildSelector({ children, selectedChildId, onSelect }: Props) {
-  if (children.length <= 1) return null;
+export default function ChildSelector({ childOptions, selectedChildId, onSelect }: Props) {
+  if (childOptions.length <= 1) return null;
   return (
     <div className="flex gap-2 mb-4 overflow-x-auto pb-1">
-      {children.map((child) => {
+      {childOptions.map((child) => {
         const name = child.monsterName || "名前未設定";
         return (
           <button

--- a/src/components/parent/PendingTaskCard.tsx
+++ b/src/components/parent/PendingTaskCard.tsx
@@ -25,15 +25,15 @@ type ChildOption = {
 
 type Props = {
   task: PendingTask;
-  children: ChildOption[];
+  childOptions: ChildOption[];
   onEdit: (task: PendingTask) => void;
   onApprove: (id: string) => void;
   onDelete: (id: string) => void;
 };
 
-export default function PendingTaskCard({ task, children, onEdit, onApprove, onDelete }: Props) {
+export default function PendingTaskCard({ task, childOptions, onEdit, onApprove, onDelete }: Props) {
   const cat = CATEGORY_LABEL[task.category];
-  const assignedChild = children.find((c) => c.id === task.assignedChildId);
+  const assignedChild = childOptions.find((c) => c.id === task.assignedChildId);
   return (
     <div className="bg-quest-card border border-purple-400/30 rounded-xl p-4 flex items-center gap-4">
       <div className="text-2xl">{task.emoji}</div>

--- a/src/components/parent/RegularTaskCard.tsx
+++ b/src/components/parent/RegularTaskCard.tsx
@@ -34,7 +34,7 @@ type ChildOption = {
 type Props = {
   task: RegularTask;
   childId: string;
-  children: ChildOption[];
+  childOptions: ChildOption[];
   todayDow: number;
   onEdit: (task: RegularTask) => void;
   onDelete: (id: string) => void;
@@ -56,7 +56,7 @@ function formatPendingCarryBadge(missedCount: number | null): string | null {
   return `${missedCount}回未完了`;
 }
 
-export default function RegularTaskCard({ task, childId, children, todayDow, onEdit, onDelete, onTogglePause }: Props) {
+export default function RegularTaskCard({ task, childId, childOptions, todayDow, onEdit, onDelete, onTogglePause }: Props) {
   const cat = CATEGORY_LABEL[task.category];
   const streakEntry = (task.taskStreaks ?? []).find((s) => s.childId === childId);
   const streak = isTaskStreakActive(task.repeatDays, streakEntry?.lastAchievedDate ?? null)
@@ -64,7 +64,7 @@ export default function RegularTaskCard({ task, childId, children, todayDow, onE
     : 0;
   const isOffDay = !task.repeatDays.includes(todayDow);
   const isPaused = task.pausedAt !== null;
-  const assignedChild = children.find((c) => c.id === task.assignedChildId);
+  const assignedChild = childOptions.find((c) => c.id === task.assignedChildId);
   const carryLabel = formatPendingCarryBadge(task.carryOverMissedCount);
   const hasBadges = isPaused || task.completedToday || streak >= 1 || task.lastSkippedDate || carryLabel;
   const dimmed = task.completedToday || isPaused;

--- a/src/components/parent/TemporaryTaskCard.tsx
+++ b/src/components/parent/TemporaryTaskCard.tsx
@@ -22,14 +22,14 @@ type ChildOption = {
 
 type Props = {
   task: TemporaryTask;
-  children: ChildOption[];
+  childOptions: ChildOption[];
   onDelete: (id: string) => void;
   onTogglePause: (id: string, paused: boolean) => void;
 };
 
-export default function TemporaryTaskCard({ task, children, onDelete, onTogglePause }: Props) {
+export default function TemporaryTaskCard({ task, childOptions, onDelete, onTogglePause }: Props) {
   const cat = CATEGORY_LABEL[task.category];
-  const assignedChild = children.find((c) => c.id === task.assignedChildId);
+  const assignedChild = childOptions.find((c) => c.id === task.assignedChildId);
   const isPaused = task.pausedAt !== null;
   const dateStr = task.targetDate
     ? new Date(task.targetDate).toLocaleDateString("ja-JP", { month: "numeric", day: "numeric" })


### PR DESCRIPTION
## Summary
- `ChildSelector`/`RegularTaskCard`/`PendingTaskCard`/`TemporaryTaskCard`のデータprops`children: ChildOption[]`が React予約語と名前衝突していたため`childOptions`にリネーム
- JSXネストへの書き換え（lintの提案通りの修正）は意図的に行わず、propsリネームで根本解決（理由: `children`は子供リストのデータでReact要素ではないため）
- UI挙動・API/DBへの影響なし

## Test plan
- [x] `npm test` パス（180 files / 2495 tests）
- [x] `npm run lint` パス（`react/no-children-prop` 8件→0件）
- [x] 対象コンポーネントの子供選択UIをコードレビューで確認（挙動変更なし）

Related issue: #21

🤖 Generated with [Claude Code](https://claude.com/claude-code)
