### PR TITLE
test(mock): vitest-mock-extendedを導入しPrismaモックを型付きに置き換える（案B基盤1）

### DIFF
--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -2613,3 +2613,47 @@
 - `src/hooks/useApiFetch.ts` — `fetchData` を promise チェーンに書き換え、`transformRef` の同期を専用 `useEffect` に分離、`setLoading(true)` に理由コメント付き disable を付与
 - テスト: `src/__tests__/hooks/useApiFetch.test.tsx`（既存の回帰テストのみ、要件追加なし）
 
+## 2026-08-12: テストの `no-explicit-any` 解消（案B）— Prisma モックを `vitest-mock-extended` の `mockDeep` に置き換える（Issue #35, #23 の基盤1）
+
+### 決定内容
+- `src/__tests__/setup.ts` の Prisma モックを、手書きの `{ user: { findUnique: vi.fn(), ... } }` オブジェクトから `vitest-mock-extended` の `mockDeep<PrismaClient>()` に置き換えた
+- 型付きアクセサを 1 箇所に集約する `src/__tests__/helpers/prisma-mock.ts` を新設し、`export const prismaMock = prisma as unknown as DeepMockProxy<PrismaClient>` という「プロジェクト内で唯一許容するキャスト」を提供する
+- 旧 setup.ts が持っていたデフォルト値（`$transaction` の配列 `Promise.all` 実装、`user.count` / `taskTemplate.count` / `treasureItem.count` の `0`、`questInstance.groupBy` / `questDeclaration.findMany` / `treasureItem.findMany` / `treasureLog.findMany` / `userCollectionItem.findMany` / `checkinLog.findMany` の `[]`）は関数 `applyPrismaDefaults()` に集約し、初回適用に加えて `vi.resetAllMocks` / `vi.restoreAllMocks` 自体をラップして呼び出し直後に再適用する設計にした（47 箇所が `beforeEach` 等でこれらを呼んでおり、フックの登録順序に依存すると再適用が効かないケースがあるため）
+- `package.json` に `"typecheck": "tsc --noEmit"` を追加。CI ゲート化はしない（本 Issue 完了後も型エラーが約 1500 件残るため）
+- `tsconfig.json` の `compilerOptions.types` に `"vitest/globals"` を追加した。副作用を検証した結果、既存の describe/it/expect 未定義エラー（約 70 件）が消えるのみで新規エラーは 0 件だったため実施した（検証内容は下記「検証結果」）
+- 各テストファイル（80 ファイル、`as any` 1621 件）の移行自体は本 Issue のスコープ外。以降の 14 個の移行 Issue が本基盤の上に乗る形で順次対応する
+
+### 案A・案C を採らなかった理由
+- #23 の推奨は案C（`eslint` の `no-explicit-any` を `src/__tests__` 配下だけ override で緩める設定変更）だったが、ユーザーが「正攻法である案Bを採る」ことを #23 で決定済み。案Cは型検査を諦めて lint 警告を黙らせるだけで、モックの意図と実装コードの乖離を検出する力が一切増えない
+- 案A（Prisma モックを使わず実 DB や sqlite 等でテストする）はここでは採用対象にすら挙げていない。既存の 183 ファイル・2506 件のテストが Prisma モック前提で書かれており、置き換えは本 Issue の規模を大きく超える
+
+### 型検査による乖離検出の効果は限定的（正直な検証結果）
+- 事前スパイクで確認済みの通り、`mockDeep<PrismaClient>()` の `mockResolvedValue()` は Prisma の fluent client 型が複雑なため、明らかに不正な形のオブジェクトを渡してもエラーにならないケースがある（`@ts-expect-error` が "Unused" と判定された）
+- したがって #23 が案Bの利点として挙げていた「モックの意図と実装の乖離を型検査で検出できる」は、期待するほど強力ではない。効果として確実に得られるのは「`as any` が消え、引数の型チェックと補完が効く」ところまでである
+- 実測でも、本 Issue の変更だけでは `npx tsc --noEmit` のエラー件数はほぼ変化しない（後述）。エラーの大半（`TS2339: Property 'mockResolvedValue' does not exist ...`）は各テストファイルが `vi.mocked(prisma)` で実 `PrismaClient` 型を経由してモックしていることに起因し、これを解消するには各テストファイルを `prismaMock`（`@/__tests__/helpers/prisma-mock`）に移行する必要がある。その移行は本 Issue のスコープ外であり、後続の 14 個の移行 Issue で順次対応する
+
+### 最大のリスクと対応
+- `mockDeep` は手書きモックと異なり、未モックのモデル/メソッド呼び出しに対して `TypeError` で落ちる代わりに `undefined` を自動生成して返す。これにより「モック漏れがテストを偽陽性で通してしまう」リスクがあるため、「`npm test` が green」だけを根拠にせず、旧 setup.ts のデフォルト値を 1 件ずつ突き合わせて移植した
+- `vi.clearAllMocks()` / `vi.resetAllMocks()` は `mockDeep` が内部で生成する `vi.fn()` にも到達することを実行時に確認済み（vitest のグローバルなモックレジストリで追跡されるため、オブジェクトグラフの探索に依存しない）
+- `$transaction` は配列形式（`Prisma.PrismaPromise[]`）のみが実装側で使われている（`child-rejoin` / `family/members/[id]`）ことを確認済みで、`(ops) => Promise.all(ops)` のデフォルト実装を維持した。コールバック形式は未使用のため対応していない
+
+### 検証結果（本 Issue 実施環境での実測値。before/after）
+- `npm test`: before 183 ファイル / 2506 件 green → after 183 ファイル / 2506 件 green（完全一致、skip/todo化なし）
+- `npm run test:coverage`: lines 73.19%→73.19%、statements 70.86%→70.86%、functions 59.66%→59.66%、branches 61.78%→61.83%（低下なし）
+- `npx tsc --noEmit`（実施環境に `.next/types/validator.ts` が存在しないため、Issue 起票時の 1507 件とは前提が異なる）: 変更前 1502 件 → 変更後（`vitest/globals` 追加込み）1432 件。差分は describe/it 等のグローバル未定義エラーの解消のみで、新規エラーは 0 件（`comm` で全件突き合わせ済み）
+- `npx eslint src/__tests__` の `no-explicit-any`: 1621 件 / 80 ファイルで変更前後一致（本 Issue ではテストファイルを触っていないため）
+- `npm ci && npx prisma generate && npm run test:coverage`（CI 手順）: green で完走
+- `src/__tests__/lib/push.test.ts` の `vi.unmock("@/lib/push")` パターン、`$transaction` に配列を渡す境界値テスト、count/findMany デフォルトに依存するマネタイズ上限テスト、`vi.resetAllMocks()` を呼ぶ 47 箇所すべて green
+- `npm run test:integration` はローカル検証環境で Docker/Supabase が起動していないため実行できなかった（DB 実接続テストのため、Prisma モックを変更した本 Issue の影響を受けない設計だが、実行確認自体は次のステップ・CI で行う必要がある）
+
+### やってはいけないこと
+- 各テストファイルの `vi.mocked(prisma)` を `prismaMock` に置き換える作業を本 Issue の範囲に含める（移行 Issue の担当）
+- 「型検査でモックの誤りを完全に検出できるようになった」という誤った前提で以降の移行 Issue を進める（効果は限定的。実際に効くのは `as any` の除去と補完）
+- `vi.resetAllMocks()` 後にデフォルトが失われる問題を、個々のテストファイル側の `beforeEach` 修正で対処する（グローバル側の `vi.resetAllMocks` ラップで一元対応済み）
+
+### 該当箇所
+- `package.json` — `vitest-mock-extended` を devDependencies に追加、`typecheck` スクリプト追加
+- `src/__tests__/setup.ts` — `mockDeep<PrismaClient>()` ベースに置き換え、デフォルト値の再適用ロジックを追加
+- `src/__tests__/helpers/prisma-mock.ts` — 新規。型付きアクセサ `prismaMock`
+- `tsconfig.json` — `compilerOptions.types` に `"vitest/globals"` を追加
+

