### PR TITLE
fix(react-hooks): useApiFetchのset-state-in-effect等を正当なdisableで解消

### DIFF
--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -2592,3 +2592,24 @@
 - `docs/未実装仕様書/monetization-plan.md §2.2` — 有効タスク定義を更新
 - テスト: `src/__tests__/lib/subscriptionService.test.ts` / `src/__tests__/api/tasks/tasks-limit.test.ts`
 
+## 2026-08-12: fetch-in-effect パターンの `react-hooks/set-state-in-effect` は eslint-disable で受け入れる（Issue #22）
+
+### 決定内容
+- マウント時・依存値変更時に `useEffect` からデータを fetch し、開始時に `setLoading(true)` を同期的に呼ぶ「fetch-in-effect」パターンは、`react-hooks/set-state-in-effect` を理由コメント付き `eslint-disable-next-line` で明示的に許容する
+- `useSyncExternalStore` 化などの根本的な再設計は現時点では行わない（`useApiFetch` は現状どの画面からも import されておらず、再設計のリスクを取る実利が薄いため）
+- disable コメントは「検知をすり抜けているだけ」の飾りにせず、実際にそのルールを発火させて抑制する形にする。`useApiFetch` は当初 `async/await` + `try/catch` で実装しており、これが React Compiler ベースの lint ルール群（`react-hooks/set-state-in-effect` 等）の解析を丸ごとバイパスさせていた（bailout）ため、`fetchData` を `try/catch` から `.then/.catch/.finally` のプロミスチェーンに書き換え、レンダー中の ref 書き込み（`transformRef.current = transform`）も専用 `useEffect` に移し、解析が正しく走った上で `setLoading(true)` の行に disable コメントを付与している
+
+### 理由
+- Issue #19 で禁止した「eslint-disable で黙らせるだけ」（=ルールの検知を回避しただけで実際の挙動は変わらない状態）を再発させないため、disable コメントは必ず「そのルールが実際に発火する箇所」に付ける方針とする
+- `async/await` + `try/catch` は可読性が高い一方、React Compiler 系の lint ルールがこの構文パターンで解析全体を bailout する（今回の調査で判明）。これにより `eslint-disable-next-line` を追加しても `Unused eslint-disable directive` 警告になり、かえって「本当は何も保証していない disable コメント」という同型の問題を生んでしまう
+- fetch-in-effect パターン自体はこのプロジェクト全体で標準的に使われており、個々のフックだけ再設計するより「eslint-disable で受け入れる」という方針を明文化する方が一貫性がある
+
+### やってはいけないこと
+- ルールが実際には発火していない行（＝ eslint が `Unused eslint-disable directive` を出す行）に disable コメントを付けて「対応済み」とする
+- `react-hooks/set-state-in-effect` を止めるためだけに `try/catch` を `.then/.catch` に書き換えるなど、挙動を変えずに解析の bailout を意図的に発生させたり解除したりする改変を、理由の説明なしに行う
+- この方針を「lint が厳しいルールは disable すればよい」という一般則として拡大解釈する。対象はあくまで fetch-in-effect の `set-state-in-effect` のような、このプロジェクトで標準化されたパターンに限る
+
+### 該当箇所
+- `src/hooks/useApiFetch.ts` — `fetchData` を promise チェーンに書き換え、`transformRef` の同期を専用 `useEffect` に分離、`setLoading(true)` に理由コメント付き disable を付与
+- テスト: `src/__tests__/hooks/useApiFetch.test.tsx`（既存の回帰テストのみ、要件追加なし）
+

