### PR TITLE
test(fix): it(がif(になっていて実行されていないテスト5件を修正

### DIFF
--- a/src/__tests__/api/push/notify-child.test.ts
+++ b/src/__tests__/api/push/notify-child.test.ts
@@ -117,7 +117,7 @@ describe("POST /api/push/notify-child", () => {
     expect(res.status).toBe(400);
   });
 
-  if("子供がアプリ未起動でもQuestInstanceを生成してリマインドを送ること", async () => {
+  it("子供がアプリ未起動でもQuestInstanceを生成してリマインドを送ること", async () => {
     const parent = parentUser();
     const child = childUser();
     const tpl1 = taskTemplate({ id: "tpl-1", title: "宿題" });
@@ -156,7 +156,7 @@ describe("POST /api/push/notify-child", () => {
     );
   });
 
-  if("テンプレートがあっても全タスク完了済みなら400を返すこと", async () => {
+  it("テンプレートがあっても全タスク完了済みなら400を返すこと", async () => {
     const parent = parentUser();
     const child = childUser();
     const tpl = taskTemplate({ id: "tpl-1" });
@@ -170,6 +170,6 @@ describe("POST /api/push/notify-child", () => {
     const res = await POST(makeRequest("/api/push/notify-child", { childId: "child-1" }));
     expect(res.status).toBe(400);
     const json = await res.json();
-    expect(json.error).toBe("未完了のリクエストがありません");
+    expect(json.error).toBe("未完了のクエストがありません");
   }); 
 });

--- a/src/__tests__/api/tasks/tasks.test.ts
+++ b/src/__tests__/api/tasks/tasks.test.ts
@@ -399,7 +399,7 @@ describe("GET /api/tasks", () => {
 });
 
 describe("POST /api/tasks", () => {
-  if("タスク名が空の場合、400を返すこと", async () => {
+  it("タスク名が空の場合、400を返すこと", async () => {
     mockGetCurrentUser.mockResolvedValue(parentUser() as any);
     const res = await POST(makeRequest("/api/tasks", { title: "", assignedChildId: "child-1" }));
     expect(res.status).toBe(400);
@@ -407,7 +407,7 @@ describe("POST /api/tasks", () => {
     expect(json.error).toBe("タスク名は必須です");
   });
   
-  if("タスク名が32文字を超える場合、400を返すこと", async () => {
+  it("タスク名が32文字を超える場合、400を返すこと", async () => {
     mockGetCurrentUser.mockResolvedValue(parentUser() as any);
     const res = await POST(
       makeRequest("/api/tasks", {
@@ -421,8 +421,9 @@ describe("POST /api/tasks", () => {
     expect(json.error).toBe("タスク名は32文字以内にしてください");
   });
   
-  if("タスク名が32文字ちょうどなら作成できること", async () => {
+  it("タスク名が32文字ちょうどなら作成できること", async () => {
     mockGetCurrentUser.mockResolvedValue(parentUser() as any);
+    mockPrisma.taskTemplate.create.mockResolvedValue({ id: "t-exact32" } as any);
     const res = await POST(
       makeRequest("/api/tasks", {
         title: "あ".repeat(32),


### PR DESCRIPTION
## Summary
- `if(`→`it(` のタイポ修正で実行されていなかったテスト5件を実行状態に復活（`notify-child.test.ts` 2件、`tasks.test.ts` 3件）
- テスト件数 2506→2511（+5）
- 復活後に2件が失敗したため切り分けを実施:
  1. 「未完了のクエストがありません」エラーメッセージの期待値誤記を修正（実装は変更なし、`git log` で文言が一貫していたことを確認済み）
  2. 32文字境界テストでモック設定漏れを発見し、他の作成系テストと同じパターンでモックを追加
- 実装コード（`src/app/api/push/notify-child/route.ts` / `src/app/api/tasks/route.ts`）は一切変更していない（実装バグは見つからなかった）

## Test plan
- [x] `npm test` パス（183 files / 2511 tests）
- [ ] `npm run lint` パス
- [x] 対象2ファイルの単体実行で36件全て成功を確認

Closes #34

🤖 Generated with [Claude Code](https://claude.com/claude-code)