--- a/package-lock.json
+++ b/package-lock.json
@@ -41,7 +41,8 @@
         "husky": "^9.1.7",
         "jsdom": "^29.0.2",
         "tailwindcss": "^4",
-        "typescript": "5.9.3"
+        "typescript": "5.9.3",
+        "vitest-mock-extended": "^5.1.1"
       }
     },
     "node_modules/@adobe/css-tools": {
@@ -9094,6 +9095,21 @@
         "typescript": ">=4.8.4"
       }
     },
+    "node_modules/ts-essentials": {
+      "version": "10.2.1",
+      "resolved": "https://registry.npmjs.org/ts-essentials/-/ts-essentials-10.2.1.tgz",
+      "integrity": "sha512-+Id1fRkuir+CsgK2x04/icS2b4V1hQmq7ObzIrDjhN0ozfRYivnP7aaKMVJfLApQm0trjR39A6NIMVchiB9Erw==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "typescript": ">=4.5.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/tsconfig-paths": {
       "version": "3.15.0",
       "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.15.0.tgz",
@@ -9798,6 +9814,20 @@
         "vite": {
           "optional": false
         }
+      }
+    },
+    "node_modules/vitest-mock-extended": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/vitest-mock-extended/-/vitest-mock-extended-5.1.1.tgz",
+      "integrity": "sha512-k5Ji2+t4+nsdepXeakCkilyKydtgaULtP0HsjwQGIZsYr5hDTqrwCtC0+Sh0YBKUS7cY/Wxplf7SVjcZstTIMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ts-essentials": "^10.2.1"
+      },
+      "peerDependencies": {
+        "typescript": "3.x || 4.x || 5.x || 6.x || 7.x",
+        "vitest": ">=4.0.0"
       }
     },
     "node_modules/vitest/node_modules/picomatch": {

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "test:integration": "vitest run --config vitest.config.integration.ts",
     "test:e2e": "playwright test",
     "test:e2e:ui": "playwright test --ui",
+    "typecheck": "tsc --noEmit",
     "prepare": "husky"
   },
   "dependencies": {
@@ -49,6 +50,7 @@
     "husky": "^9.1.7",
     "jsdom": "^29.0.2",
     "tailwindcss": "^4",
-    "typescript": "5.9.3"
+    "typescript": "5.9.3",
+    "vitest-mock-extended": "^5.1.1"
   }
 }

