### PR TITLE
fix(react-hooks): set-state-in-effect残り8箇所を理由コメント付きdisableで解消

### DIFF
--- a/src/app/app/parent/(app)/gathering/page.tsx
+++ b/src/app/app/parent/(app)/gathering/page.tsx
@@ -56,6 +56,9 @@ export default function ParentGatheringPage() {
   // 子供が変わったらグループを取得
   useEffect(() => {
     if (!selectedChildId) return;
+    // selectedChildId変更時にグループ再取得の直前でローディング表示に切り替え、前回のグループ情報をクリアする。
+    // fetch自体が外部システムとの同期であり、その開始を示す状態の即時反映が必要なため。
+    // eslint-disable-next-line react-hooks/set-state-in-effect
     setLoading(true);
     setGroup(undefined);
 

--- a/src/components/IOSInstallPrompt.tsx
+++ b/src/components/IOSInstallPrompt.tsx
@@ -7,6 +7,8 @@ export default function IOSInstallPrompt() {
   const [show, setShow] = useState(false);
 
   useEffect(() => {
+    // navigator/localStorage依存の判定でSSR時は実行できないため、マウント後にuseEffect内で一度だけ判定する。
+    // eslint-disable-next-line react-hooks/set-state-in-effect
     setShow(shouldShowInstallPrompt());
   }, []);
 

--- a/src/components/child/AchievementBell.tsx
+++ b/src/components/child/AchievementBell.tsx
@@ -25,6 +25,8 @@ export default function AchievementBell() {
   const [open, setOpen] = useState(false);
 
   useEffect(() => {
+    // localStorage依存の既読状態はSSR時に読めないため、マウント後にuseEffect内で一度だけ確定させる。
+    // eslint-disable-next-line react-hooks/set-state-in-effect
     setSeenTitles(getSeenTitles());
     fetch("/api/streak")
       .then((r) => r.json())

--- a/src/components/lp/InstallGuideSection.tsx
+++ b/src/components/lp/InstallGuideSection.tsx
@@ -18,6 +18,8 @@ export function InstallGuideSection({ s }: { s: Record<string, string> }) {
       /iPad/.test(ua) ||
       (/Macintosh/.test(ua) && navigator.maxTouchPoints > 1);
     const android = /Android/.test(ua);
+    // navigator.userAgent依存の判定でSSR時は実行できないため、マウント後にuseEffect内で一度だけ判定する。
+    // eslint-disable-next-line react-hooks/set-state-in-effect
     setIsIos(ios);
     setIsAndroid(android);
 

--- a/src/components/parent/HistoryContent.tsx
+++ b/src/components/parent/HistoryContent.tsx
@@ -43,7 +43,10 @@ export default function HistoryContent() {
   const [checkin, setCheckin] = useState<CheckinResponse | null>(null);
 
   useEffect(() => {
+    // selectedChildId/viewMonth変更時にチェックイン再取得の直前で前回結果をクリアする。
+    // fetch自体が外部システムとの同期であり、その開始を示す状態の即時反映が必要なため。
     if (!selectedChildId) {
+      // eslint-disable-next-line react-hooks/set-state-in-effect
       setCheckin(null);
       return;
     }

--- a/src/components/parent/PushSubscriber.tsx
+++ b/src/components/parent/PushSubscriber.tsx
@@ -53,6 +53,8 @@ export default function PushSubscriber({
 
   useEffect(() => {
     if (!("Notification" in window) || !("serviceWorker" in navigator) || !("PushManager" in window)) return;
+    // Notification API依存の判定でSSR時は実行できないため、マウント後にuseEffect内で一度だけ現在の許可状態を確認する。
+    // eslint-disable-next-line react-hooks/set-state-in-effect
     setPermission(Notification.permission);
     // 既に許可済みなら購読を静かに更新
     if (Notification.permission === "granted") {

--- a/src/hooks/useChildQuests.ts
+++ b/src/hooks/useChildQuests.ts
@@ -118,6 +118,9 @@ export function useChildQuests(): UseChildQuestsResult {
   }
 
   useEffect(() => {
+    // マウント時に一度だけ今日のクエストを取得する。fetchQuests内部でsetLoading/setQuestsを呼ぶが、
+    // 外部API（サーバー）との同期が目的でありレンダー時算出はできないためuseEffect内が正しい。
+    // eslint-disable-next-line react-hooks/set-state-in-effect
     fetchQuests();
 
     const supabase = createClient();

--- a/src/hooks/useHistoryData.ts
+++ b/src/hooks/useHistoryData.ts
@@ -71,6 +71,9 @@ export function useHistoryData(selectedDate: Date, viewMonth: Date): UseHistoryD
     if (!selectedChildId) return;
     const year = viewMonth.getFullYear();
     const month = viewMonth.getMonth() + 1;
+    // viewMonth/selectedChildId変更時にサマリー再取得の直前でローディング表示に切り替える。
+    // fetch自体が外部システムとの同期であり、その開始を示すloading状態の即時反映が必要なため。
+    // eslint-disable-next-line react-hooks/set-state-in-effect
     setLoadingSummary(true);
     setMonthlySummary(null);
     fetch(`/api/quests/monthly-summary?year=${year}&month=${month}&childId=${selectedChildId}`)
@@ -81,6 +84,9 @@ export function useHistoryData(selectedDate: Date, viewMonth: Date): UseHistoryD
 
   useEffect(() => {
     if (!selectedChildId) return;
+    // selectedDate/selectedChildId変更時に履歴再取得の直前でローディング表示に切り替える。
+    // fetch自体が外部システムとの同期であり、その開始を示すloading状態の即時反映が必要なため。
+    // eslint-disable-next-line react-hooks/set-state-in-effect
     setLoadingItems(true);
     fetch(`/api/quests/history?date=${formatDate(selectedDate)}&childId=${selectedChildId}`)
       .then((res) => (res.ok ? res.json() : []))


### PR DESCRIPTION
## Summary
- PR #32（useApiFetch）で確立した方針（fetch-in-effect/ブラウザAPI依存の初回判定パターンは `eslint-disable` + 理由コメントで受け入れる）を、`react-hooks/set-state-in-effect` が残る8ファイルに適用
- 対象: `useChildQuests.ts` / `useHistoryData.ts`（2箇所） / `gathering/page.tsx` / `IOSInstallPrompt.tsx` / `AchievementBell.tsx` / `InstallGuideSection.tsx` / `HistoryContent.tsx` / `PushSubscriber.tsx`
- ロジック変更なし。`eslint-disable-next-line react-hooks/set-state-in-effect` と理由コメントの追加のみ（8ファイル・23行追加）
- 実測確認: `useHistoryData.ts` 以外の7ファイルは `npx eslint` で disable が実際にルール発火を抑制していること（Unused eslint-disable directive が出ないこと）を確認済み
- 注記: `useHistoryData.ts` の2箇所は、develop に未マージの `react-hooks/refs` 修正（PR #30）が先に入るまでは "Unused eslint-disable directive" 警告が一時的に出る（`firstLoad` の ref アクセスによる `Cannot access refs during render` エラーが同一コンポーネントの set-state-in-effect 解析をバイパスさせるため、develop 単体では未検証・PR #30 マージ後に解消される既知の順序依存）。ロジックには影響なし、警告レベルのため CI ブロッカーにはならない
- 本PRでIssue #22の全4カテゴリ（PR #29 immutability, PR #30 refs, PR #31 no-img-element, 本PR set-state-in-effect）の実装が揃う

## Test plan
- [x] `npm test` パス（180 files / 2495 tests、本ブランチ単体で確認済み）
- [x] `npm run lint` 実行し、対象8ファイルへの追加行がルール発火を抑制していることを個別確認（`useHistoryData.ts` の順序依存注記あり、上記参照）
- [ ] 手動確認: 各画面のマウント時挙動（インストール案内表示・実績ベル・親の集計/履歴画面のローディング表示等）に変化がないこと

## Related decision
- `docs/decisions.md`（方針自体はPR #32で追記済みのためこのPRでの追記なし）

Closes #22

（develop向けPRのため、GitHub自動クローズはdevelop→mainマージ時まで発動しません。全4カテゴリ完了の意図を明示するために記載しています）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
