### PR TITLE
test(fixtures): fixtures.tsをPrisma生成型準拠にしrequest.tsをNextRequest化する（案B基盤2）

### DIFF
--- a/src/__tests__/api/family/code.test.ts
+++ b/src/__tests__/api/family/code.test.ts
@@ -29,13 +29,13 @@ describe("GET /api/family/code", () => {
   it("ファミリー情報とメンバー一覧を返すこと", async () => {
     mockGetCurrentUser.mockResolvedValue(parentUser() as any);
     mockPrisma.family.findUnique.mockResolvedValue(
-      family({
-        code: "ABCD12",
+      {
+        ...family({ code: "ABCD12" }),
         users: [
           { id: "u1", name: "パパ", role: "PARENT", monsterName: null, side: null, childCode: null },
           { id: "u2", name: "太郎", role: "CHILD", monsterName: "ドラゴン", side: "DARK", childCode: "1234" },
         ],
-      }) as any,
+      } as any,
     );
 
     const res = await GET();
@@ -69,12 +69,13 @@ describe("GET /api/family/code", () => {
   it("子供メンバーのXPフィールドを返すこと", async () => {
     mockGetCurrentUser.mockResolvedValue(parentUser() as any);
     mockPrisma.family.findUnique.mockResolvedValue(
-      family({
+      {
+        ...family(),
         users: [
           { id: "u2", name: "太郎", role: "CHILD", monsterName: "ドラゴン", side: "DARK", childCode: "1234",
             studyPt: 5, staminaPt: 3, lifePt: 2 },
         ],
-      }) as any,
+      } as any,
     );
 
     const res = await GET();
@@ -87,7 +88,7 @@ describe("GET /api/family/code", () => {
 
   it("usersをcreatedAt昇順で取得すること", async () => {
     mockGetCurrentUser.mockResolvedValue(parentUser() as any);
-    mockPrisma.family.findUnique.mockResolvedValue(family({ users: [] }) as any);
+    mockPrisma.family.findUnique.mockResolvedValue({ ...family(), users: [] } as any);
 
     await GET();
 

--- a/src/__tests__/api/quests/history.test.ts
+++ b/src/__tests__/api/quests/history.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { NextRequest } from "next/server";
 import { GET } from "@/app/api/quests/history/route";
 import { prisma } from "@/lib/prisma";
 import { getCurrentUser } from "@/lib/auth";
@@ -12,7 +13,7 @@ function makeRequest(params?: Record<string, string>) {
   if (params) {
     Object.entries(params).forEach(([k, v]) => url.searchParams.set(k, v));
   }
-  return new Request(url.toString());
+  return new NextRequest(url.toString());
 }
 
 beforeEach(() => {

--- a/src/__tests__/api/quests/monthly-summary.test.ts
+++ b/src/__tests__/api/quests/monthly-summary.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
 import { GET } from "@/app/api/quests/monthly-summary/route";
 import { prisma } from "@/lib/prisma";
 import { getCurrentUser } from "@/lib/auth";
@@ -10,7 +11,7 @@ const mockGetCurrentUser = vi.mocked(getCurrentUser);
 function makeRequest(params: Record<string, string> = {}) {
   const url = new URL("http://localhost/api/quests/monthly-summary");
   Object.entries(params).forEach(([k, v]) => url.searchParams.set(k, v));
-  return new Request(url.toString());
+  return new NextRequest(url.toString());
 }
 
 beforeEach(() => {

--- a/src/__tests__/api/quests/skip.test.ts
+++ b/src/__tests__/api/quests/skip.test.ts
@@ -252,12 +252,10 @@ describe("POST /api/quests/[id]/skip", () => {
 
       mockGetCurrentUser.mockResolvedValue(childUser({ minTasksForStreak: 1 }) as any);
       mockPrisma.questInstance.findUnique.mockResolvedValue(
-        questInstance({
-          id: "q1",
-          status: "PENDING",
-          date: oldDate,
-          template: { id: "tpl-1", carryOver: true } as any,
-        }) as any,
+        {
+          ...questInstance({ id: "q1", status: "PENDING", date: oldDate }),
+          template: { id: "tpl-1", carryOver: true },
+        } as any,
       );
       mockPrisma.questInstance.update.mockResolvedValue({} as any);
       // 今日（2026-03-28）には PENDING タスクが 2件（carryOver 自身は別日付なので含まれない）
@@ -296,12 +294,10 @@ describe("POST /api/quests/[id]/skip", () => {
 
       mockGetCurrentUser.mockResolvedValue(childUser({ minTasksForStreak: 1 }) as any);
       mockPrisma.questInstance.findUnique.mockResolvedValue(
-        questInstance({
-          id: "q1",
-          status: "PENDING",
-          date: oldDate,
-          template: { id: "tpl-1", carryOver: false } as any,
-        }) as any,
+        {
+          ...questInstance({ id: "q1", status: "PENDING", date: oldDate }),
+          template: { id: "tpl-1", carryOver: false },
+        } as any,
       );
       mockPrisma.questInstance.update.mockResolvedValue({} as any);
       mockPrisma.questInstance.findMany.mockResolvedValue([

--- a/src/__tests__/helpers/fixtures.ts
+++ b/src/__tests__/helpers/fixtures.ts
@@ -1,38 +1,68 @@
 /**
  * テスト用フィクスチャファクトリ
  *
- * 各ファクトリは overrides でフィールドを上書き可能。
+ * 各ファクトリは Prisma 生成型（`@/generated/prisma/client` の `User` / `Family` 等）に
+ * 準拠した完全な値を返す。overrides でフィールドを上書き可能。
  * テスト内でリテラルオブジェクトを書く代わりにこれを使う。
+ *
+ * ## リレーション付きバリアント
+ * `include` の有無で型が変わる Prisma の実態に合わせ、リレーションを含む戻り値が
+ * 必要な場合は `Prisma.XGetPayload<{ include: {...} } }>` を使った専用ファクトリを
+ * 用意する（例: `childUserWithFamily` / `questWithTemplateAndChild`）。
+ * ベースファクトリ（`parentUser` / `questInstance` 等）はリレーションを含まない
+ * 素の Prisma モデル型を返す。
+ *
+ * ## select 用の部分型の書き方
+ * `select` で一部フィールドだけを取得するクエリの戻り値は、完全型フィクスチャでは
+ * 表現できない。呼び出し側で `Prisma.XGetPayload<{ select: {...} }>` を直接書く。
+ * 例:
+ * ```ts
+ * import type { Prisma } from "@/generated/prisma/client";
+ *
+ * const partial: Prisma.TreasureLogGetPayload<{ select: { id: true; trigger: true } }> = {
+ *   id: "log-1",
+ *   trigger: "STREAK",
+ * };
+ * ```
  */
+
+import type {
+  BulletinLog,
+  CheckinLog,
+  Family,
+  Prisma,
+  PushSubscription,
+  QuestDeclaration,
+  QuestInstance,
+  Streak,
+  Subscription,
+  TaskStreak,
+  TaskTemplate,
+  TreasureItem,
+  TreasureLog,
+  User,
+  UserBadge,
+  UserCollectionItem,
+} from "@/generated/prisma/client";
+
+/** createdAt / updatedAt 等、値そのものに意味を持たないタイムスタンプ系フィールドの既定値 */
+const FIXTURE_TIMESTAMP = new Date("2026-01-01T00:00:00.000Z");
+
+// ─── Family ───────────────────────────────────────────
+
+export function family(overrides?: Partial<Family>): Family {
+  return {
+    id: "fam-1",
+    code: "ABC123",
+    autoApproveTime: "24:00",
+    createdAt: FIXTURE_TIMESTAMP,
+    ...overrides,
+  };
+}
 
 // ─── User ─────────────────────────────────────────────
 
-interface UserFixture {
-  id: string;
-  supabaseId: string;
-  role: "PARENT" | "CHILD";
-  familyId: string | null;
-  name: string | null;
-  monsterName: string | null;
-  side: "DARK" | "LIGHT" | null;
-  evolutionStage: number;
-  evolutionPath: string;
-  collectedPaths: string;
-  monsterLevels: string;
-  studyPt: number;
-  staminaPt: number;
-  lifePt: number;
-  minTasksForStreak: number;
-  childCode: string | null;
-  rebirthPending: boolean;
-  rebirthEggBonus: string | null;
-  usedEggBonuses: string;
-  reportDeadlineTime: string | null;
-  checkinDeadlineTime: string | null;
-  family?: { id: string; code: string };
-}
-
-export function parentUser(overrides?: Partial<UserFixture>): UserFixture {
+export function parentUser(overrides?: Partial<User>): User {
   return {
     id: "parent-1",
     supabaseId: "sup-parent-1",
@@ -55,11 +85,14 @@ export function parentUser(overrides?: Partial<UserFixture>): UserFixture {
     usedEggBonuses: "[]",
     reportDeadlineTime: null,
     checkinDeadlineTime: null,
+    questTimeNotifyEnabled: true,
+    treasurePityCount: 0,
+    createdAt: FIXTURE_TIMESTAMP,
     ...overrides,
   };
 }
 
-export function childUser(overrides?: Partial<UserFixture>): UserFixture {
+export function childUser(overrides?: Partial<User>): User {
   return {
     id: "child-1",
     supabaseId: "sup-child-1",
@@ -82,31 +115,44 @@ export function childUser(overrides?: Partial<UserFixture>): UserFixture {
     usedEggBonuses: "[]",
     reportDeadlineTime: null,
     checkinDeadlineTime: null,
+    questTimeNotifyEnabled: true,
+    treasurePityCount: 0,
+    createdAt: FIXTURE_TIMESTAMP,
+    ...overrides,
+  };
+}
+
+/** `include: { family: true }` 付きクエリの戻り値用。 `childUser` + `family` の合成。 */
+export function childUserWithFamily(
+  overrides?: Partial<User>,
+  familyOverrides?: Partial<Family>,
+): Prisma.UserGetPayload<{ include: { family: true } }> {
+  return {
+    ...childUser(overrides),
+    family: family(familyOverrides),
+  };
+}
+
+// ─── Subscription ─────────────────────────────────────
+
+export function subscription(overrides?: Partial<Subscription>): Subscription {
+  return {
+    id: "sub-1",
+    userId: "parent-1",
+    plan: "FREE",
+    platform: null,
+    externalId: null,
+    currentPeriodEnd: null,
+    canceledAt: null,
+    createdAt: FIXTURE_TIMESTAMP,
+    updatedAt: FIXTURE_TIMESTAMP,
     ...overrides,
   };
 }
 
 // ─── TaskTemplate ─────────────────────────────────────
 
-interface TaskTemplateFixture {
-  id: string;
-  title: string;
-  emoji: string;
-  category: "STUDY" | "STAMINA" | "LIFE";
-  repeatDays: number[];
-  isTemporary: boolean;
-  targetDate: Date | null;
-  createdBy: "PARENT" | "CHILD";
-  originalCreatedBy: "PARENT" | "CHILD";
-  isActive: boolean;
-  familyId: string;
-  photoBonus: boolean;
-  carryOver: boolean;
-  assignedChildId: string | null;
-  quests?: QuestInstanceFixture[];
-}
-
-export function taskTemplate(overrides?: Partial<TaskTemplateFixture>): TaskTemplateFixture {
+export function taskTemplate(overrides?: Partial<TaskTemplate>): TaskTemplate {
   return {
     id: "tpl-1",
     title: "宿題",
@@ -118,34 +164,20 @@ export function taskTemplate(overrides?: Partial<TaskTemplateFixture>): TaskTemp
     createdBy: "PARENT",
     originalCreatedBy: "PARENT",
     isActive: true,
+    requestedDate: null,
     familyId: "fam-1",
     photoBonus: false,
     carryOver: false,
+    pausedAt: null,
     assignedChildId: "child-1",
+    createdAt: FIXTURE_TIMESTAMP,
     ...overrides,
   };
 }
 
 // ─── QuestInstance ────────────────────────────────────
 
-interface QuestInstanceFixture {
-  id: string;
-  templateId: string;
-  childId: string;
-  date: Date;
-  status: "PENDING" | "REPORTED" | "APPROVED" | "REJECTED" | "SKIP_REPORTED" | "SKIPPED";
-  comment: string | null;
-  reportedAt: Date | null;
-  approvedAt: Date | null;
-  deadlineBonusEarned: boolean;
-  photoUrl: string | null;
-  approvalStamp: string | null;
-  rejectionReason: string | null;
-  template?: Partial<TaskTemplateFixture>;
-  child?: Partial<UserFixture>;
-}
-
-export function questInstance(overrides?: Partial<QuestInstanceFixture>): QuestInstanceFixture {
+export function questInstance(overrides?: Partial<QuestInstance>): QuestInstance {
   return {
     id: "q-1",
     templateId: "tpl-1",
@@ -159,43 +191,30 @@ export function questInstance(overrides?: Partial<QuestInstanceFixture>): QuestI
     photoUrl: null,
     approvalStamp: null,
     rejectionReason: null,
+    snapshotTitle: "宿題",
+    snapshotEmoji: "📚",
+    snapshotCategory: "STUDY",
+    createdAt: FIXTURE_TIMESTAMP,
     ...overrides,
   };
 }
 
-// ─── Family ───────────────────────────────────────────
-
-interface FamilyFixture {
-  id: string;
-  code: string;
-  users?: Partial<UserFixture>[];
-}
-
-export function family(overrides?: Partial<FamilyFixture>): FamilyFixture {
+/** `include: { template: true, child: true }` 付きクエリの戻り値用。 */
+export function questWithTemplateAndChild(
+  overrides?: Partial<QuestInstance>,
+  templateOverrides?: Partial<TaskTemplate>,
+  childOverrides?: Partial<User>,
+): Prisma.QuestInstanceGetPayload<{ include: { template: true; child: true } }> {
   return {
-    id: "fam-1",
-    code: "ABC123",
-    ...overrides,
+    ...questInstance(overrides),
+    template: taskTemplate(templateOverrides),
+    child: childUser(childOverrides),
   };
 }
 
 // ─── Streak ──────────────────────────────────────────
 
-interface StreakFixture {
-  id: string;
-  childId: string;
-  currentStreak: number;
-  bestStreak: number;
-  lastAchievedDate: Date | null;
-  loginCurrentStreak: number;
-  loginBestStreak: number;
-  lastLoginDate: Date | null;
-  checkinCurrentStreak: number;
-  checkinBestStreak: number;
-  lastCheckinDate: Date | null;
-}
-
-export function streak(overrides?: Partial<StreakFixture>): StreakFixture {
+export function streak(overrides?: Partial<Streak>): Streak {
   return {
     id: "streak-1",
     childId: "child-1",
@@ -208,6 +227,144 @@ export function streak(overrides?: Partial<StreakFixture>): StreakFixture {
     checkinCurrentStreak: 0,
     checkinBestStreak: 0,
     lastCheckinDate: null,
+    createdAt: FIXTURE_TIMESTAMP,
+    updatedAt: FIXTURE_TIMESTAMP,
+    ...overrides,
+  };
+}
+
+// ─── CheckinLog ───────────────────────────────────────
+
+export function checkinLog(overrides?: Partial<CheckinLog>): CheckinLog {
+  return {
+    id: "checkin-1",
+    childId: "child-1",
+    date: new Date("2026-03-12"),
+    success: true,
+    checkedInAt: null,
+    createdAt: FIXTURE_TIMESTAMP,
+    ...overrides,
+  };
+}
+
+// ─── TaskStreak ───────────────────────────────────────
+
+export function taskStreak(overrides?: Partial<TaskStreak>): TaskStreak {
+  return {
+    id: "task-streak-1",
+    taskId: "tpl-1",
+    childId: "child-1",
+    currentStreak: 0,
+    bestStreak: 0,
+    lastAchievedDate: null,
+    createdAt: FIXTURE_TIMESTAMP,
+    updatedAt: FIXTURE_TIMESTAMP,
+    ...overrides,
+  };
+}
+
+// ─── UserBadge ────────────────────────────────────────
+
+export function userBadge(overrides?: Partial<UserBadge>): UserBadge {
+  return {
+    id: "badge-1",
+    userId: "child-1",
+    badgeId: "first-quest",
+    unlockedAt: FIXTURE_TIMESTAMP,
+    ...overrides,
+  };
+}
+
+// ─── PushSubscription ─────────────────────────────────
+
+export function pushSubscription(overrides?: Partial<PushSubscription>): PushSubscription {
+  return {
+    id: "push-1",
+    userId: "child-1",
+    endpoint: "https://fcm.googleapis.com/fcm/send/test-endpoint",
+    p256dh: "test-p256dh-key",
+    auth: "test-auth-key",
+    createdAt: FIXTURE_TIMESTAMP,
+    ...overrides,
+  };
+}
+
+// ─── QuestDeclaration ─────────────────────────────────
+
+export function questDeclaration(overrides?: Partial<QuestDeclaration>): QuestDeclaration {
+  return {
+    id: "decl-1",
+    templateId: "tpl-1",
+    childId: "child-1",
+    date: new Date("2026-03-12"),
+    createdAt: FIXTURE_TIMESTAMP,
+    ...overrides,
+  };
+}
+
+// ─── TreasureItem ─────────────────────────────────────
+
+export function treasureItem(overrides?: Partial<TreasureItem>): TreasureItem {
+  return {
+    id: "item-1",
+    childId: "child-1",
+    title: "ゲーム30分",
+    rarity: "COMMON",
+    sortOrder: 0,
+    isActive: true,
+    createdAt: FIXTURE_TIMESTAMP,
+    updatedAt: FIXTURE_TIMESTAMP,
+    ...overrides,
+  };
+}
+
+// ─── TreasureLog ──────────────────────────────────────
+
+export function treasureLog(overrides?: Partial<TreasureLog>): TreasureLog {
+  return {
+    id: "log-1",
+    childId: "child-1",
+    date: new Date("2026-03-12"),
+    trigger: "STREAK",
+    boosted: false,
+    status: "LOCKED",
+    itemId: null,
+    collectionItemId: null,
+    fulfilled: false,
+    openedAt: null,
+    createdAt: FIXTURE_TIMESTAMP,
+    updatedAt: FIXTURE_TIMESTAMP,
+    ...overrides,
+  };
+}
+
+// ─── UserCollectionItem ───────────────────────────────
+
+export function userCollectionItem(overrides?: Partial<UserCollectionItem>): UserCollectionItem {
+  return {
+    id: "collection-1",
+    childId: "child-1",
+    itemId: "summer-01",
+    season: "2026-summer",
+    count: 1,
+    firstAcquiredAt: FIXTURE_TIMESTAMP,
+    lastAcquiredAt: FIXTURE_TIMESTAMP,
+    ...overrides,
+  };
+}
+
+// ─── BulletinLog ──────────────────────────────────────
+
+export function bulletinLog(overrides?: Partial<BulletinLog>): BulletinLog {
+  return {
+    id: "bulletin-1",
+    groupId: "group-1",
+    childId: "child-1",
+    type: "TASK_COMPLETE",
+    message: "宿題完了！",
+    key: "",
+    date: new Date("2026-03-12"),
+    createdAt: FIXTURE_TIMESTAMP,
     ...overrides,
   };
 }

--- a/src/__tests__/helpers/request.ts
+++ b/src/__tests__/helpers/request.ts
@@ -2,18 +2,20 @@
  * テスト用リクエスト・パラメータビルダー
  */
 
+import { NextRequest } from "next/server";
+
 /** Next.js App Router の動的ルートパラメータ形式を生成 */
 export function makeParams(id: string) {
   return { params: Promise.resolve({ id }) };
 }
 
-/** JSON ボディ付き Request を生成 */
+/** JSON ボディ付き NextRequest を生成 */
 export function makeRequest(
   path: string,
   body: Record<string, unknown>,
   method = "POST",
-) {
-  return new Request(`http://localhost${path}`, {
+): NextRequest {
+  return new NextRequest(`http://localhost${path}`, {
     method,
     body: JSON.stringify(body),
   });


### PR DESCRIPTION
## Summary
- Issue #23案Bの基盤2。5つの独自interfaceベースのフィクスチャをPrisma生成型準拠に書き換え、10モデル分のファクトリを新規追加した
- `request.ts`の`makeRequest()`を`NextRequest`対応に変更し、`TS2345`を計40件解消した
- 既存デフォルト値（進化・XP計算の分岐条件）は一切変更していない

## Test plan
- [x] `npm test` パス（183 files / 2506 tests、変更前後で完全一致）
- [x] `npm run typecheck`（1432→1392件、-40件。TS2345が40件完全解消）
- [ ] `npm run lint` パス

## Base branch について
このPRは #35 のブランチ `feature/prisma-mock-deep-foundation`（PR #53）の上に積まれています。base は `develop` ではなく `feature/prisma-mock-deep-foundation` です。**PR #53 がdevelopにマージされたら、本PRのbaseをdevelopに変更する必要があります**（GitHubが自動でretargetする場合もありますが、されない場合は手動で `gh pr edit --base develop` 等を実行してください）。

## 後続作業
このfixtures.tsの上に、後続14個の移行Issueが乗る予定です。

Closes #36

🤖 Generated with [Claude Code](https://claude.com/claude-code)