--- a/src/__tests__/helpers/prisma-mock.ts
+++ b/src/__tests__/helpers/prisma-mock.ts
@@ -1,0 +1,19 @@
+import { prisma } from "@/lib/prisma";
+import type { DeepMockProxy } from "vitest-mock-extended";
+import type { PrismaClient } from "@/generated/prisma/client";
+
+/**
+ * 型付き Prisma モックへのアクセサ。
+ *
+ * `src/__tests__/setup.ts` が `@/lib/prisma` を `mockDeep<PrismaClient>()` で
+ * モックしているため、実体は `DeepMockProxy<PrismaClient>` だが `@/lib/prisma` の
+ * 型は本来の `PrismaClient` のまま（テスト対象コードと同じ import を共有するため）。
+ *
+ * プロジェクト内でこのキャストを許容するのはここ 1 箇所のみとする。
+ * 各テストファイルは `import { prismaMock } from "@/__tests__/helpers/prisma-mock"` から
+ * 利用し、`vi.mocked(prisma)` や `as any` によるキャストを個別に書かないこと。
+ *
+ * 各テストファイルを `vi.mocked(prisma)` からこの `prismaMock` に置き換える作業自体は
+ * 本ファイルのスコープ外（移行 Issue で対応）。
+ */
+export const prismaMock = prisma as unknown as DeepMockProxy<PrismaClient>;

