### PR TITLE
fix(react-hooks): 巻き上げ依存によるimmutabilityエラー3件を解消

### DIFF
--- a/src/__tests__/components/child-quests-treasure-get.test.tsx
+++ b/src/__tests__/components/child-quests-treasure-get.test.tsx
@@ -91,7 +91,7 @@ function setupFetch(opts: {
   reportResponse?: { treasureIds: string[] };
   skipResponse?: { treasureIds: string[] };
 }) {
-  global.fetch = vi.fn().mockImplementation((url: string, init?: RequestInit) => {
+  const fetchMock = vi.fn().mockImplementation((url: string, init?: RequestInit) => {
     if (url.includes("/api/quests/today")) {
       return Promise.resolve({ ok: true, json: () => Promise.resolve([quest]) });
     }
@@ -108,7 +108,9 @@ function setupFetch(opts: {
       return Promise.resolve({ ok: true, json: () => Promise.resolve(opts.skipResponse ?? { treasureIds: [] }) });
     }
     return Promise.resolve({ ok: true, json: () => Promise.resolve({}) });
-  }) as unknown as typeof fetch;
+  });
+  global.fetch = fetchMock as unknown as typeof fetch;
+  return fetchMock;
 }
 
 beforeEach(() => {
@@ -122,7 +124,7 @@ afterEach(() => {
 
 describe("child quests page - 宝箱ゲット演出", () => {
   it("report API が treasureIds を返したら、シートが閉じたあと「宝箱ゲット！」が表示される", async () => {
-    setupFetch({ reportResponse: { treasureIds: ["t1"] } });
+    const fetchMock = setupFetch({ reportResponse: { treasureIds: ["t1"] } });
     await act(async () => {
       render(<ChildQuestsPage />);
     });
@@ -131,6 +133,12 @@ describe("child quests page - 宝箱ゲット演出", () => {
     await waitFor(() => {
       expect(screen.getByText(/宿題/)).toBeTruthy();
     });
+
+    // マウント時に fetchMonster が1回だけ呼ばれる（回帰テスト）
+    const monsterStatusCalls = () =>
+      fetchMock.mock.calls.filter((c) => String(c[0]).includes("/api/monster-status"));
+    expect(monsterStatusCalls()).toHaveLength(1);
+
     await act(async () => {
       fireEvent.click(screen.getByText(/宿題/));
     });
@@ -146,6 +154,9 @@ describe("child quests page - 宝箱ゲット演出", () => {
     await waitFor(() => {
       expect(screen.getByText("宝箱ゲット！")).toBeTruthy();
     });
+
+    // 報告後も /api/monster-status は再取得されない（マウント時1回のまま）
+    expect(monsterStatusCalls()).toHaveLength(1);
   });
 
   it("treasureIds が空なら宝箱ゲット演出は出ない", async () => {

--- a/src/__tests__/components/parent-tasks-page-mount-fetch.test.tsx
+++ b/src/__tests__/components/parent-tasks-page-mount-fetch.test.tsx
@@ -1,0 +1,44 @@
+// @vitest-environment jsdom
+import { render, waitFor, screen } from "@testing-library/react";
+import { describe, it, expect, vi, afterEach } from "vitest";
+import React from "react";
+
+vi.mock("@/components/LoadingSpinner", () => ({
+  default: () => React.createElement("div", { "data-testid": "spinner" }),
+}));
+
+import TasksPage from "@/app/app/parent/(app)/tasks/page";
+
+describe("親 タスク管理ページ: マウント時のfetch回数", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("マウント時に /api/tasks と /api/family/code がそれぞれ1回ずつ呼ばれる（fetchTasks/fetchChildrenの巻き上げ後も回帰しない）", async () => {
+    const fetchMock = vi.fn().mockImplementation((url: string) => {
+      if (url.includes("/api/tasks")) {
+        return Promise.resolve({ ok: true, json: () => Promise.resolve([]) });
+      }
+      if (url.includes("/api/family/code")) {
+        return Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve({ code: "ABC123", members: [] }),
+        });
+      }
+      return Promise.resolve({ ok: false, status: 404, json: () => Promise.resolve({}) });
+    });
+    global.fetch = fetchMock as unknown as typeof fetch;
+
+    render(<TasksPage />);
+
+    await waitFor(() => {
+      expect(screen.queryByTestId("spinner")).toBeNull();
+    });
+
+    const tasksCalls = fetchMock.mock.calls.filter((c) => String(c[0]).includes("/api/tasks"));
+    const familyCalls = fetchMock.mock.calls.filter((c) => String(c[0]).includes("/api/family/code"));
+
+    expect(tasksCalls).toHaveLength(1);
+    expect(familyCalls).toHaveLength(1);
+  });
+});

--- a/src/app/app/child/quests/page.tsx
+++ b/src/app/app/child/quests/page.tsx
@@ -80,10 +80,6 @@ export default function QuestsPage() {
     return () => clearInterval(id);
   }, []);
 
-  useEffect(() => {
-    fetchMonster();
-  }, []);
-
   async function fetchMonster() {
     const res = await fetch("/api/monster-status");
     if (!res.ok) return;
@@ -102,6 +98,10 @@ export default function QuestsPage() {
       }),
     );
   }
+
+  useEffect(() => {
+    fetchMonster();
+  }, []);
 
   async function handleReport(questId: string, comment: string | null, photoUrl: string | null) {
     const res = await fetch(`/api/quests/${questId}/report`, {

--- a/src/app/app/parent/(app)/tasks/page.tsx
+++ b/src/app/app/parent/(app)/tasks/page.tsx
@@ -69,10 +69,6 @@ export default function TasksPage() {
   const [formMode, setFormMode] = useState<FormMode>("regular");
   const [form, setForm] = useState(defaultForm(""));
 
-  useEffect(() => {
-    Promise.all([fetchTasks(), fetchChildren()]).finally(() => setLoading(false));
-  }, []);
-
   async function fetchTasks() {
     const res = await fetch("/api/tasks");
     if (res.ok) setTasks(await res.json());
@@ -87,6 +83,10 @@ export default function TasksPage() {
       setSelectedChildId((prev) => prev ?? (kids[0]?.id ?? null));
     }
   }
+
+  useEffect(() => {
+    Promise.all([fetchTasks(), fetchChildren()]).finally(() => setLoading(false));
+  }, []);
 
   function openFormForChild(childId: string) {
     setForm(defaultForm(childId));


### PR DESCRIPTION
## Summary
- `quests/page.tsx`・`tasks/page.tsx`で`useEffect`より後ろにあった関数宣言（`fetchMonster` / `fetchTasks`・`fetchChildren`）を`useEffect`より前に移動し、巻き上げ依存による`react-hooks/immutability`エラー3件を解消（挙動は不変）
- 回帰テストとしてマウント時のfetch呼び出し回数アサーションを追加（`parent-tasks-page-mount-fetch.test.tsx`を新規追加、`child-quests-treasure-get.test.tsx`にアサーションを追加）

## 申し送り事項
- 今回の修正により、同じ2ファイル（`quests/page.tsx`・`tasks/page.tsx`）で隠れていた`react-hooks/set-state-in-effect`エラーが新たに可視化されました。これは今回のdiffが原因ではなく既存の技術的負債であり、Issue #22 のカテゴリ(3)で対応予定です。
- 本PRは Issue #22 の一部（カテゴリ1「react-hooks/immutability」）対応です。残り3カテゴリが未着手のため、Issueはまだクローズしません。

## Test plan
- [x] `npm test` パス（181 files / 2496 tests）
- [x] `npm run lint` 対象2ファイルのみ確認（`react-hooks/immutability`は解消。新たに可視化された`react-hooks/set-state-in-effect`は既存負債としてカテゴリ(3)へ引き継ぎ）
- [x] 親のタスク管理ページ・子のクエストページのマウント時挙動を手動確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)
