### PR TITLE
fix(react-hooks): useHistoryDataのfirstLoadをrefからstateに変更しrefsエラー2件を解消

### DIFF
--- a/src/__tests__/hooks/useHistoryData.test.ts
+++ b/src/__tests__/hooks/useHistoryData.test.ts
@@ -1,0 +1,91 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { renderHook, waitFor } from "@testing-library/react";
+import { useHistoryData } from "@/hooks/useHistoryData";
+
+const FAMILY_CODE_RESPONSE = {
+  members: [
+    { id: "child-1", name: "たろう", role: "CHILD", monsterName: null },
+  ],
+};
+
+function mockFetchSequence() {
+  return vi.fn((url: string) => {
+    if (url.includes("/api/family/code")) {
+      return Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve(FAMILY_CODE_RESPONSE),
+      });
+    }
+    if (url.includes("/api/quests/monthly-summary")) {
+      return Promise.resolve({
+        ok: true,
+        json: () =>
+          Promise.resolve({
+            days: {},
+            achievedDays: 0,
+            totalApproved: 0,
+            totalXp: 0,
+          }),
+      });
+    }
+    if (url.includes("/api/quests/history")) {
+      return Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve([]),
+      });
+    }
+    return Promise.resolve({ ok: false, json: () => Promise.resolve(null) });
+  }) as unknown as typeof fetch;
+}
+
+describe("useHistoryData の isFirstLoad", () => {
+  beforeEach(() => {
+    global.fetch = mockFetchSequence();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("初回ロード時は isFirstLoad が true から始まる", () => {
+    const selectedDate = new Date(2026, 0, 1);
+    const viewMonth = new Date(2026, 0, 1);
+    const { result } = renderHook(() => useHistoryData(selectedDate, viewMonth));
+
+    expect(result.current.isFirstLoad).toBe(true);
+  });
+
+  it("初回の history フェッチ完了後は isFirstLoad が false になる", async () => {
+    const selectedDate = new Date(2026, 0, 1);
+    const viewMonth = new Date(2026, 0, 1);
+    const { result } = renderHook(() => useHistoryData(selectedDate, viewMonth));
+
+    await waitFor(() => {
+      expect(result.current.isFirstLoad).toBe(false);
+    });
+
+    expect(result.current.loadingItems).toBe(false);
+  });
+
+  it("2回目以降の history フェッチが完了しても isFirstLoad は false のまま", async () => {
+    const viewMonth = new Date(2026, 0, 1);
+    const { result, rerender } = renderHook(
+      ({ selectedDate }) => useHistoryData(selectedDate, viewMonth),
+      { initialProps: { selectedDate: new Date(2026, 0, 1) } }
+    );
+
+    await waitFor(() => {
+      expect(result.current.isFirstLoad).toBe(false);
+    });
+
+    // 日付を変えて2回目のフェッチをトリガー
+    rerender({ selectedDate: new Date(2026, 0, 2) });
+
+    await waitFor(() => {
+      expect(result.current.loadingItems).toBe(false);
+    });
+
+    expect(result.current.isFirstLoad).toBe(false);
+  });
+});

--- a/src/hooks/useHistoryData.ts
+++ b/src/hooks/useHistoryData.ts
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useState } from "react";
 import { formatDate, type DaySummary } from "@/lib/heatmap";
 import type { Category } from "@/types";
 
@@ -45,7 +45,7 @@ export function useHistoryData(selectedDate: Date, viewMonth: Date): UseHistoryD
   const [monthlySummary, setMonthlySummary] = useState<MonthlySummary | null>(null);
   const [loadingItems, setLoadingItems] = useState(false);
   const [loadingSummary, setLoadingSummary] = useState(true);
-  const firstLoad = useRef(true);
+  const [firstLoad, setFirstLoad] = useState(true);
 
   useEffect(() => {
     fetch("/api/family/code")
@@ -86,7 +86,7 @@ export function useHistoryData(selectedDate: Date, viewMonth: Date): UseHistoryD
       .then((res) => (res.ok ? res.json() : []))
       .then((data) => setItems(data))
       .finally(() => {
-        firstLoad.current = false;
+        setFirstLoad(false);
         setLoadingItems(false);
       });
   }, [selectedDate, selectedChildId]);
@@ -99,6 +99,6 @@ export function useHistoryData(selectedDate: Date, viewMonth: Date): UseHistoryD
     monthlySummary,
     loadingItems,
     loadingSummary,
-    isFirstLoad: firstLoad.current,
+    isFirstLoad: firstLoad,
   };
 }


### PR DESCRIPTION
## Summary
- `isFirstLoad` はレンダー結果に使われる値のため `useRef` ではなく `useState` が適切と判断し変更した（`src/hooks/useHistoryData.ts`）
- 回帰テストを追加した（初回 true / フェッチ完了後 false / 2回目以降 false 維持の3ケース、`src/__tests__/hooks/useHistoryData.test.ts`）
- 本PRは Issue #22 の一部（カテゴリ2: react-hooks/refs 2件）対応。カテゴリ3・4は未着手のため **Issue #22 はまだクローズしない**（`Closes #22` 等のキーワードは使用していない）

## 申し送り事項

- 今回の修正により、同ファイル（`useHistoryData.ts`）内で `react-hooks/set-state-in-effect` エラーが2件新たに可視化された。これは既存の技術的負債であり、今回のdiffが原因で発生したものではない。Issue #22 のカテゴリ(3)で対応予定。
- **ローカル環境の制約により目視確認ができていない**: `.env.local` がローカルSupabaseスタックを指しており、当該スタックが未起動のためブラウザでの動作確認ができなかった。自動テスト（3ケース）とコード分析（`setFirstLoad` と `setLoadingItems` が同一の `.finally()` 内で連続実行されるため、React 19 の自動バッチングにより1回の再レンダーに収まる）でカバーしている。
  - **マージ前に Vercel プレビューで履歴画面（`/app/parent/history`）のちらつき・スピナー表示に変化がないか目視確認することを推奨します。**

## Test plan
- [x] `npm test` パス（181 files / 2498 tests）
- [ ] `npm run lint` パス
- [ ] Vercelプレビューで `/app/parent/history` の目視確認（ちらつき・スピナー表示に変化がないか）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