--- a/src/__tests__/setup.ts
+++ b/src/__tests__/setup.ts
@@ -1,154 +1,86 @@
 import { vi } from "vitest";
+import { mockDeep } from "vitest-mock-extended";
+import type { PrismaClient } from "@/generated/prisma/client";
+import type { DeepMockProxy } from "vitest-mock-extended";
 
 // Mock Prisma
+//
+// vi.mock はファイル内の他のコードよりも先頭に巻き上げられる（hoisting）ため、
+// mockDeep() はこのファクトリ関数の中で呼ぶ必要がある。
+// 外側で定義した変数をここから参照すると
+// "Cannot access '...' before initialization" になる。
 vi.mock("@/lib/prisma", () => ({
-  prisma: {
-    $transaction: vi.fn().mockImplementation((ops: unknown[]) => Promise.all(ops)),
-    user: {
-      findUnique: vi.fn(),
-      findFirst: vi.fn(),
-      findMany: vi.fn(),
-      create: vi.fn(),
-      update: vi.fn(),
-      upsert: vi.fn(),
-      updateMany: vi.fn(),
-      delete: vi.fn(),
-      // マネタイズ上限チェックで子アカウント数をカウント。デフォルト 0。
-      count: vi.fn().mockResolvedValue(0),
-    },
-    family: {
-      findUnique: vi.fn(),
-      create: vi.fn(),
-      update: vi.fn(),
-    },
-    taskTemplate: {
-      findUnique: vi.fn(),
-      findFirst: vi.fn(),
-      findMany: vi.fn(),
-      create: vi.fn(),
-      createMany: vi.fn(),
-      update: vi.fn(),
-      updateMany: vi.fn(),
-      // マネタイズ上限チェックでカウントが必要。デフォルトは 0 (制限に到達していない状態)。
-      count: vi.fn().mockResolvedValue(0),
-    },
-    questInstance: {
-      findUnique: vi.fn(),
-      findFirst: vi.fn(),
-      findMany: vi.fn(),
-      create: vi.fn(),
-      update: vi.fn(),
-      updateMany: vi.fn(),
-      upsert: vi.fn(),
-      count: vi.fn(),
-      deleteMany: vi.fn(),
-      groupBy: vi.fn().mockResolvedValue([]),
-    },
-    streak: {
-      findUnique: vi.fn(),
-      upsert: vi.fn(),
-      update: vi.fn(),
-      deleteMany: vi.fn(),
-    },
-    taskStreak: {
-      findUnique: vi.fn(),
-      upsert: vi.fn(),
-      update: vi.fn(),
-      deleteMany: vi.fn(),
-    },
-    pushSubscription: {
-      findUnique: vi.fn(),
-      findMany: vi.fn(),
-      upsert: vi.fn(),
-      delete: vi.fn(),
-    },
-    userBadge: {
-      findMany: vi.fn(),
-      create: vi.fn(),
-      createMany: vi.fn(),
-      findUnique: vi.fn(),
-      count: vi.fn(),
-    },
-    gatheringGroup: {
-      upsert: vi.fn(),
-      findUnique: vi.fn(),
-    },
-    gatheringMember: {
-      findUnique: vi.fn(),
-      create: vi.fn(),
-      delete: vi.fn(),
-    },
-    bulletinLog: {
-      create: vi.fn(),
-      findMany: vi.fn(),
-      count: vi.fn(),
-    },
-    stamp: {
-      create: vi.fn(),
-      findUnique: vi.fn(),
-      findFirst: vi.fn(),
-      findMany: vi.fn(),
-    },
-    questDeclaration: {
-      create: vi.fn(),
-      findUnique: vi.fn(),
-      findFirst: vi.fn(),
-      findMany: vi.fn().mockResolvedValue([]),
-      upsert: vi.fn(),
-      deleteMany: vi.fn(),
-    },
-    treasureItem: {
-      findMany: vi.fn().mockResolvedValue([]),
-      findUnique: vi.fn(),
-      findFirst: vi.fn(),
-      create: vi.fn(),
-      createMany: vi.fn(),
-      update: vi.fn(),
-      updateMany: vi.fn(),
-      delete: vi.fn(),
-      // マネタイズ上限チェックで active な ごほうび数をカウント。デフォルト 0。
-      count: vi.fn().mockResolvedValue(0),
-    },
-    treasureLog: {
-      findMany: vi.fn().mockResolvedValue([]),
-      findUnique: vi.fn(),
-      findFirst: vi.fn(),
-      create: vi.fn(),
-      createMany: vi.fn(),
-      update: vi.fn(),
-      updateMany: vi.fn(),
-      delete: vi.fn(),
-      deleteMany: vi.fn(),
-      count: vi.fn(),
-    },
-    userCollectionItem: {
-      findMany: vi.fn().mockResolvedValue([]),
-      findUnique: vi.fn(),
-      findFirst: vi.fn(),
-      create: vi.fn(),
-      update: vi.fn(),
-      upsert: vi.fn(),
-      delete: vi.fn(),
-      deleteMany: vi.fn(),
-      count: vi.fn(),
-    },
-    checkinLog: {
-      findUnique: vi.fn(),
-      findFirst: vi.fn(),
-      findMany: vi.fn().mockResolvedValue([]),
-      create: vi.fn(),
-      upsert: vi.fn(),
-      deleteMany: vi.fn(),
-    },
-    subscription: {
-      findUnique: vi.fn(),
-      create: vi.fn(),
-      update: vi.fn(),
-      upsert: vi.fn(),
-      delete: vi.fn(),
-    },
-  },
+  prisma: mockDeep<PrismaClient>(),
 }));
