### PR TITLE
chore(lint): MonsterImg.tsxのno-img-elementを理由コメント付きdisableで対応

### DIFF
--- a/src/components/lp/MonsterImg.tsx
+++ b/src/components/lp/MonsterImg.tsx
@@ -20,6 +20,10 @@ export function MonsterImg({
     );
   }
   return (
+    // next/image はビルド時に固定 width/height を要求する最適化前提のコンポーネントで、
+    // 画像読み込み失敗時に onError でフォールバック絵文字へ差し替えるこのユースケースとは相性が悪いため、
+    // 意図的に生の <img> を使用する。
+    // eslint-disable-next-line @next/next/no-img-element
     <img
       src={src}
       alt={alt}


### PR DESCRIPTION
## Summary
- `MonsterImg.tsx` は `onError` によるフォールバック絵文字差し替えが必要で、固定 width/height 前提の `next/image` とは相性が悪いため、生の `<img>` を意図的に維持し、理由コメント付きで `eslint-disable-next-line @next/next/no-img-element` を追加した
- `docs/decisions.md`（2026-03-22 写真添付機能）の既存前例に沿った判断であり、新規の方針決定ではないため decisions.md への追記は行っていない
- `next/image` への本格移行・LP画像最適化は本PRのスコープ外とし、別Issueとして切り出す方針
- 本PRは Issue #22 の対応の一部（カテゴリ4/4: `@next/next/no-img-element` 1件）であり、残り1カテゴリ（カテゴリ3）が未着手のため Issue #22 自体はまだクローズしない

## Test plan
- [x] `npm test` パス（180 files / 2495 tests）
- [x] `@next/next/no-img-element` の警告が解消されたことを `npm run lint` で確認（リポジトリ全体では Issue #22 カテゴリ3を含む未対応の既存エラーが残るため lint 全体はグリーンではない）
- [x] code-reviewer による APPROVED 済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)