--- a/src/__tests__/hooks/useApiFetch.test.tsx
+++ b/src/__tests__/hooks/useApiFetch.test.tsx
@@ -1,0 +1,126 @@
+// @vitest-environment jsdom
+import { renderHook, waitFor, act } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { useApiFetch } from "@/hooks/useApiFetch";
+
+describe("useApiFetch", () => {
+  beforeEach(() => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        json: async () => ({ foo: "bar" }),
+      }),
+    );
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it("マウント時にurlが設定されていれば1回だけfetchする", async () => {
+    const { result } = renderHook(() => useApiFetch<{ foo: string }>("/api/test"));
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    expect(fetch).toHaveBeenCalledTimes(1);
+    expect(result.current.data).toEqual({ foo: "bar" });
+    expect(result.current.error).toBeNull();
+  });
+
+  it("urlがnullのときはfetchしない", async () => {
+    const { result } = renderHook(() => useApiFetch<{ foo: string }>(null));
+
+    // loadingの初期値はtrueのままフェッチされないことを確認するため、
+    // 少し待ってからアサーションする
+    await act(async () => {
+      await new Promise(r => setTimeout(r, 0));
+    });
+
+    expect(fetch).not.toHaveBeenCalled();
+    expect(result.current.data).toBeNull();
+  });
+
+  it("urlが変わったときに1回だけ再フェッチする", async () => {
+    const { result, rerender } = renderHook(
+      ({ url }: { url: string | null }) => useApiFetch<{ foo: string }>(url),
+      { initialProps: { url: "/api/a" } },
+    );
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(fetch).toHaveBeenCalledTimes(1);
+
+    rerender({ url: "/api/b" });
+
+    await waitFor(() => expect(fetch).toHaveBeenCalledTimes(2));
+    expect(fetch).toHaveBeenNthCalledWith(2, "/api/b");
+  });
+
+  it("refetch()を手動で呼ぶと再フェッチされる", async () => {
+    const { result } = renderHook(() => useApiFetch<{ foo: string }>("/api/test"));
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(fetch).toHaveBeenCalledTimes(1);
+
+    act(() => {
+      result.current.refetch();
+    });
+
+    await waitFor(() => expect(fetch).toHaveBeenCalledTimes(2));
+  });
+
+  it("回帰テスト: transformに毎レンダー新規のインラインアロー関数を渡しても無限フェッチループが起きず1回で収まる", async () => {
+    // transform を毎回新しい参照で渡す (呼び出し側が useCallback していないケースを再現)
+    const { result, rerender } = renderHook(() =>
+      useApiFetch<{ foo: string }>("/api/test", (d) => ({ foo: d.foo.toUpperCase() })),
+    );
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(fetch).toHaveBeenCalledTimes(1);
+    expect(result.current.data).toEqual({ foo: "BAR" });
+
+    // 何度再レンダーしても(transformが新規関数でも)fetchは増えない
+    rerender();
+    rerender();
+    rerender();
+
+    // 非同期の余地を与えてから確認
+    await act(async () => {
+      await new Promise(r => setTimeout(r, 0));
+    });
+
+    expect(fetch).toHaveBeenCalledTimes(1);
+  });
+
+  it("APIエラー時はerrorがセットされdataがnullになる", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: false,
+        status: 500,
+        json: async () => ({}),
+      }),
+    );
+
+    const { result } = renderHook(() => useApiFetch<{ foo: string }>("/api/test"));
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    expect(result.current.error).toBe("HTTP 500");
+    expect(result.current.data).toBeNull();
+  });
+
+  it("setDataで手動にデータを更新できる", async () => {
+    const { result } = renderHook(() => useApiFetch<{ foo: string }>("/api/test"));
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    act(() => {
+      result.current.setData({ foo: "baz" });
+    });
+
+    expect(result.current.data).toEqual({ foo: "baz" });
+  });
+});