+
+// vi.mock 済みの "@/lib/prisma" から prisma を取得する。
+// これは上の mockDeep() が返したインスタンスと同一の参照になる。
+import { prisma } from "@/lib/prisma";
+
+const prismaMock = prisma as unknown as DeepMockProxy<PrismaClient>;
+
+/**
+ * 旧 setup.ts（手書きモック）が持っていたデフォルト値を再現する。
+ *
+ * mockDeep は未設定のメソッド呼び出しに対して常に undefined を返すため、
+ * 呼び出し元が配列・数値を前提にしている箇所（.map / 上限チェックの比較等）では
+ * ここで明示的にデフォルト値を設定しないとランタイムエラーになる。
+ *
+ * 対象は旧 setup.ts で `.mockResolvedValue(...)` / `.mockImplementation(...)` が
+ * 設定されていたメソッドのみ。それ以外は元々 undefined 相当だったため据え置く。
+ */
+function applyPrismaDefaults(): void {
+  // src/app/api/auth/child-rejoin/route.ts, src/app/api/family/members/[id]/route.ts が
+  // 配列形式（Prisma.PrismaPromise[]）の $transaction のみを利用している。
+  // コールバック形式は現状使われていない。
+  const transactionMock = prismaMock.$transaction as unknown as {
+    mockImplementation: (fn: (ops: unknown[]) => Promise<unknown[]>) => void;
+  };
+  transactionMock.mockImplementation((ops) => Promise.all(ops));
+
+  // マネタイズ上限チェックで利用するカウント系。デフォルトは 0（上限未到達の状態）。
+  prismaMock.user.count.mockResolvedValue(0);
+  prismaMock.taskTemplate.count.mockResolvedValue(0);
+  prismaMock.treasureItem.count.mockResolvedValue(0);
+
+  // 一覧取得系。デフォルトは空配列（呼び出し元の .map 等で落ちないように）。
+  // groupBy はジェネリクスが複雑で mockResolvedValue の型検査が通らないため、
+  // $transaction と同様にモック関数として明示的にキャストする。
+  const groupByMock = prismaMock.questInstance.groupBy as unknown as {
+    mockResolvedValue: (value: unknown[]) => void;
+  };
+  groupByMock.mockResolvedValue([]);
+  prismaMock.questDeclaration.findMany.mockResolvedValue([]);
+  prismaMock.treasureItem.findMany.mockResolvedValue([]);
+  prismaMock.treasureLog.findMany.mockResolvedValue([]);
+  prismaMock.userCollectionItem.findMany.mockResolvedValue([]);
+  prismaMock.checkinLog.findMany.mockResolvedValue([]);
+}
+
+applyPrismaDefaults();
+
+// vi.resetAllMocks() / vi.restoreAllMocks() はモック実装そのものを消してしまうため、
+// 上記デフォルトも失われる。47 箇所のテストファイルが vi.resetAllMocks() を
+// beforeEach 等で呼んでおり、その実行タイミングはテストファイルごとに異なる。
+//
+// グローバル beforeEach で再適用しようとすると、setupFiles で登録した
+// beforeEach は各テストファイル自身の beforeEach より「先に」実行されるため、
+// テスト側の resetAllMocks() の方が後に走ってしまい効果がない。
+// そのため vi.resetAllMocks / vi.restoreAllMocks 自体をラップし、
+// 呼び出された直後（フックの登録順序に関わらず）にデフォルトを再適用する。
+const originalResetAllMocks = vi.resetAllMocks.bind(vi);
+vi.resetAllMocks = ((): typeof vi => {
+  originalResetAllMocks();
+  applyPrismaDefaults();
+  return vi;
+}) as typeof vi.resetAllMocks;
+
+const originalRestoreAllMocks = vi.restoreAllMocks.bind(vi);
+vi.restoreAllMocks = ((): typeof vi => {
+  originalRestoreAllMocks();
+  applyPrismaDefaults();
+  return vi;
+}) as typeof vi.restoreAllMocks;
 
 // Mock Supabase server client
 vi.mock("@/lib/supabase/server", () => ({

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,6 +11,7 @@
     "moduleResolution": "bundler",
     "resolveJsonModule": true,
     "isolatedModules": true,
+    "types": ["vitest/globals"],
     "jsx": "react-jsx",
     "incremental": true,
     "plugins": [


### PR DESCRIPTION
## Summary
- Issue #23で選択された案B（Prismaモックの本格型付け）の基盤1。`vitest-mock-extended`の`mockDeep<PrismaClient>()`ベースに`src/__tests__/setup.ts`を置き換え
- 既存のデフォルト値（`$transaction`、`count`系0、`findMany`/`groupBy`系`[]`）を`applyPrismaDefaults()`に集約し、`vi.resetAllMocks`/`vi.restoreAllMocks`実行後も再適用されるよう設計
- `typecheck`スクリプトを追加、`tsconfig.json`に`vitest/globals`型を追加

## 重要な申し送り
- `npm run test:integration`はローカルDocker未起動のため実行確認できていません。ただし対象は別のsetupファイルでPrismaをモックしない設計のため影響範囲外と判断しています（code-reviewerがコードレビューで論理的に確認済み）。CI環境での実行確認を推奨します
- 各テストファイル（80ファイル、`as any` 1621件）の除去・`fixtures.ts`の型付けは後続の別Issue（基盤2 #36、移行Issue群）で対応します
- 本PRの後続として14個の移行Issueが控えています

## Test plan
- [x] `npm test` パス（183 files / 2506 tests、変更前後で完全一致）
- [x] `npx tsc --noEmit`（1502→1432件、新規エラー0件。describe/it等のグローバル未定義エラー解消のみ）
- [x] `npm run lint` の `no-explicit-any`（1621件で変更前後一致）
- [ ] `npm run test:integration`（ローカルDocker未起動のため未確認。上記「重要な申し送り」参照）

## Related decision
- `docs/decisions.md`（「2026-08-12: テストの `no-explicit-any` 解消（案B）— Prisma モックを `vitest-mock-extended` の `mockDeep` に置き換える（Issue #35, #23 の基盤1）」の項）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