--- a/src/hooks/useApiFetch.ts
+++ b/src/hooks/useApiFetch.ts
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 
 type UseApiFetchResult<T> = {
   data: T | null;
@@ -15,6 +15,20 @@ type UseApiFetchResult<T> = {
  * - 初回レンダリング時に自動フェッチ
  * - refetch で再取得
  * - transform で取得データを加工可能
+ *
+ * 注意: `transform` は呼び出し側がインラインのアロー関数を渡すことが多い。
+ * `transform` を fetch 処理の依存配列に含めてしまうと、毎レンダーで新しい参照になり
+ * fetch 用コールバックが再生成 → 副作用が再実行 → 無限フェッチループになる。
+ * そのため `transform` は ref に退避して常に最新版を参照し、
+ * fetch 用コールバックの identity は `url` のみに依存させる。
+ * ref への書き込みはレンダー中ではなく専用 effect で行う
+ * （レンダー中の ref 書き込みは react-hooks/refs の対象になるため）。
+ *
+ * 注意（set-state-in-effect）: マウント時・url変更時にデータをfetchする前に
+ * ローディング状態を同期的に true へ更新している。このプロジェクトで標準的な
+ * fetch-in-effect パターンであり、React Compiler の最適化対象からは外れるが
+ * 影響は限定的なため eslint-disable で明示的に許容する
+ * （方針決定は docs/decisions.md 参照）。
  */
 export function useApiFetch<T>(
   url: string | null,
@@ -24,28 +38,43 @@ export function useApiFetch<T>(
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
-  const refetch = useCallback(() => {
+  const transformRef = useRef(transform);
+  useEffect(() => {
+    transformRef.current = transform;
+  });
+
+  const fetchData = useCallback(() => {
     if (!url) return;
-    setLoading(true);
     setError(null);
     fetch(url)
-      .then(r => {
+      .then((r) => {
         if (!r.ok) throw new Error(`HTTP ${r.status}`);
-        return r.json();
+        return r.json() as Promise<T>;
       })
-      .then((d: T) => {
-        setData(transform ? transform(d) : d);
+      .then((d) => {
+        const currentTransform = transformRef.current;
+        setData(currentTransform ? currentTransform(d) : d);
       })
-      .catch(e => {
+      .catch((e: unknown) => {
         setError(e instanceof Error ? e.message : "Unknown error");
         setData(null);
       })
-      .finally(() => setLoading(false));
+      .finally(() => {
+        setLoading(false);
+      });
   }, [url]);
 
+  const refetch = useCallback(() => {
+    setLoading(true);
+    fetchData();
+  }, [fetchData]);
+
   useEffect(() => {
-    refetch();
-  }, [refetch]);
+    if (!url) return;
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- マウント時・url変更時にfetchを開始する前にローディング状態を同期的に更新する、fetch-in-effectパターン（このプロジェクトの標準パターン。docs/decisions.md参照）。React Compilerの最適化対象外になるが影響は限定的。
+    setLoading(true);
+    fetchData();
+  }, [url, fetchData]);
 
   return { data, loading, error, setData, refetch };
 }


### PR DESCRIPTION
## Summary
- `transform` を `useRef` に退避し、`try/catch` を `.then/.catch/.finally` チェーンに書き換えて React Compiler 系 lint ルールの解析 bailout を解消
- `setLoading(true)` の行に理由コメント付き `eslint-disable-next-line react-hooks/set-state-in-effect` を付与。**disable が実際にルールの発火を抑制していることを実測（`npx eslint`）で確認済み**。一度は「async 化で lint の検知自体を回避しているだけ」という不十分な実装を経て、code-reviewer が見抜いて CHANGES_REQUESTED にした経緯があり、その反省を踏まえた対応
- `docs/decisions.md` に「fetch-in-effect パターンの `set-state-in-effect` は eslint-disable で受け入れる」方針を追記（Related decision 参照）
- `useApiFetch` は現時点でどの画面からも import されていない（新規標準フックとして規定済みだが未採用）ため、既存画面への影響はゼロ
- 回帰テスト7件を追加（無限フェッチループ防止、url が null/変更時の挙動、refetch、APIエラー処理、setDataでの手動更新等）

## Test plan
- [x] `npm test` パス（181 files / 2502 tests + 新規7件）
- [x] `npx eslint src/hooks/useApiFetch.ts` パス（`Unused eslint-disable directive` 警告なし＝disable が実際にルールを抑制していることを確認）

## Related decision
- `docs/decisions.md#2026-08-12-fetch-in-effect-パターンの-react-hookskaset-state-in-effect-は-eslint-disable-で受け入れる-issue-22`
- 本文中の見出し: `## 2026-08-12: fetch-in-effect パターンの react-hooks/set-state-in-effect は eslint-disable で受け入れる（Issue #22）`

## Note
- Issue #22 のうちカテゴリ(3)は未着手のため、この PR マージ後も Issue はクローズしない

🤖 Generated with [Claude Code](https://claude.com/claude-code)
