### PR TITLE
test(approve): 承認APIテストのas anyを型付きモック・フィクスチャに移行

### DIFF
--- a/src/__tests__/api/approve/approve-id.test.ts
+++ b/src/__tests__/api/approve/approve-id.test.ts
@@ -1,11 +1,11 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { POST } from "@/app/api/approve/[id]/route";
-import { prisma } from "@/lib/prisma";
 import { getCurrentUser } from "@/lib/auth";
 import { recordTaskStreak } from "@/lib/streak";
 import { cancelTreasuresOnReject } from "@/lib/treasureService";
 import { makeRequest, makeParams } from "../../helpers/request";
-import { parentUser, childUser } from "../../helpers/fixtures";
+import { prismaMock } from "../../helpers/prisma-mock";
+import { parentUserWithFamily, childUserWithFamily, questWithTemplateAndChild, questInstance, questDeclaration } from "../../helpers/fixtures";
 
 // recordDailyAchievement / recordTaskStreak をモックして承認テストから分離
 vi.mock("@/lib/streak", () => ({
@@ -25,14 +25,13 @@ vi.mock("@/lib/treasureService", () => ({
 const mockRecordTaskStreak = vi.mocked(recordTaskStreak);
 const mockCancelTreasures = vi.mocked(cancelTreasuresOnReject);
 
-const mockPrisma = vi.mocked(prisma);
 const mockGetCurrentUser = vi.mocked(getCurrentUser);
 
 beforeEach(() => {
   vi.clearAllMocks();
   // 宣言ボーナス: 既定では宣言なし（テスト毎に上書き可能）
-  mockPrisma.questDeclaration.findUnique.mockResolvedValue(null);
-  mockPrisma.questInstance.findMany.mockResolvedValue([]);
+  prismaMock.questDeclaration.findUnique.mockResolvedValue(null);
+  prismaMock.questInstance.findMany.mockResolvedValue([]);
 });
 
 describe("POST /api/approve/[id]", () => {
@@ -43,14 +42,14 @@ describe("POST /api/approve/[id]", () => {
   });
 
   it("CHILDロールの場合、403を返すこと", async () => {
-    mockGetCurrentUser.mockResolvedValue(childUser() as any);
+    mockGetCurrentUser.mockResolvedValue(childUserWithFamily());
     const res = await POST(makeRequest("/api/approve/q1", { action: "approve" }), makeParams("q1"));
     expect(res.status).toBe(403);
   });
 
   it("存在しないクエストで404を返すこと", async () => {
-    mockGetCurrentUser.mockResolvedValue(parentUser() as any);
-    mockPrisma.questInstance.findUnique.mockResolvedValue(null);
+    mockGetCurrentUser.mockResolvedValue(parentUserWithFamily());
+    prismaMock.questInstance.findUnique.mockResolvedValue(null);
 
     const res = await POST(
       makeRequest("/api/approve/q-none", { action: "approve" }),
@@ -62,83 +61,75 @@ describe("POST /api/approve/[id]", () => {
   // ── ステータスバリデーション ─────────────
 
   it("REPORTED以外のステータス（PENDING等）で400を返すこと", async () => {
-    mockGetCurrentUser.mockResolvedValue(parentUser() as any);
-    mockPrisma.questInstance.findUnique.mockResolvedValue({
-      id: "q-pending",
-      status: "PENDING",
-      date: new Date("2026-03-13"),
-      childId: "child-1",
-      templateId: "tpl-1",
-      template: { category: "STUDY", createdBy: "PARENT" },
-      child: { id: "child-1" },
-    } as any);
+    mockGetCurrentUser.mockResolvedValue(parentUserWithFamily());
+    prismaMock.questInstance.findUnique.mockResolvedValue(
+      questWithTemplateAndChild(
+        { id: "q-pending", status: "PENDING", date: new Date("2026-03-13"), childId: "child-1", templateId: "tpl-1" },
+        { category: "STUDY", createdBy: "PARENT" },
+        { id: "child-1" },
+      ),
+    );
 
     const res = await POST(
       makeRequest("/api/approve/q-pending", { action: "approve" }),
       makeParams("q-pending"),
     );
     expect(res.status).toBe(400);
-    expect(mockPrisma.user.update).not.toHaveBeenCalled();
+    expect(prismaMock.user.update).not.toHaveBeenCalled();
   });
 
   it("既にAPPROVED済みのクエストで400を返すこと（二重承認防止）", async () => {
-    mockGetCurrentUser.mockResolvedValue(parentUser() as any);
-    mockPrisma.questInstance.findUnique.mockResolvedValue({
-      id: "q-approved",
-      status: "APPROVED",
-      date: new Date("2026-03-13"),
-      childId: "child-1",
-      templateId: "tpl-1",
-      template: { category: "STUDY", createdBy: "PARENT" },
-      child: { id: "child-1" },
-    } as any);
+    mockGetCurrentUser.mockResolvedValue(parentUserWithFamily());
+    prismaMock.questInstance.findUnique.mockResolvedValue(
+      questWithTemplateAndChild(
+        { id: "q-approved", status: "APPROVED", date: new Date("2026-03-13"), childId: "child-1", templateId: "tpl-1" },
+        { category: "STUDY", createdBy: "PARENT" },
+        { id: "child-1" },
+      ),
+    );
 
     const res = await POST(
       makeRequest("/api/approve/q-approved", { action: "approve" }),
       makeParams("q-approved"),
     );
     expect(res.status).toBe(400);
-    expect(mockPrisma.user.update).not.toHaveBeenCalled();
+    expect(prismaMock.user.update).not.toHaveBeenCalled();
   });
 
   it("SKIPPED済みのクエストで400を返すこと", async () => {
-    mockGetCurrentUser.mockResolvedValue(parentUser() as any);
-    mockPrisma.questInstance.findUnique.mockResolvedValue({
-      id: "q-skipped",
-      status: "SKIPPED",
-      date: new Date("2026-03-13"),
-      childId: "child-1",
-      templateId: "tpl-1",
-      template: { category: "STUDY", createdBy: "PARENT" },
-      child: { id: "child-1" },
-    } as any);
+    mockGetCurrentUser.mockResolvedValue(parentUserWithFamily());
+    prismaMock.questInstance.findUnique.mockResolvedValue(
+      questWithTemplateAndChild(
+        { id: "q-skipped", status: "SKIPPED", date: new Date("2026-03-13"), childId: "child-1", templateId: "tpl-1" },
+        { category: "STUDY", createdBy: "PARENT" },
+        { id: "child-1" },
+      ),
+    );
 
     const res = await POST(
       makeRequest("/api/approve/q-skipped", { action: "approve" }),
       makeParams("q-skipped"),
     );
     expect(res.status).toBe(400);
-    expect(mockPrisma.user.update).not.toHaveBeenCalled();
+    expect(prismaMock.user.update).not.toHaveBeenCalled();
   });
 
   it("REJECTED（差し戻し中）のクエストで400を返すこと", async () => {
-    mockGetCurrentUser.mockResolvedValue(parentUser() as any);
-    mockPrisma.questInstance.findUnique.mockResolvedValue({
-      id: "q-rejected",
-      status: "REJECTED",
-      date: new Date("2026-03-13"),
-      childId: "child-1",
-      templateId: "tpl-1",
-      template: { category: "STUDY", createdBy: "PARENT" },
-      child: { id: "child-1" },
-    } as any);
+    mockGetCurrentUser.mockResolvedValue(parentUserWithFamily());
+    prismaMock.questInstance.findUnique.mockResolvedValue(
+      questWithTemplateAndChild(
+        { id: "q-rejected", status: "REJECTED", date: new Date("2026-03-13"), childId: "child-1", templateId: "tpl-1" },
+        { category: "STUDY", createdBy: "PARENT" },
+        { id: "child-1" },
+      ),
+    );
 
     const res = await POST(
       makeRequest("/api/approve/q-rejected", { action: "approve" }),
       makeParams("q-rejected"),
     );
     expect(res.status).toBe(400);
-    expect(mockPrisma.user.update).not.toHaveBeenCalled();
+    expect(prismaMock.user.update).not.toHaveBeenCalled();
   });
 
   // ── 承認 ──────────────────────────────────
@@ -146,22 +137,18 @@ describe("POST /api/approve/[id]", () => {
   describe("action: approve", () => {
     it("クエストをAPPROVEDに更新しXP（基本1pt）を付与すること", async () => {
       vi.spyOn(Math, "random").mockReturnValue(0); // STUDY が選ばれる
-      mockGetCurrentUser.mockResolvedValue(parentUser() as any);
-      const childData = { id: "child-1", evolutionPath: "", evolutionStage: 0, studyPt: 5, staminaPt: 3, lifePt: 1, collectedPaths: "[]" };
-      mockPrisma.questInstance.findUnique.mockResolvedValue({
-        id: "q1",
-        status: "REPORTED",
-        date: new Date("2026-03-13"),
-        childId: "child-1",
-        templateId: "tpl-1",
-        deadlineBonusEarned: false,
-        photoUrl: null,
-        template: { category: "STUDY", createdBy: "PARENT", photoBonus: false },
-        child: childData,
-      } as any);
-      mockPrisma.user.findUnique.mockResolvedValue(childData as any);
-      mockPrisma.questInstance.update.mockResolvedValue({} as any);
-      mockPrisma.user.update.mockResolvedValue({} as any);
+      mockGetCurrentUser.mockResolvedValue(parentUserWithFamily());
+      // side: null（未選択）でも進化ログ用の getMonsterStage フォールバックが動くことを合わせて確認する
+      const childOverrides = { id: "child-1", evolutionPath: "", evolutionStage: 0, studyPt: 5, staminaPt: 3, lifePt: 1, collectedPaths: "[]", side: null };
+      const quest = questWithTemplateAndChild(
+        { id: "q1", status: "REPORTED", date: new Date("2026-03-13"), childId: "child-1", templateId: "tpl-1", deadlineBonusEarned: false, photoUrl: null, snapshotCategory: "STUDY" },
+        { category: "STUDY", createdBy: "PARENT", photoBonus: false },
+        childOverrides,
+      );
+      prismaMock.questInstance.findUnique.mockResolvedValue(quest);
+      prismaMock.user.findUnique.mockResolvedValue(quest.child);
+      prismaMock.questInstance.update.mockResolvedValue(quest);
+      prismaMock.user.update.mockResolvedValue(quest.child);
 
       const res = await POST(
         makeRequest("/api/approve/q1", { action: "approve" }),
@@ -170,12 +157,12 @@ describe("POST /api/approve/[id]", () => {
       const json = await res.json();
 
       expect(json.ok).toBe(true);
-      expect(mockPrisma.questInstance.update).toHaveBeenCalledWith({
+      expect(prismaMock.questInstance.update).toHaveBeenCalledWith({
         where: { id: "q1" },
         data: { status: "APPROVED", approvedAt: expect.any(Date) },
       });
       // 基本1pt → studyPt: 5+1=6, total=6+3+1=10 >= 1（stage0閾値） → 孵化、STUDY選択
-      expect(mockPrisma.user.update).toHaveBeenCalledWith({
+      expect(prismaMock.user.update).toHaveBeenCalledWith({
         where: { id: "child-1" },
         data: {
           studyPt: 0,
@@ -191,108 +178,88 @@ describe("POST /api/approve/[id]", () => {
     });
 
     it("deadlineBonusEarned=trueで+1、合計2ptが付与されること", async () => {
-      mockGetCurrentUser.mockResolvedValue(parentUser() as any);
-      const childData = { id: "child-1", evolutionPath: "", evolutionStage: 1, studyPt: 0, staminaPt: 0, lifePt: 0, collectedPaths: "[]" };
-      mockPrisma.questInstance.findUnique.mockResolvedValue({
-        id: "q1-dl",
-        status: "REPORTED",
-        date: new Date("2026-03-13"),
-        childId: "child-1",
-        templateId: "tpl-1",
-        deadlineBonusEarned: true,
-        photoUrl: null,
-        template: { category: "STUDY", createdBy: "PARENT", photoBonus: false },
-        child: childData,
-      } as any);
-      mockPrisma.user.findUnique.mockResolvedValue(childData as any);
-      mockPrisma.questInstance.update.mockResolvedValue({} as any);
-      mockPrisma.user.update.mockResolvedValue({} as any);
+      mockGetCurrentUser.mockResolvedValue(parentUserWithFamily());
+      const childOverrides = { id: "child-1", evolutionPath: "", evolutionStage: 1, studyPt: 0, staminaPt: 0, lifePt: 0, collectedPaths: "[]" };
+      const quest = questWithTemplateAndChild(
+        { id: "q1-dl", status: "REPORTED", date: new Date("2026-03-13"), childId: "child-1", templateId: "tpl-1", deadlineBonusEarned: true, photoUrl: null, snapshotCategory: "STUDY" },
+        { category: "STUDY", createdBy: "PARENT", photoBonus: false },
+        childOverrides,
+      );
+      prismaMock.questInstance.findUnique.mockResolvedValue(quest);
+      prismaMock.user.findUnique.mockResolvedValue(quest.child);
+      prismaMock.questInstance.update.mockResolvedValue(quest);
+      prismaMock.user.update.mockResolvedValue(quest.child);
 
       await POST(makeRequest("/api/approve/q1-dl", { action: "approve" }), makeParams("q1-dl"));
 
       // 基本1 + 期限1 = 2pt → studyPt: 2
-      expect(mockPrisma.user.update).toHaveBeenCalledWith({
+      expect(prismaMock.user.update).toHaveBeenCalledWith({
         where: { id: "child-1" },
         data: expect.objectContaining({ studyPt: 2 }),
       });
     });
 
     it("photoBonus=trueかつphotoUrlありで+1、合計2ptが付与されること", async () => {
-      mockGetCurrentUser.mockResolvedValue(parentUser() as any);
-      const childData = { id: "child-1", evolutionPath: "", evolutionStage: 1, studyPt: 0, staminaPt: 0, lifePt: 0, collectedPaths: "[]" };
-      mockPrisma.questInstance.findUnique.mockResolvedValue({
-        id: "q1-ph",
-        status: "REPORTED",
-        date: new Date("2026-03-13"),
-        childId: "child-1",
-        templateId: "tpl-1",
-        deadlineBonusEarned: false,
-        photoUrl: "https://example.com/photo.jpg",
-        template: { category: "STAMINA", createdBy: "PARENT", photoBonus: true },
-        child: childData,
-      } as any);
-      mockPrisma.user.findUnique.mockResolvedValue(childData as any);
-      mockPrisma.questInstance.update.mockResolvedValue({} as any);
-      mockPrisma.user.update.mockResolvedValue({} as any);
+      mockGetCurrentUser.mockResolvedValue(parentUserWithFamily());
+      const childOverrides = { id: "child-1", evolutionPath: "", evolutionStage: 1, studyPt: 0, staminaPt: 0, lifePt: 0, collectedPaths: "[]" };
+      const quest = questWithTemplateAndChild(
+        { id: "q1-ph", status: "REPORTED", date: new Date("2026-03-13"), childId: "child-1", templateId: "tpl-1", deadlineBonusEarned: false, photoUrl: "https://example.com/photo.jpg", snapshotCategory: "STAMINA" },
+        { category: "STAMINA", createdBy: "PARENT", photoBonus: true },
+        childOverrides,
+      );
+      prismaMock.questInstance.findUnique.mockResolvedValue(quest);
+      prismaMock.user.findUnique.mockResolvedValue(quest.child);
+      prismaMock.questInstance.update.mockResolvedValue(quest);
+      prismaMock.user.update.mockResolvedValue(quest.child);
 
       await POST(makeRequest("/api/approve/q1-ph", { action: "approve" }), makeParams("q1-ph"));
 
       // 基本1 + 写真1 = 2pt → staminaPt: 2
-      expect(mockPrisma.user.update).toHaveBeenCalledWith({
+      expect(prismaMock.user.update).toHaveBeenCalledWith({
         where: { id: "child-1" },
         data: expect.objectContaining({ staminaPt: 2 }),
       });
     });
 
     it("全ボーナスありで3ptが付与されること", async () => {
-      mockGetCurrentUser.mockResolvedValue(parentUser() as any);
-      const childData = { id: "child-1", evolutionPath: "", evolutionStage: 1, studyPt: 0, staminaPt: 0, lifePt: 0, collectedPaths: "[]" };
-      mockPrisma.questInstance.findUnique.mockResolvedValue({
-        id: "q1-all",
-        status: "REPORTED",
-        date: new Date("2026-03-13"),
-        childId: "child-1",
-        templateId: "tpl-1",
-        deadlineBonusEarned: true,
-        photoUrl: "https://example.com/photo.jpg",
-        template: { category: "LIFE", createdBy: "PARENT", photoBonus: true },
-        child: childData,
-      } as any);
-      mockPrisma.user.findUnique.mockResolvedValue(childData as any);
-      mockPrisma.questInstance.update.mockResolvedValue({} as any);
-      mockPrisma.user.update.mockResolvedValue({} as any);
+      mockGetCurrentUser.mockResolvedValue(parentUserWithFamily());
+      const childOverrides = { id: "child-1", evolutionPath: "", evolutionStage: 1, studyPt: 0, staminaPt: 0, lifePt: 0, collectedPaths: "[]" };
+      const quest = questWithTemplateAndChild(
+        { id: "q1-all", status: "REPORTED", date: new Date("2026-03-13"), childId: "child-1", templateId: "tpl-1", deadlineBonusEarned: true, photoUrl: "https://example.com/photo.jpg", snapshotCategory: "LIFE" },
+        { category: "LIFE", createdBy: "PARENT", photoBonus: true },
+        childOverrides,
+      );
+      prismaMock.questInstance.findUnique.mockResolvedValue(quest);
+      prismaMock.user.findUnique.mockResolvedValue(quest.child);
+      prismaMock.questInstance.update.mockResolvedValue(quest);
+      prismaMock.user.update.mockResolvedValue(quest.child);
 
       await POST(makeRequest("/api/approve/q1-all", { action: "approve" }), makeParams("q1-all"));
 
       // 基本1 + 期限1 + 写真1 = 3pt → lifePt: 3
-      expect(mockPrisma.user.update).toHaveBeenCalledWith({
+      expect(prismaMock.user.update).toHaveBeenCalledWith({
         where: { id: "child-1" },
         data: expect.objectContaining({ lifePt: 3 }),
       });
     });
 
     it("進化閾値未満ならステージ変更なしでポイント更新すること", async () => {
-      mockGetCurrentUser.mockResolvedValue(parentUser() as any);
-      const childData = { id: "child-1", evolutionPath: "", evolutionStage: 1, studyPt: 1, staminaPt: 0, lifePt: 0, collectedPaths: "[]" };
-      mockPrisma.questInstance.findUnique.mockResolvedValue({
-        id: "q1b",
-        status: "REPORTED",
-        date: new Date("2026-03-13"),
-        childId: "child-1",
-        templateId: "tpl-1",
-        deadlineBonusEarned: false,
-        photoUrl: null,
-        template: { category: "STUDY", createdBy: "PARENT", photoBonus: false },
-        child: childData,
-      } as any);
-      mockPrisma.user.findUnique.mockResolvedValue(childData as any);
-      mockPrisma.questInstance.update.mockResolvedValue({} as any);
-      mockPrisma.user.update.mockResolvedValue({} as any);
+      mockGetCurrentUser.mockResolvedValue(parentUserWithFamily());
+      const childOverrides = { id: "child-1", evolutionPath: "", evolutionStage: 1, studyPt: 1, staminaPt: 0, lifePt: 0, collectedPaths: "[]" };
+      const quest = questWithTemplateAndChild(
+        { id: "q1b", status: "REPORTED", date: new Date("2026-03-13"), childId: "child-1", templateId: "tpl-1", deadlineBonusEarned: false, photoUrl: null, snapshotCategory: "STUDY" },
+        { category: "STUDY", createdBy: "PARENT", photoBonus: false },
+        childOverrides,
+      );
+      prismaMock.questInstance.findUnique.mockResolvedValue(quest);
+      prismaMock.user.findUnique.mockResolvedValue(quest.child);
+      prismaMock.questInstance.update.mockResolvedValue(quest);
+      prismaMock.user.update.mockResolvedValue(quest.child);
 
       await POST(makeRequest("/api/approve/q1b", { action: "approve" }), makeParams("q1b"));
 
       // EASY=1pt → studyPt: 1+1=2, total=2 < 10 (ステージ1の閾値) → 進化しない
-      expect(mockPrisma.user.update).toHaveBeenCalledWith({
+      expect(prismaMock.user.update).toHaveBeenCalledWith({
         where: { id: "child-1" },
         data: {
           studyPt: 2,
@@ -307,23 +274,18 @@ describe("POST /api/approve/[id]", () => {
     });
 
     it("仮タスク（createdBy=CHILD）承認時にテンプレートも同時承認すること", async () => {
-      mockGetCurrentUser.mockResolvedValue(parentUser() as any);
-      const childData = { id: "child-1", evolutionPath: "", evolutionStage: 0, studyPt: 0, staminaPt: 0, lifePt: 1, collectedPaths: "[]" };
-      mockPrisma.questInstance.findUnique.mockResolvedValue({
-        id: "q2",
-        status: "REPORTED",
-        date: new Date("2026-03-13"),
-        childId: "child-1",
-        templateId: "tpl-child",
-        deadlineBonusEarned: false,
-        photoUrl: null,
-        template: { category: "LIFE", createdBy: "CHILD", photoBonus: false },
-        child: childData,
-      } as any);
-      mockPrisma.user.findUnique.mockResolvedValue(childData as any);
-      mockPrisma.questInstance.update.mockResolvedValue({} as any);
-      mockPrisma.user.update.mockResolvedValue({} as any);
-      mockPrisma.taskTemplate.update.mockResolvedValue({} as any);
+      mockGetCurrentUser.mockResolvedValue(parentUserWithFamily());
+      const childOverrides = { id: "child-1", evolutionPath: "", evolutionStage: 0, studyPt: 0, staminaPt: 0, lifePt: 1, collectedPaths: "[]" };
+      const quest = questWithTemplateAndChild(
+        { id: "q2", status: "REPORTED", date: new Date("2026-03-13"), childId: "child-1", templateId: "tpl-child", deadlineBonusEarned: false, photoUrl: null, snapshotCategory: "LIFE" },
+        { id: "tpl-child", category: "LIFE", createdBy: "CHILD", photoBonus: false },
+        childOverrides,
+      );
+      prismaMock.questInstance.findUnique.mockResolvedValue(quest);
+      prismaMock.user.findUnique.mockResolvedValue(quest.child);
+      prismaMock.questInstance.update.mockResolvedValue(quest);
+      prismaMock.user.update.mockResolvedValue(quest.child);
+      prismaMock.taskTemplate.update.mockResolvedValue(quest.template);
 
       const res = await POST(
         makeRequest("/api/approve/q2", { action: "approve" }),
@@ -332,29 +294,24 @@ describe("POST /api/approve/[id]", () => {
       const json = await res.json();
 
       expect(json.ok).toBe(true);
-      expect(mockPrisma.taskTemplate.update).toHaveBeenCalledWith({
+      expect(prismaMock.taskTemplate.update).toHaveBeenCalledWith({
         where: { id: "tpl-child" },
         data: { createdBy: "PARENT" },
       });
     });
 
     it("一時タスク承認時にrecordTaskStreakを呼ばないこと", async () => {
-      mockGetCurrentUser.mockResolvedValue(parentUser() as any);
-      const childData = { id: "child-1", evolutionPath: "", evolutionStage: 0, studyPt: 0, staminaPt: 0, lifePt: 0, collectedPaths: "[]" };
-      mockPrisma.questInstance.findUnique.mockResolvedValue({
-        id: "q-tmp",
-        status: "REPORTED",
-        date: new Date("2026-03-19"),
-        childId: "child-1",
-        templateId: "tpl-tmp",
-        deadlineBonusEarned: false,
-        photoUrl: null,
-        template: { category: "LIFE", createdBy: "PARENT", photoBonus: false, isTemporary: true },
-        child: childData,
-      } as any);
-      mockPrisma.user.findUnique.mockResolvedValue(childData as any);
-      mockPrisma.questInstance.update.mockResolvedValue({} as any);
-      mockPrisma.user.update.mockResolvedValue({} as any);
+      mockGetCurrentUser.mockResolvedValue(parentUserWithFamily());
+      const childOverrides = { id: "child-1", evolutionPath: "", evolutionStage: 0, studyPt: 0, staminaPt: 0, lifePt: 0, collectedPaths: "[]" };
+      const quest = questWithTemplateAndChild(
+        { id: "q-tmp", status: "REPORTED", date: new Date("2026-03-19"), childId: "child-1", templateId: "tpl-tmp", deadlineBonusEarned: false, photoUrl: null, snapshotCategory: "LIFE" },
+        { id: "tpl-tmp", category: "LIFE", createdBy: "PARENT", photoBonus: false, isTemporary: true },
+        childOverrides,
+      );
+      prismaMock.questInstance.findUnique.mockResolvedValue(quest);
+      prismaMock.user.findUnique.mockResolvedValue(quest.child);
+      prismaMock.questInstance.update.mockResolvedValue(quest);
+      prismaMock.user.update.mockResolvedValue(quest.child);
 
       const res = await POST(
         makeRequest("/api/approve/q-tmp", { action: "approve" }),
@@ -368,29 +325,24 @@ describe("POST /api/approve/[id]", () => {
 
     it("stamp を渡すと questInstance.update に approvalStamp が含まれること", async () => {
       vi.spyOn(Math, "random").mockReturnValue(0);
-      mockGetCurrentUser.mockResolvedValue(parentUser() as any);
-      const childData = { id: "child-1", evolutionPath: "", evolutionStage: 1, studyPt: 0, staminaPt: 0, lifePt: 0, collectedPaths: "[]" };
-      mockPrisma.questInstance.findUnique.mockResolvedValue({
-        id: "q-stamp",
-        status: "REPORTED",
-        date: new Date("2026-04-09"),
-        childId: "child-1",
-        templateId: "tpl-1",
-        deadlineBonusEarned: false,
-        photoUrl: null,
-        template: { category: "STUDY", createdBy: "PARENT", photoBonus: false, isTemporary: false },
-        child: childData,
-      } as any);
-      mockPrisma.user.findUnique.mockResolvedValue(childData as any);
-      mockPrisma.questInstance.update.mockResolvedValue({} as any);
-      mockPrisma.user.update.mockResolvedValue({} as any);
+      mockGetCurrentUser.mockResolvedValue(parentUserWithFamily());
+      const childOverrides = { id: "child-1", evolutionPath: "", evolutionStage: 1, studyPt: 0, staminaPt: 0, lifePt: 0, collectedPaths: "[]" };
+      const quest = questWithTemplateAndChild(
+        { id: "q-stamp", status: "REPORTED", date: new Date("2026-04-09"), childId: "child-1", templateId: "tpl-1", deadlineBonusEarned: false, photoUrl: null, snapshotCategory: "STUDY" },
+        { category: "STUDY", createdBy: "PARENT", photoBonus: false, isTemporary: false },
+        childOverrides,
+      );
+      prismaMock.questInstance.findUnique.mockResolvedValue(quest);
+      prismaMock.user.findUnique.mockResolvedValue(quest.child);
+      prismaMock.questInstance.update.mockResolvedValue(quest);
+      prismaMock.user.update.mockResolvedValue(quest.child);
 
       await POST(
         makeRequest("/api/approve/q-stamp", { action: "approve", stamp: "⭐" }),
         makeParams("q-stamp"),
       );
 
-      expect(mockPrisma.questInstance.update).toHaveBeenCalledWith({
+      expect(prismaMock.questInstance.update).toHaveBeenCalledWith({
         where: { id: "q-stamp" },
         data: { status: "APPROVED", approvedAt: expect.any(Date), approvalStamp: "⭐" },
       });
@@ -399,29 +351,24 @@ describe("POST /api/approve/[id]", () => {
 
     it("stamp なしで承認すると approvalStamp は undefined（フィールドなし）であること", async () => {
       vi.spyOn(Math, "random").mockReturnValue(0);
-      mockGetCurrentUser.mockResolvedValue(parentUser() as any);
-      const childData = { id: "child-1", evolutionPath: "", evolutionStage: 1, studyPt: 0, staminaPt: 0, lifePt: 0, collectedPaths: "[]" };
-      mockPrisma.questInstance.findUnique.mockResolvedValue({
-        id: "q-nostamp",
-        status: "REPORTED",
-        date: new Date("2026-04-09"),
-        childId: "child-1",
-        templateId: "tpl-1",
-        deadlineBonusEarned: false,
-        photoUrl: null,
-        template: { category: "STUDY", createdBy: "PARENT", photoBonus: false, isTemporary: false },
-        child: childData,
-      } as any);
-      mockPrisma.user.findUnique.mockResolvedValue(childData as any);
-      mockPrisma.questInstance.update.mockResolvedValue({} as any);
-      mockPrisma.user.update.mockResolvedValue({} as any);
+      mockGetCurrentUser.mockResolvedValue(parentUserWithFamily());
+      const childOverrides = { id: "child-1", evolutionPath: "", evolutionStage: 1, studyPt: 0, staminaPt: 0, lifePt: 0, collectedPaths: "[]" };
+      const quest = questWithTemplateAndChild(
+        { id: "q-nostamp", status: "REPORTED", date: new Date("2026-04-09"), childId: "child-1", templateId: "tpl-1", deadlineBonusEarned: false, photoUrl: null, snapshotCategory: "STUDY" },
+        { category: "STUDY", createdBy: "PARENT", photoBonus: false, isTemporary: false },
+        childOverrides,
+      );
+      prismaMock.questInstance.findUnique.mockResolvedValue(quest);
+      prismaMock.user.findUnique.mockResolvedValue(quest.child);
+      prismaMock.questInstance.update.mockResolvedValue(quest);
+      prismaMock.user.update.mockResolvedValue(quest.child);
 
       await POST(
         makeRequest("/api/approve/q-nostamp", { action: "approve" }),
         makeParams("q-nostamp"),
       );
 
-      expect(mockPrisma.questInstance.update).toHaveBeenCalledWith({
+      expect(prismaMock.questInstance.update).toHaveBeenCalledWith({
         where: { id: "q-nostamp" },
         data: { status: "APPROVED", approvedAt: expect.any(Date) },
       });
@@ -429,133 +376,131 @@ describe("POST /api/approve/[id]", () => {
     });
 
     it("PARENT作成テンプレートの場合、テンプレート承認をスキップすること", async () => {
-      mockGetCurrentUser.mockResolvedValue(parentUser() as any);
-      const childData = { id: "child-1", evolutionPath: "", evolutionStage: 0, studyPt: 0, staminaPt: 0, lifePt: 0, collectedPaths: "[]" };
-      mockPrisma.questInstance.findUnique.mockResolvedValue({
-        id: "q3",
-        status: "REPORTED",
-        date: new Date("2026-03-13"),
-        childId: "child-1",
-        templateId: "tpl-parent",
-        deadlineBonusEarned: false,
-        photoUrl: null,
-        template: { category: "STAMINA", createdBy: "PARENT", photoBonus: false },
-        child: childData,
-      } as any);
-      mockPrisma.user.findUnique.mockResolvedValue(childData as any);
-      mockPrisma.questInstance.update.mockResolvedValue({} as any);
-      mockPrisma.user.update.mockResolvedValue({} as any);
+      mockGetCurrentUser.mockResolvedValue(parentUserWithFamily());
+      const childOverrides = { id: "child-1", evolutionPath: "", evolutionStage: 0, studyPt: 0, staminaPt: 0, lifePt: 0, collectedPaths: "[]" };
+      const quest = questWithTemplateAndChild(
+        { id: "q3", status: "REPORTED", date: new Date("2026-03-13"), childId: "child-1", templateId: "tpl-parent", deadlineBonusEarned: false, photoUrl: null, snapshotCategory: "STAMINA" },
+        { id: "tpl-parent", category: "STAMINA", createdBy: "PARENT", photoBonus: false },
+        childOverrides,
+      );
+      prismaMock.questInstance.findUnique.mockResolvedValue(quest);
+      prismaMock.user.findUnique.mockResolvedValue(quest.child);
+      prismaMock.questInstance.update.mockResolvedValue(quest);
+      prismaMock.user.update.mockResolvedValue(quest.child);
 
       await POST(makeRequest("/api/approve/q3", { action: "approve" }), makeParams("q3"));
 
-      expect(mockPrisma.taskTemplate.update).not.toHaveBeenCalled();
+      expect(prismaMock.taskTemplate.update).not.toHaveBeenCalled();
     });
 
     it("宣言済みタスク承認時、+1XPボーナスが付与されること", async () => {
-      mockGetCurrentUser.mockResolvedValue(parentUser() as any);
-      const childData = { id: "child-1", evolutionPath: "", evolutionStage: 1, studyPt: 0, staminaPt: 0, lifePt: 0, collectedPaths: "[]" };
-      mockPrisma.questInstance.findUnique.mockResolvedValue({
-        id: "q-decl",
-        status: "REPORTED",
-        date: new Date("2026-05-09"),
-        reportedAt: new Date("2026-05-09T05:00:00Z"),
-        childId: "child-1",
-        templateId: "tpl-1",
-        deadlineBonusEarned: false,
-        photoUrl: null,
-        template: { category: "STUDY", createdBy: "PARENT", photoBonus: false, isTemporary: false },
-        child: childData,
-      } as any);
-      mockPrisma.user.findUnique.mockResolvedValue(childData as any);
+      mockGetCurrentUser.mockResolvedValue(parentUserWithFamily());
+      const childOverrides = { id: "child-1", evolutionPath: "", evolutionStage: 1, studyPt: 0, staminaPt: 0, lifePt: 0, collectedPaths: "[]" };
+      const quest = questWithTemplateAndChild(
+        {
+          id: "q-decl",
+          status: "REPORTED",
+          date: new Date("2026-05-09"),
+          reportedAt: new Date("2026-05-09T05:00:00Z"),
+          childId: "child-1",
+          templateId: "tpl-1",
+          deadlineBonusEarned: false,
+          photoUrl: null,
+          snapshotCategory: "STUDY",
+        },
+        { category: "STUDY", createdBy: "PARENT", photoBonus: false, isTemporary: false },
+        childOverrides,
+      );
+      prismaMock.questInstance.findUnique.mockResolvedValue(quest);
+      prismaMock.user.findUnique.mockResolvedValue(quest.child);
       // reportedAt の JST日付（2026-05-09）に対する宣言レコードあり
-      mockPrisma.questDeclaration.findUnique.mockResolvedValue({
-        id: "decl-1",
-        templateId: "tpl-1",
-        childId: "child-1",
-        date: new Date("2026-05-09"),
-      } as any);
-      mockPrisma.questInstance.update.mockResolvedValue({} as any);
-      mockPrisma.user.update.mockResolvedValue({} as any);
+      prismaMock.questDeclaration.findUnique.mockResolvedValue(
+        questDeclaration({ id: "decl-1", templateId: "tpl-1", childId: "child-1", date: new Date("2026-05-09") }),
+      );
+      prismaMock.questInstance.update.mockResolvedValue(quest);
+      prismaMock.user.update.mockResolvedValue(quest.child);
 
       await POST(makeRequest("/api/approve/q-decl", { action: "approve" }), makeParams("q-decl"));
 
       // 基本1pt + 宣言ボーナス1pt = 2pt
-      expect(mockPrisma.user.update).toHaveBeenCalledWith({
+      expect(prismaMock.user.update).toHaveBeenCalledWith({
         where: { id: "child-1" },
         data: expect.objectContaining({ studyPt: 2 }),
       });
     });
 
     it("宣言なしのタスク承認時はボーナスなし（基本のみ）", async () => {
-      mockGetCurrentUser.mockResolvedValue(parentUser() as any);
-      const childData = { id: "child-1", evolutionPath: "", evolutionStage: 1, studyPt: 0, staminaPt: 0, lifePt: 0, collectedPaths: "[]" };
-      mockPrisma.questInstance.findUnique.mockResolvedValue({
-        id: "q-no-decl",
-        status: "REPORTED",
-        date: new Date("2026-05-09"),
-        reportedAt: new Date("2026-05-09T05:00:00Z"),
-        childId: "child-1",
-        templateId: "tpl-1",
-        deadlineBonusEarned: false,
-        photoUrl: null,
-        template: { category: "STUDY", createdBy: "PARENT", photoBonus: false, isTemporary: false },
-        child: childData,
-      } as any);
-      mockPrisma.user.findUnique.mockResolvedValue(childData as any);
-      mockPrisma.questDeclaration.findUnique.mockResolvedValue(null);
-      mockPrisma.questInstance.update.mockResolvedValue({} as any);
-      mockPrisma.user.update.mockResolvedValue({} as any);
+      mockGetCurrentUser.mockResolvedValue(parentUserWithFamily());
+      const childOverrides = { id: "child-1", evolutionPath: "", evolutionStage: 1, studyPt: 0, staminaPt: 0, lifePt: 0, collectedPaths: "[]" };
+      const quest = questWithTemplateAndChild(
+        {
+          id: "q-no-decl",
+          status: "REPORTED",
+          date: new Date("2026-05-09"),
+          reportedAt: new Date("2026-05-09T05:00:00Z"),
+          childId: "child-1",
+          templateId: "tpl-1",
+          deadlineBonusEarned: false,
+          photoUrl: null,
+          snapshotCategory: "STUDY",
+        },
+        { category: "STUDY", createdBy: "PARENT", photoBonus: false, isTemporary: false },
+        childOverrides,
+      );
+      prismaMock.questInstance.findUnique.mockResolvedValue(quest);
+      prismaMock.user.findUnique.mockResolvedValue(quest.child);
+      prismaMock.questDeclaration.findUnique.mockResolvedValue(null);
+      prismaMock.questInstance.update.mockResolvedValue(quest);
+      prismaMock.user.update.mockResolvedValue(quest.child);
 
       await POST(makeRequest("/api/approve/q-no-decl", { action: "approve" }), makeParams("q-no-decl"));
 
-      expect(mockPrisma.user.update).toHaveBeenCalledWith({
+      expect(prismaMock.user.update).toHaveBeenCalledWith({
         where: { id: "child-1" },
         data: expect.objectContaining({ studyPt: 1 }),
       });
     });
 
     it("宣言あり + deadlineBonus + photoBonus を全部加算（最大4pt）", async () => {
-      mockGetCurrentUser.mockResolvedValue(parentUser() as any);
-      const childData = { id: "child-1", evolutionPath: "", evolutionStage: 1, studyPt: 0, staminaPt: 0, lifePt: 0, collectedPaths: "[]" };
-      mockPrisma.questInstance.findUnique.mockResolvedValue({
-        id: "q-decl-all",
-        status: "REPORTED",
-        date: new Date("2026-05-09"),
-        reportedAt: new Date("2026-05-09T05:00:00Z"),
-        childId: "child-1",
-        templateId: "tpl-1",
-        deadlineBonusEarned: true,
-        photoUrl: "https://example.com/p.jpg",
-        template: { category: "LIFE", createdBy: "PARENT", photoBonus: true, isTemporary: false },
-        child: childData,
-      } as any);
-      mockPrisma.user.findUnique.mockResolvedValue(childData as any);
-      mockPrisma.questDeclaration.findUnique.mockResolvedValue({ id: "decl-2" } as any);
-      mockPrisma.questInstance.update.mockResolvedValue({} as any);
-      mockPrisma.user.update.mockResolvedValue({} as any);
+      mockGetCurrentUser.mockResolvedValue(parentUserWithFamily());
+      const childOverrides = { id: "child-1", evolutionPath: "", evolutionStage: 1, studyPt: 0, staminaPt: 0, lifePt: 0, collectedPaths: "[]" };
+      const quest = questWithTemplateAndChild(
+        {
+          id: "q-decl-all",
+          status: "REPORTED",
+          date: new Date("2026-05-09"),
+          reportedAt: new Date("2026-05-09T05:00:00Z"),
+          childId: "child-1",
+          templateId: "tpl-1",
+          deadlineBonusEarned: true,
+          photoUrl: "https://example.com/p.jpg",
+          snapshotCategory: "LIFE",
+        },
+        { category: "LIFE", createdBy: "PARENT", photoBonus: true, isTemporary: false },
+        childOverrides,
+      );
+      prismaMock.questInstance.findUnique.mockResolvedValue(quest);
+      prismaMock.user.findUnique.mockResolvedValue(quest.child);
+      prismaMock.questDeclaration.findUnique.mockResolvedValue(questDeclaration({ id: "decl-2" }));
+      prismaMock.questInstance.update.mockResolvedValue(quest);
+      prismaMock.user.update.mockResolvedValue(quest.child);
 
       await POST(makeRequest("/api/approve/q-decl-all", { action: "approve" }), makeParams("q-decl-all"));
 
       // 1 + 1 (deadline) + 1 (photo) + 1 (declaration) = 4
-      expect(mockPrisma.user.update).toHaveBeenCalledWith({
+      expect(prismaMock.user.update).toHaveBeenCalledWith({
         where: { id: "child-1" },
         data: expect.objectContaining({ lifePt: 4 }),
       });
     });
 
     it("転生条件達成時にrebirthPending=trueをセットしstageをリセットしないこと", async () => {
-      mockGetCurrentUser.mockResolvedValue(parentUser() as any);
+      mockGetCurrentUser.mockResolvedValue(parentUserWithFamily());
       // stage3でbasic 1pt追加 → total=19+1=20 >= REBIRTH_THRESHOLD(20) → 転生保留
-      mockPrisma.questInstance.findUnique.mockResolvedValue({
-        id: "q-rebirth",
-        status: "REPORTED",
-        date: new Date("2026-03-26"),
-        childId: "child-1",
-        templateId: "tpl-1",
-        deadlineBonusEarned: false,
-        photoUrl: null,
-        template: { category: "STUDY", createdBy: "PARENT", photoBonus: false, isTemporary: false },
-        child: {
+      const quest = questWithTemplateAndChild(
+        { id: "q-rebirth", status: "REPORTED", date: new Date("2026-03-26"), childId: "child-1", templateId: "tpl-1", deadlineBonusEarned: false, photoUrl: null, snapshotCategory: "STUDY" },
+        { category: "STUDY", createdBy: "PARENT", photoBonus: false, isTemporary: false },
+        {
           id: "child-1",
           evolutionPath: "STUDY_STAMINA_LIFE",
           evolutionStage: 3,
@@ -564,20 +509,15 @@ describe("POST /api/approve/[id]", () => {
           lifePt: 0,
           collectedPaths: '["STUDY","STUDY_STAMINA","STUDY_STAMINA_LIFE"]',
         },
-      } as any);
-      mockPrisma.user.findUnique.mockResolvedValue({
-        id: "child-1",
-        evolutionPath: "STUDY_STAMINA_LIFE",
-        evolutionStage: 3,
-        studyPt: 19,
-        staminaPt: 0,
-        lifePt: 0,
-        collectedPaths: '["STUDY","STUDY_STAMINA","STUDY_STAMINA_LIFE"]',
+      );
+      prismaMock.questInstance.findUnique.mockResolvedValue(quest);
+      prismaMock.user.findUnique.mockResolvedValue({
+        ...quest.child,
         rebirthPending: false,
         rebirthEggBonus: null,
-      } as any);
-      mockPrisma.questInstance.update.mockResolvedValue({} as any);
-      mockPrisma.user.update.mockResolvedValue({} as any);
+      });
+      prismaMock.questInstance.update.mockResolvedValue(quest);
+      prismaMock.user.update.mockResolvedValue(quest.child);
 
       const res = await POST(
         makeRequest("/api/approve/q-rebirth", { action: "approve" }),
@@ -587,7 +527,7 @@ describe("POST /api/approve/[id]", () => {
 
       expect(json.ok).toBe(true);
       // 基本1pt → studyPt=20, total=20 >= REBIRTH_THRESHOLD(20) → rebirthPending=true
-      expect(mockPrisma.user.update).toHaveBeenCalledWith(
+      expect(prismaMock.user.update).toHaveBeenCalledWith(
         expect.objectContaining({
           where: { id: "child-1" },
           data: expect.objectContaining({
@@ -597,8 +537,39 @@ describe("POST /api/approve/[id]", () => {
         }),
       );
       // evolutionStage はリセットされないこと
-      const callArgs = mockPrisma.user.update.mock.calls[0][0];
+      const callArgs = prismaMock.user.update.mock.calls[0][0];
       expect(callArgs.data.evolutionStage).toBeUndefined();
+    });
+
+    it("スキーマ導入前の旧データ（snapshotCategory / monsterLevels 欠落）でも template.category / \"{}\" にフォールバックして承認できること", async () => {
+      mockGetCurrentUser.mockResolvedValue(parentUserWithFamily());
+      const childOverrides = { id: "child-1", evolutionPath: "", evolutionStage: 1, studyPt: 0, staminaPt: 0, lifePt: 0, collectedPaths: "[]" };
+      const quest = questWithTemplateAndChild(
+        { id: "q-legacy", status: "REPORTED", date: new Date("2026-03-13"), childId: "child-1", templateId: "tpl-1", deadlineBonusEarned: false, photoUrl: null },
+        { category: "STAMINA", createdBy: "PARENT", photoBonus: false },
+        childOverrides,
+      );
+      // snapshotCategory（Category, non-null）/ monsterLevels（String, @default("{}")）は
+      // Prisma の生成型では必須フィールドだが、実データはこれらのカラムが追加される前に
+      // 作成された行を含みうる。approve.ts の
+      // `quest.snapshotCategory ?? quest.template.category` / `child.monsterLevels ?? "{}"`
+      // はこの旧データ互換のための防御的フォールバックであり、生成型のままでは欠落を表現
+      // できないため、この1テストに限り as unknown as で意図的に欠落を再現する。
+      const legacyQuest = { ...quest, snapshotCategory: undefined } as unknown as typeof quest;
+      const legacyChild = { ...quest.child, monsterLevels: undefined } as unknown as typeof quest.child;
+      prismaMock.questInstance.findUnique.mockResolvedValue(legacyQuest);
+      prismaMock.user.findUnique.mockResolvedValue(legacyChild);
+      prismaMock.questInstance.update.mockResolvedValue(quest);
+      prismaMock.user.update.mockResolvedValue(quest.child);
+
+      await POST(makeRequest("/api/approve/q-legacy", { action: "approve" }), makeParams("q-legacy"));
+
+      // snapshotCategory欠落 → template.category (STAMINA) にフォールバックして staminaPt に加算
+      // monsterLevels欠落 → "{}" 扱いで正常に更新される
+      expect(prismaMock.user.update).toHaveBeenCalledWith({
+        where: { id: "child-1" },
+        data: expect.objectContaining({ staminaPt: 1, monsterLevels: "{}" }),
+      });
     });
   });
 
@@ -606,17 +577,14 @@ describe("POST /api/approve/[id]", () => {
 
   describe("SKIP_REPORTED", () => {
     it("スキップ申請を承認するとSKIPPEDに更新すること", async () => {
-      mockGetCurrentUser.mockResolvedValue(parentUser() as any);
-      mockPrisma.questInstance.findUnique.mockResolvedValue({
-        id: "q-skip",
-        status: "SKIP_REPORTED",
-        date: new Date("2026-03-13"),
-        childId: "child-1",
-        templateId: "tpl-1",
-        template: { category: "STUDY", createdBy: "PARENT" },
-        child: { id: "child-1", evolutionPath: "", evolutionStage: 0, studyPt: 0, staminaPt: 0, lifePt: 0 },
-      } as any);
-      mockPrisma.questInstance.update.mockResolvedValue({} as any);
+      mockGetCurrentUser.mockResolvedValue(parentUserWithFamily());
+      const quest = questWithTemplateAndChild(
+        { id: "q-skip", status: "SKIP_REPORTED", date: new Date("2026-03-13"), childId: "child-1", templateId: "tpl-1" },
+        { category: "STUDY", createdBy: "PARENT" },
+        { id: "child-1", evolutionPath: "", evolutionStage: 0, studyPt: 0, staminaPt: 0, lifePt: 0 },
+      );
+      prismaMock.questInstance.findUnique.mockResolvedValue(quest);
+      prismaMock.questInstance.update.mockResolvedValue(quest);
 
       const res = await POST(
         makeRequest("/api/approve/q-skip", { action: "approve" }),
@@ -625,30 +593,27 @@ describe("POST /api/approve/[id]", () => {
       const json = await res.json();
 
       expect(json.ok).toBe(true);
-      expect(mockPrisma.questInstance.update).toHaveBeenCalledWith({
+      expect(prismaMock.questInstance.update).toHaveBeenCalledWith({
         where: { id: "q-skip" },
         data: { status: "SKIPPED", approvedAt: expect.any(Date) },
       });
       // XP付与されないこと
-      expect(mockPrisma.user.update).not.toHaveBeenCalled();
+      expect(prismaMock.user.update).not.toHaveBeenCalled();
     });
 
     it("スキップ申請を差し戻すとPENDINGに戻しコメントをクリアすること", async () => {
-      mockGetCurrentUser.mockResolvedValue(parentUser() as any);
-      mockPrisma.questInstance.findUnique.mockResolvedValue({
-        id: "q-skip2",
-        status: "SKIP_REPORTED",
-        date: new Date("2026-03-13"),
-        childId: "child-1",
-        templateId: "tpl-1",
-        template: { category: "STUDY", createdBy: "PARENT" },
-        child: { id: "child-1", minTasksForStreak: 1, evolutionPath: "", evolutionStage: 0, studyPt: 0, staminaPt: 0, lifePt: 0 },
-      } as any);
-      mockPrisma.questInstance.update.mockResolvedValue({} as any);
-      mockPrisma.questInstance.findMany.mockResolvedValue([
-        { status: "PENDING" } as any,
-        { status: "REPORTED" } as any,
-        { status: "REPORTED" } as any,
+      mockGetCurrentUser.mockResolvedValue(parentUserWithFamily());
+      const quest = questWithTemplateAndChild(
+        { id: "q-skip2", status: "SKIP_REPORTED", date: new Date("2026-03-13"), childId: "child-1", templateId: "tpl-1" },
+        { category: "STUDY", createdBy: "PARENT" },
+        { id: "child-1", minTasksForStreak: 1, evolutionPath: "", evolutionStage: 0, studyPt: 0, staminaPt: 0, lifePt: 0 },
+      );
+      prismaMock.questInstance.findUnique.mockResolvedValue(quest);
+      prismaMock.questInstance.update.mockResolvedValue(quest);
+      prismaMock.questInstance.findMany.mockResolvedValue([
+        questInstance({ status: "PENDING" }),
+        questInstance({ status: "REPORTED" }),
+        questInstance({ status: "REPORTED" }),
       ]);
 
       const res = await POST(
@@ -658,7 +623,7 @@ describe("POST /api/approve/[id]", () => {
       const json = await res.json();
 
       expect(json.ok).toBe(true);
-      expect(mockPrisma.questInstance.update).toHaveBeenCalledWith({
+      expect(prismaMock.questInstance.update).toHaveBeenCalledWith({
         where: { id: "q-skip2" },
         data: { status: "PENDING", comment: null },
       });
@@ -667,24 +632,21 @@ describe("POST /api/approve/[id]", () => {
     // スキップ却下で reportedCount が落ちる (SKIP_REPORTED→PENDING) ため、
     // 既存 LOCKED 宝箱 (ALL_COMPLETE の boosted=false 等) を再評価する必要がある
     it("スキップ申請を差し戻すと cancelTreasuresOnReject を呼んで stale な LOCKED を整理する", async () => {
-      mockGetCurrentUser.mockResolvedValue(parentUser() as any);
+      mockGetCurrentUser.mockResolvedValue(parentUserWithFamily());
       const dateJST = new Date("2026-03-13");
-      mockPrisma.questInstance.findUnique.mockResolvedValue({
-        id: "q-skip3",
-        status: "SKIP_REPORTED",
-        date: dateJST,
-        childId: "child-1",
-        templateId: "tpl-1",
-        template: { category: "STUDY", createdBy: "PARENT" },
-        child: { id: "child-1", minTasksForStreak: 1, evolutionPath: "", evolutionStage: 0, studyPt: 0, staminaPt: 0, lifePt: 0 },
-      } as any);
-      mockPrisma.questInstance.update.mockResolvedValue({} as any);
+      const quest = questWithTemplateAndChild(
+        { id: "q-skip3", status: "SKIP_REPORTED", date: dateJST, childId: "child-1", templateId: "tpl-1" },
+        { category: "STUDY", createdBy: "PARENT" },
+        { id: "child-1", minTasksForStreak: 1, evolutionPath: "", evolutionStage: 0, studyPt: 0, staminaPt: 0, lifePt: 0 },
+      );
+      prismaMock.questInstance.findUnique.mockResolvedValue(quest);
+      prismaMock.questInstance.update.mockResolvedValue(quest);
       // 却下後の集計: 3 件中 PENDING (戻った本人) + REPORTED 1 + REPORTED 1
       //   → reportedCount=2, totalCount=3, skippedCount=0
-      mockPrisma.questInstance.findMany.mockResolvedValue([
-        { status: "PENDING" } as any,
-        { status: "REPORTED" } as any,
-        { status: "REPORTED" } as any,
+      prismaMock.questInstance.findMany.mockResolvedValue([
+        questInstance({ status: "PENDING" }),
+        questInstance({ status: "REPORTED" }),
+        questInstance({ status: "REPORTED" }),
       ]);
 
       await POST(
@@ -702,22 +664,19 @@ describe("POST /api/approve/[id]", () => {
         isProxy: false,
       });
       // 差し戻し用の集計も子供画面と同じ template.isActive / pausedAt フィルタで絞る
-      const findManyCall = (mockPrisma.questInstance.findMany as any).mock.calls[0][0];
-      expect(findManyCall.where.template).toEqual({ isActive: true, pausedAt: null });
+      const findManyCall = prismaMock.questInstance.findMany.mock.calls[0][0];
+      expect(findManyCall?.where?.template).toEqual({ isActive: true, pausedAt: null });
     });
 
     it("スキップ申請承認 (SKIPPED) では cancelTreasuresOnReject を呼ばない", async () => {
-      mockGetCurrentUser.mockResolvedValue(parentUser() as any);
-      mockPrisma.questInstance.findUnique.mockResolvedValue({
-        id: "q-skip-ok",
-        status: "SKIP_REPORTED",
-        date: new Date("2026-03-13"),
-        childId: "child-1",
-        templateId: "tpl-1",
-        template: { category: "STUDY", createdBy: "PARENT" },
-        child: { id: "child-1", minTasksForStreak: 1, evolutionPath: "", evolutionStage: 0, studyPt: 0, staminaPt: 0, lifePt: 0 },
-      } as any);
-      mockPrisma.questInstance.update.mockResolvedValue({} as any);
+      mockGetCurrentUser.mockResolvedValue(parentUserWithFamily());
+      const quest = questWithTemplateAndChild(
+        { id: "q-skip-ok", status: "SKIP_REPORTED", date: new Date("2026-03-13"), childId: "child-1", templateId: "tpl-1" },
+        { category: "STUDY", createdBy: "PARENT" },
+        { id: "child-1", minTasksForStreak: 1, evolutionPath: "", evolutionStage: 0, studyPt: 0, staminaPt: 0, lifePt: 0 },
+      );
+      prismaMock.questInstance.findUnique.mockResolvedValue(quest);
+      prismaMock.questInstance.update.mockResolvedValue(quest);
 
       await POST(
         makeRequest("/api/approve/q-skip-ok", { action: "approve" }),
@@ -733,35 +692,31 @@ describe("POST /api/approve/[id]", () => {
 
   describe("action: reject", () => {
     it("rejectionReason なしで400を返すこと", async () => {
-      mockGetCurrentUser.mockResolvedValue(parentUser() as any);
-      mockPrisma.questInstance.findUnique.mockResolvedValue({
-        id: "q4",
-        status: "REPORTED",
-        childId: "child-1",
-        templateId: "tpl-1",
-        template: { category: "STUDY" },
-        child: { id: "child-1", studyPt: 10, staminaPt: 5, lifePt: 3 },
-      } as any);
+      mockGetCurrentUser.mockResolvedValue(parentUserWithFamily());
+      const quest = questWithTemplateAndChild(
+        { id: "q4", status: "REPORTED", childId: "child-1", templateId: "tpl-1" },
+        { category: "STUDY" },
+        { id: "child-1", studyPt: 10, staminaPt: 5, lifePt: 3 },
+      );
+      prismaMock.questInstance.findUnique.mockResolvedValue(quest);
 
       const res = await POST(
         makeRequest("/api/approve/q4", { action: "reject" }),
         makeParams("q4"),
       );
       expect(res.status).toBe(400);
-      expect(mockPrisma.questInstance.update).not.toHaveBeenCalled();
+      expect(prismaMock.questInstance.update).not.toHaveBeenCalled();
     });
 
     it("クエストをREJECTEDに更新しrejectionReasonを保存すること（XP差し引きなし）", async () => {
-      mockGetCurrentUser.mockResolvedValue(parentUser() as any);
-      mockPrisma.questInstance.findUnique.mockResolvedValue({
-        id: "q4",
-        status: "REPORTED",
-        childId: "child-1",
-        templateId: "tpl-1",
-        template: { category: "STUDY" },
-        child: { id: "child-1", studyPt: 10, staminaPt: 5, lifePt: 3 },
-      } as any);
-      mockPrisma.questInstance.update.mockResolvedValue({} as any);
+      mockGetCurrentUser.mockResolvedValue(parentUserWithFamily());
+      const quest = questWithTemplateAndChild(
+        { id: "q4", status: "REPORTED", childId: "child-1", templateId: "tpl-1" },
+        { category: "STUDY" },
+        { id: "child-1", studyPt: 10, staminaPt: 5, lifePt: 3 },
+      );
+      prismaMock.questInstance.findUnique.mockResolvedValue(quest);
+      prismaMock.questInstance.update.mockResolvedValue(quest);
 
       const res = await POST(
         makeRequest("/api/approve/q4", { action: "reject", rejectionReason: "写真が暗くてよく見えないよ" }),
@@ -770,24 +725,22 @@ describe("POST /api/approve/[id]", () => {
       const json = await res.json();
 
       expect(json.ok).toBe(true);
-      expect(mockPrisma.questInstance.update).toHaveBeenCalledWith({
+      expect(prismaMock.questInstance.update).toHaveBeenCalledWith({
         where: { id: "q4" },
         data: { status: "REJECTED", rejectionReason: "写真が暗くてよく見えないよ" },
       });
       // XPは承認時付与のため差し引き不要
-      expect(mockPrisma.user.update).not.toHaveBeenCalled();
+      expect(prismaMock.user.update).not.toHaveBeenCalled();
     });
 
     it("その他を選択し追加メッセージなしで400を返すこと", async () => {
-      mockGetCurrentUser.mockResolvedValue(parentUser() as any);
-      mockPrisma.questInstance.findUnique.mockResolvedValue({
-        id: "q4b",
-        status: "REPORTED",
-        childId: "child-1",
-        templateId: "tpl-1",
-        template: { category: "STUDY" },
-        child: { id: "child-1", studyPt: 10, staminaPt: 5, lifePt: 3 },
-      } as any);
+      mockGetCurrentUser.mockResolvedValue(parentUserWithFamily());
+      const quest = questWithTemplateAndChild(
+        { id: "q4b", status: "REPORTED", childId: "child-1", templateId: "tpl-1" },
+        { category: "STUDY" },
+        { id: "child-1", studyPt: 10, staminaPt: 5, lifePt: 3 },
+      );
+      prismaMock.questInstance.findUnique.mockResolvedValue(quest);
 
       const res = await POST(
         makeRequest("/api/approve/q4b", { action: "reject", rejectionReason: "その他" }),
@@ -797,16 +750,14 @@ describe("POST /api/approve/[id]", () => {
     });
 
     it("その他＋追加メッセージでREJECTEDに更新すること", async () => {
-      mockGetCurrentUser.mockResolvedValue(parentUser() as any);
-      mockPrisma.questInstance.findUnique.mockResolvedValue({
-        id: "q4c",
-        status: "REPORTED",
-        childId: "child-1",
-        templateId: "tpl-1",
-        template: { category: "STUDY" },
-        child: { id: "child-1", studyPt: 10, staminaPt: 5, lifePt: 3 },
-      } as any);
-      mockPrisma.questInstance.update.mockResolvedValue({} as any);
+      mockGetCurrentUser.mockResolvedValue(parentUserWithFamily());
+      const quest = questWithTemplateAndChild(
+        { id: "q4c", status: "REPORTED", childId: "child-1", templateId: "tpl-1" },
+        { category: "STUDY" },
+        { id: "child-1", studyPt: 10, staminaPt: 5, lifePt: 3 },
+      );
+      prismaMock.questInstance.findUnique.mockResolvedValue(quest);
+      prismaMock.questInstance.update.mockResolvedValue(quest);
 
       const res = await POST(
         makeRequest("/api/approve/q4c", {
@@ -819,30 +770,27 @@ describe("POST /api/approve/[id]", () => {
       const json = await res.json();
 
       expect(json.ok).toBe(true);
-      expect(mockPrisma.questInstance.update).toHaveBeenCalledWith({
+      expect(prismaMock.questInstance.update).toHaveBeenCalledWith({
         where: { id: "q4c" },
         data: { status: "REJECTED", rejectionReason: "算数プリントだけやってね" },
       });
     });
 
     it("差し戻し後の当日進捗を集計して cancelTreasuresOnReject を呼ぶ", async () => {
-      mockGetCurrentUser.mockResolvedValue(parentUser() as any);
+      mockGetCurrentUser.mockResolvedValue(parentUserWithFamily());
       const dateJST = new Date("2026-03-13");
-      mockPrisma.questInstance.findUnique.mockResolvedValue({
-        id: "q-rej",
-        status: "REPORTED",
-        childId: "child-1",
-        templateId: "tpl-1",
-        date: dateJST,
-        template: { category: "STUDY" },
-        child: { id: "child-1", minTasksForStreak: 1, studyPt: 0, staminaPt: 0, lifePt: 0 },
-      } as any);
-      mockPrisma.questInstance.update.mockResolvedValue({} as any);
+      const quest = questWithTemplateAndChild(
+        { id: "q-rej", status: "REPORTED", childId: "child-1", templateId: "tpl-1", date: dateJST },
+        { category: "STUDY" },
+        { id: "child-1", minTasksForStreak: 1, studyPt: 0, staminaPt: 0, lifePt: 0 },
+      );
+      prismaMock.questInstance.findUnique.mockResolvedValue(quest);
+      prismaMock.questInstance.update.mockResolvedValue(quest);
       // 差し戻し後の集計: 当日 3個中 PENDING (差し戻し後) + REPORTED 1個 + PENDING 1個 → reportedCount=1, totalCount=3
-      mockPrisma.questInstance.findMany.mockResolvedValue([
-        { status: "PENDING" } as any,
-        { status: "REPORTED" } as any,
-        { status: "PENDING" } as any,
+      prismaMock.questInstance.findMany.mockResolvedValue([
+        questInstance({ status: "PENDING" }),
+        questInstance({ status: "REPORTED" }),
+        questInstance({ status: "PENDING" }),
       ]);
 
       await POST(
@@ -859,8 +807,8 @@ describe("POST /api/approve/[id]", () => {
         minTasks: 1,
         isProxy: false,
       });
-      const findManyCall = (mockPrisma.questInstance.findMany as any).mock.calls[0][0];
-      expect(findManyCall.where.template).toEqual({ isActive: true, pausedAt: null });
+      const findManyCall = prismaMock.questInstance.findMany.mock.calls[0][0];
+      expect(findManyCall?.where?.template).toEqual({ isActive: true, pausedAt: null });
     });
   });
 });

--- a/src/__tests__/api/approve/bulk.test.ts
+++ b/src/__tests__/api/approve/bulk.test.ts
@@ -1,9 +1,10 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { Prisma } from "@/generated/prisma/client";
 import { POST } from "@/app/api/approve/bulk/route";
-import { prisma } from "@/lib/prisma";
 import { getCurrentUser } from "@/lib/auth";
 import { makeRequest } from "../../helpers/request";
-import { parentUser, childUser } from "../../helpers/fixtures";
+import { prismaMock } from "../../helpers/prisma-mock";
+import { parentUserWithFamily, childUserWithFamily, questWithTemplateAndChild } from "../../helpers/fixtures";
 
 vi.mock("@/lib/streak", () => ({
   recordDailyAchievement: vi.fn().mockResolvedValue(undefined),
@@ -19,34 +20,40 @@ vi.mock("@/lib/treasureService", () => ({
   cancelTreasuresOnReject: vi.fn().mockResolvedValue(0),
 }));
 
-const mockPrisma = vi.mocked(prisma);
 const mockGetCurrentUser = vi.mocked(getCurrentUser);
 
-const makeQuest = (id: string, childId = "child-1", category = "STUDY") => ({
-  id,
-  date: new Date("2026-03-30"),
-  childId,
-  templateId: `tpl-${id}`,
-  status: "REPORTED" as const,
-  deadlineBonusEarned: false,
-  photoUrl: null,
-  template: {
-    id: `tpl-${id}`,
-    category: category as "STUDY" | "STAMINA" | "LIFE",
-    createdBy: "PARENT" as const,
-    photoBonus: false,
-    isTemporary: false,
-  },
-  child: {
-    id: childId,
-    evolutionStage: 1,
-    evolutionPath: "STUDY",
-    collectedPaths: "[]",
-    studyPt: 0,
-    staminaPt: 0,
-    lifePt: 0,
-  },
-});
+const makeQuest = (
+  id: string,
+  childId = "child-1",
+  category: "STUDY" | "STAMINA" | "LIFE" = "STUDY",
+): Prisma.QuestInstanceGetPayload<{ include: { template: true; child: true } }> =>
+  questWithTemplateAndChild(
+    {
+      id,
+      date: new Date("2026-03-30"),
+      childId,
+      templateId: `tpl-${id}`,
+      status: "REPORTED",
+      deadlineBonusEarned: false,
+      photoUrl: null,
+    },
+    {
+      id: `tpl-${id}`,
+      category,
+      createdBy: "PARENT",
+      photoBonus: false,
+      isTemporary: false,
+    },
+    {
+      id: childId,
+      evolutionStage: 1,
+      evolutionPath: "STUDY",
+      collectedPaths: "[]",
+      studyPt: 0,
+      staminaPt: 0,
+      lifePt: 0,
+    },
+  );
 
 beforeEach(() => {
   vi.clearAllMocks();
@@ -60,13 +67,13 @@ describe("POST /api/approve/bulk", () => {
   });
 
   it("CHILDロールの場合、403を返すこと", async () => {
-    mockGetCurrentUser.mockResolvedValue(childUser() as any);
+    mockGetCurrentUser.mockResolvedValue(childUserWithFamily());
     const res = await POST(makeRequest("/api/approve/bulk", { ids: ["q1"] }));
     expect(res.status).toBe(403);
   });
 
   it("idsが空配列の場合、count:0で返すこと", async () => {
-    mockGetCurrentUser.mockResolvedValue(parentUser() as any);
+    mockGetCurrentUser.mockResolvedValue(parentUserWithFamily());
     const res = await POST(makeRequest("/api/approve/bulk", { ids: [] }));
     const json = await res.json();
     expect(res.status).toBe(200);
@@ -74,21 +81,21 @@ describe("POST /api/approve/bulk", () => {
   });
 
   it("複数クエストを順次承認しcount件数を返すこと", async () => {
-    mockGetCurrentUser.mockResolvedValue(parentUser() as any);
+    mockGetCurrentUser.mockResolvedValue(parentUserWithFamily());
 
     const q1 = makeQuest("q1");
     const q2 = makeQuest("q2");
 
     // 順次処理のため、2回目のfindUniqueはq1承認後の最新値を返す
-    mockPrisma.questInstance.findUnique
-      .mockResolvedValueOnce(q1 as any)
-      .mockResolvedValueOnce(q2 as any);
+    prismaMock.questInstance.findUnique
+      .mockResolvedValueOnce(q1)
+      .mockResolvedValueOnce(q2);
     // approveQuestInstance内のuser.findUnique（最新child取得）
-    mockPrisma.user.findUnique
-      .mockResolvedValueOnce({ ...q1.child, studyPt: 0 } as any)  // q1承認時
-      .mockResolvedValueOnce({ ...q2.child, studyPt: 1 } as any); // q2承認時（q1の+1が反映済み）
-    mockPrisma.questInstance.update.mockResolvedValue({} as any);
-    mockPrisma.user.update.mockResolvedValue({} as any);
+    prismaMock.user.findUnique
+      .mockResolvedValueOnce({ ...q1.child, studyPt: 0 })  // q1承認時
+      .mockResolvedValueOnce({ ...q2.child, studyPt: 1 }); // q2承認時（q1の+1が反映済み）
+    prismaMock.questInstance.update.mockResolvedValue(q1);
+    prismaMock.user.update.mockResolvedValue(q1.child);
 
     const res = await POST(makeRequest("/api/approve/bulk", { ids: ["q1", "q2"] }));
     const json = await res.json();
@@ -96,36 +103,36 @@ describe("POST /api/approve/bulk", () => {
     expect(res.status).toBe(200);
     expect(json).toEqual({ ok: true, count: 2 });
     // 2件のクエストが承認されること
-    expect(mockPrisma.questInstance.update).toHaveBeenCalledTimes(2);
-    expect(mockPrisma.questInstance.update).toHaveBeenCalledWith(
+    expect(prismaMock.questInstance.update).toHaveBeenCalledTimes(2);
+    expect(prismaMock.questInstance.update).toHaveBeenCalledWith(
       expect.objectContaining({ where: { id: "q1" }, data: expect.objectContaining({ status: "APPROVED" }) })
     );
-    expect(mockPrisma.questInstance.update).toHaveBeenCalledWith(
+    expect(prismaMock.questInstance.update).toHaveBeenCalledWith(
       expect.objectContaining({ where: { id: "q2" }, data: expect.objectContaining({ status: "APPROVED" }) })
     );
   });
 
   it("順次処理により2件目のXPが1件目の承認後の値を参照すること", async () => {
-    mockGetCurrentUser.mockResolvedValue(parentUser() as any);
+    mockGetCurrentUser.mockResolvedValue(parentUserWithFamily());
 
     const q1 = makeQuest("q1");
     const q2 = makeQuest("q2");
 
-    mockPrisma.questInstance.findUnique
-      .mockResolvedValueOnce(q1 as any)
-      .mockResolvedValueOnce(q2 as any);
+    prismaMock.questInstance.findUnique
+      .mockResolvedValueOnce(q1)
+      .mockResolvedValueOnce(q2);
 
     // q1承認時: studyPt=0、q2承認時: studyPt=1（q1の+1が反映済みのDBから取得）
-    mockPrisma.user.findUnique
-      .mockResolvedValueOnce({ ...q1.child, studyPt: 0 } as any)
-      .mockResolvedValueOnce({ ...q2.child, studyPt: 1 } as any);
-    mockPrisma.questInstance.update.mockResolvedValue({} as any);
-    mockPrisma.user.update.mockResolvedValue({} as any);
+    prismaMock.user.findUnique
+      .mockResolvedValueOnce({ ...q1.child, studyPt: 0 })
+      .mockResolvedValueOnce({ ...q2.child, studyPt: 1 });
+    prismaMock.questInstance.update.mockResolvedValue(q1);
+    prismaMock.user.update.mockResolvedValue(q1.child);
 
     await POST(makeRequest("/api/approve/bulk", { ids: ["q1", "q2"] }));
 
     // 1件目: studyPt 0+1=1
-    expect(mockPrisma.user.update).toHaveBeenNthCalledWith(
+    expect(prismaMock.user.update).toHaveBeenNthCalledWith(
       1,
       expect.objectContaining({
         where: { id: "child-1" },
@@ -133,7 +140,7 @@ describe("POST /api/approve/bulk", () => {
       })
     );
     // 2件目: studyPt 1+1=2（並列なら0+1=1になってしまう）
-    expect(mockPrisma.user.update).toHaveBeenNthCalledWith(
+    expect(prismaMock.user.update).toHaveBeenNthCalledWith(
       2,
       expect.objectContaining({
         where: { id: "child-1" },
@@ -143,14 +150,15 @@ describe("POST /api/approve/bulk", () => {
   });
 
   it("存在しないクエストIDはスキップして続行すること", async () => {
-    mockGetCurrentUser.mockResolvedValue(parentUser() as any);
+    mockGetCurrentUser.mockResolvedValue(parentUserWithFamily());
 
-    mockPrisma.questInstance.findUnique
+    const q2 = makeQuest("q2");
+    prismaMock.questInstance.findUnique
       .mockResolvedValueOnce(null) // q-none は存在しない
-      .mockResolvedValueOnce(makeQuest("q2") as any);
-    mockPrisma.user.findUnique.mockResolvedValue({ ...makeQuest("q2").child } as any);
-    mockPrisma.questInstance.update.mockResolvedValue({} as any);
-    mockPrisma.user.update.mockResolvedValue({} as any);
+      .mockResolvedValueOnce(q2);
+    prismaMock.user.findUnique.mockResolvedValue(q2.child);
+    prismaMock.questInstance.update.mockResolvedValue(q2);
+    prismaMock.user.update.mockResolvedValue(q2.child);
 
     const res = await POST(makeRequest("/api/approve/bulk", { ids: ["q-none", "q2"] }));
     const json = await res.json();
@@ -159,23 +167,23 @@ describe("POST /api/approve/bulk", () => {
   });
 
   it("SKIP_REPORTEDクエストもまとめて承認できること", async () => {
-    mockGetCurrentUser.mockResolvedValue(parentUser() as any);
+    mockGetCurrentUser.mockResolvedValue(parentUserWithFamily());
 
     const skipQuest = {
       ...makeQuest("q-skip"),
       status: "SKIP_REPORTED" as const,
     };
 
-    mockPrisma.questInstance.findUnique.mockResolvedValue(skipQuest as any);
-    mockPrisma.questInstance.update.mockResolvedValue({} as any);
+    prismaMock.questInstance.findUnique.mockResolvedValue(skipQuest);
+    prismaMock.questInstance.update.mockResolvedValue(skipQuest);
 
     const res = await POST(makeRequest("/api/approve/bulk", { ids: ["q-skip"] }));
     const json = await res.json();
 
     expect(json).toEqual({ ok: true, count: 1 });
-    expect(mockPrisma.questInstance.update).toHaveBeenCalledWith(
+    expect(prismaMock.questInstance.update).toHaveBeenCalledWith(
       expect.objectContaining({ where: { id: "q-skip" }, data: expect.objectContaining({ status: "SKIPPED" }) })
     );
-    expect(mockPrisma.user.update).not.toHaveBeenCalled();
+    expect(prismaMock.user.update).not.toHaveBeenCalled();
   });
 });

--- a/src/__tests__/api/approve/pending.test.ts
+++ b/src/__tests__/api/approve/pending.test.ts
@@ -1,10 +1,9 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { GET } from "@/app/api/approve/pending/route";
-import { prisma } from "@/lib/prisma";
 import { getCurrentUser } from "@/lib/auth";
-import { parentUser, childUser } from "../../helpers/fixtures";
+import { prismaMock } from "../../helpers/prisma-mock";
+import { parentUserWithFamily, childUserWithFamily, childUser, taskTemplate, questInstance, questDeclaration } from "../../helpers/fixtures";
 
-const mockPrisma = vi.mocked(prisma);
 const mockGetCurrentUser = vi.mocked(getCurrentUser);
 
 beforeEach(() => {
@@ -14,9 +13,9 @@ beforeEach(() => {
 describe("GET /api/approve/pending", () => {
   beforeEach(() => {
     // ensureTodayQuests / cleanup が呼ぶデフォルトのモック
-    mockPrisma.user.findMany.mockResolvedValue([] as any);
-    mockPrisma.taskTemplate.findMany.mockResolvedValue([] as any);
-    mockPrisma.questInstance.findMany.mockResolvedValue([] as any);
+    prismaMock.user.findMany.mockResolvedValue([]);
+    prismaMock.taskTemplate.findMany.mockResolvedValue([]);
+    prismaMock.questInstance.findMany.mockResolvedValue([]);
   });
 
   it("未認証の場合、空配列を返すこと", async () => {
@@ -26,35 +25,34 @@ describe("GET /api/approve/pending", () => {
   });
 
   it("CHILDロールの場合、空配列を返すこと", async () => {
-    mockGetCurrentUser.mockResolvedValue(childUser() as any);
+    mockGetCurrentUser.mockResolvedValue(childUserWithFamily());
     const res = await GET();
     expect(await res.json()).toEqual([]);
   });
 
   it("familyIdがない場合、空配列を返すこと", async () => {
-    mockGetCurrentUser.mockResolvedValue(parentUser({ familyId: null }) as any);
+    mockGetCurrentUser.mockResolvedValue(parentUserWithFamily({ familyId: null }, null));
     const res = await GET();
     expect(await res.json()).toEqual([]);
   });
 
   it("親アクセス時にファミリーの carryOver タスクの stale クリーンアップが走ること", async () => {
-    mockGetCurrentUser.mockResolvedValue(parentUser() as any);
+    mockGetCurrentUser.mockResolvedValue(parentUserWithFamily());
 
     // ファミリーの子供
-    mockPrisma.user.findMany.mockResolvedValue([{ id: "child-1" }] as any);
+    const child = childUser({ id: "child-1" });
+    prismaMock.user.findMany.mockResolvedValue([child]);
     // 子供の carryOver タスク
-    mockPrisma.taskTemplate.findMany.mockResolvedValue([
-      { id: "tpl-1", carryOver: true },
-    ] as any);
+    const carryOverTemplate = taskTemplate({ id: "tpl-1", carryOver: true });
+    prismaMock.taskTemplate.findMany.mockResolvedValue([carryOverTemplate]);
     // 直近 APPROVED が存在 → cleanup が updateMany を呼ぶ
-    mockPrisma.questInstance.findMany.mockResolvedValue([
-      { templateId: "tpl-1", date: new Date("2026-03-13T00:00:00Z") },
-    ] as any);
-    mockPrisma.questInstance.updateMany.mockResolvedValue({ count: 2 } as any);
+    const settled = questInstance({ templateId: "tpl-1", date: new Date("2026-03-13T00:00:00Z") });
+    prismaMock.questInstance.findMany.mockResolvedValue([settled]);
+    prismaMock.questInstance.updateMany.mockResolvedValue({ count: 2 });
 
     await GET();
 
-    expect(mockPrisma.questInstance.updateMany).toHaveBeenCalledWith(
+    expect(prismaMock.questInstance.updateMany).toHaveBeenCalledWith(
       expect.objectContaining({
         where: expect.objectContaining({
           templateId: "tpl-1",
@@ -67,33 +65,33 @@ describe("GET /api/approve/pending", () => {
   });
 
   it("PARENTがREPORTEDとSKIP_REPORTEDのクエストを取得できること", async () => {
-    mockGetCurrentUser.mockResolvedValue(parentUser() as any);
+    mockGetCurrentUser.mockResolvedValue(parentUserWithFamily());
 
     const pendingQuests = [
       {
-        id: "q1",
-        status: "REPORTED",
-        reportedAt: new Date("2026-03-12T10:00:00"),
+        ...questInstance({ id: "q1", status: "REPORTED", reportedAt: new Date("2026-03-12T10:00:00") }),
         child: { name: "太郎", monsterName: "ドラゴン", side: "DARK" },
         template: { title: "宿題", emoji: "📚", category: "STUDY" },
       },
       {
-        id: "q2",
-        templateId: "tpl-2",
-        status: "SKIP_REPORTED",
-        reportedAt: new Date("2026-03-12T09:00:00"),
+        ...questInstance({
+          id: "q2",
+          templateId: "tpl-2",
+          status: "SKIP_REPORTED",
+          reportedAt: new Date("2026-03-12T09:00:00"),
+        }),
         child: { name: "花子", monsterName: "ユニコーン", side: "LIGHT" },
         template: { title: "運動", emoji: "💪", category: "STAMINA", isTemporary: true },
       },
     ];
-    mockPrisma.questInstance.findMany.mockResolvedValue(pendingQuests as any);
+    prismaMock.questInstance.findMany.mockResolvedValue(pendingQuests);
 
     const res = await GET();
     const json = await res.json();
 
     expect(json).toHaveLength(2);
     expect(json[1].templateId).toBeDefined();
-    expect(mockPrisma.questInstance.findMany).toHaveBeenCalledWith({
+    expect(prismaMock.questInstance.findMany).toHaveBeenCalledWith({
       where: {
         OR: [{ status: "REPORTED" }, { status: "SKIP_REPORTED" }],
         template: { familyId: "fam-1" },
@@ -108,26 +106,27 @@ describe("GET /api/approve/pending", () => {
 
   describe("declaredToday: 承認時の宣言ボーナスを反映する", () => {
     it("(templateId, childId, reportedAtのJST日付) に一致する宣言があれば declaredToday=true", async () => {
-      mockGetCurrentUser.mockResolvedValue(parentUser() as any);
+      mockGetCurrentUser.mockResolvedValue(parentUserWithFamily());
 
       // JST 2026-03-12 09:00 = UTC 2026-03-12 00:00
       const reportedAt = new Date("2026-03-12T00:00:00Z");
       const jstDate = new Date("2026-03-12T00:00:00Z"); // jstDateOf の戻り値（JST 日付の UTC 0:00）
 
-      mockPrisma.questInstance.findMany.mockResolvedValue([
-        {
+      const quest = {
+        ...questInstance({
           id: "q1",
           templateId: "tpl-1",
           childId: "child-1",
           status: "REPORTED",
           reportedAt,
-          child: { name: "太郎", monsterName: "ド" },
-          template: { title: "宿題", emoji: "📚", category: "STUDY", photoBonus: false, isTemporary: false },
-        },
-      ] as any);
-      mockPrisma.questDeclaration.findMany.mockResolvedValue([
-        { templateId: "tpl-1", childId: "child-1", date: jstDate },
-      ] as any);
+        }),
+        child: { name: "太郎", monsterName: "ド" },
+        template: { title: "宿題", emoji: "📚", category: "STUDY", photoBonus: false, isTemporary: false },
+      };
+      prismaMock.questInstance.findMany.mockResolvedValue([quest]);
+      prismaMock.questDeclaration.findMany.mockResolvedValue([
+        questDeclaration({ templateId: "tpl-1", childId: "child-1", date: jstDate }),
+      ]);
 
       const res = await GET();
       const json = await res.json();
@@ -136,20 +135,21 @@ describe("GET /api/approve/pending", () => {
     });
 
     it("該当宣言が無ければ declaredToday=false", async () => {
-      mockGetCurrentUser.mockResolvedValue(parentUser() as any);
+      mockGetCurrentUser.mockResolvedValue(parentUserWithFamily());
 
-      mockPrisma.questInstance.findMany.mockResolvedValue([
-        {
+      const quest = {
+        ...questInstance({
           id: "q1",
           templateId: "tpl-1",
           childId: "child-1",
           status: "REPORTED",
           reportedAt: new Date("2026-03-12T00:00:00Z"),
-          child: { name: "太郎" },
-          template: { title: "宿題", emoji: "📚", category: "STUDY", photoBonus: false, isTemporary: false },
-        },
-      ] as any);
-      mockPrisma.questDeclaration.findMany.mockResolvedValue([] as any);
+        }),
+        child: { name: "太郎" },
+        template: { title: "宿題", emoji: "📚", category: "STUDY", photoBonus: false, isTemporary: false },
+      };
+      prismaMock.questInstance.findMany.mockResolvedValue([quest]);
+      prismaMock.questDeclaration.findMany.mockResolvedValue([]);
 
       const res = await GET();
       const json = await res.json();
@@ -158,24 +158,25 @@ describe("GET /api/approve/pending", () => {
     });
 
     it("別の templateId の宣言は混同しない", async () => {
-      mockGetCurrentUser.mockResolvedValue(parentUser() as any);
+      mockGetCurrentUser.mockResolvedValue(parentUserWithFamily());
 
       const jstDate = new Date("2026-03-12T00:00:00Z");
-      mockPrisma.questInstance.findMany.mockResolvedValue([
-        {
+      const quest = {
+        ...questInstance({
           id: "q1",
           templateId: "tpl-1",
           childId: "child-1",
           status: "REPORTED",
           reportedAt: new Date("2026-03-12T00:00:00Z"),
-          child: { name: "太郎" },
-          template: { title: "宿題", emoji: "📚", category: "STUDY", photoBonus: false, isTemporary: false },
-        },
-      ] as any);
+        }),
+        child: { name: "太郎" },
+        template: { title: "宿題", emoji: "📚", category: "STUDY", photoBonus: false, isTemporary: false },
+      };
+      prismaMock.questInstance.findMany.mockResolvedValue([quest]);
       // 別 template の宣言は来るが、対象クエストの templateId とは違う
-      mockPrisma.questDeclaration.findMany.mockResolvedValue([
-        { templateId: "tpl-OTHER", childId: "child-1", date: jstDate },
-      ] as any);
+      prismaMock.questDeclaration.findMany.mockResolvedValue([
+        questDeclaration({ templateId: "tpl-OTHER", childId: "child-1", date: jstDate }),
+      ]);
 
       const res = await GET();
       const json = await res.json();
@@ -184,12 +185,12 @@ describe("GET /api/approve/pending", () => {
     });
 
     it("REPORTED クエストが0件なら QuestDeclaration を検索しない", async () => {
-      mockGetCurrentUser.mockResolvedValue(parentUser() as any);
-      mockPrisma.questInstance.findMany.mockResolvedValue([] as any);
+      mockGetCurrentUser.mockResolvedValue(parentUserWithFamily());
+      prismaMock.questInstance.findMany.mockResolvedValue([]);
 
       await GET();
 
-      expect(mockPrisma.questDeclaration.findMany).not.toHaveBeenCalled();
+      expect(prismaMock.questDeclaration.findMany).not.toHaveBeenCalled();
     });
   });
 });

--- a/src/__tests__/helpers/fixtures.ts
+++ b/src/__tests__/helpers/fixtures.ts
@@ -133,6 +133,21 @@ export function childUserWithFamily(
   };
 }
 
+/**
+ * `include: { family: true }` 付きクエリの戻り値用。 `parentUser` + `family` の合成。
+ * `getCurrentUser()` のモック（`family` が必須プロパティ）に使う。
+ * familyOverrides に `null` を渡すと `family: null`（familyId なしのケース）を表現する。
+ */
+export function parentUserWithFamily(
+  overrides?: Partial<User>,
+  familyOverrides?: Partial<Family> | null,
+): Prisma.UserGetPayload<{ include: { family: true } }> {
+  return {
+    ...parentUser(overrides),
+    family: familyOverrides === null ? null : family(familyOverrides),
+  };
+}
+
 // ─── Subscription ─────────────────────────────────────
 
 export function subscription(overrides?: Partial<Subscription>): Subscription {


### PR DESCRIPTION
## Summary
- 承認API関連テスト（`approve-id.test.ts` / `bulk.test.ts` / `pending.test.ts`）の `as any` 166件を全廃し、型付きPrismaモック（#35）・Prisma生成型フィクスチャ（#36）に移行
- `fixtures.ts` に `parentUserWithFamily()` を純追加（既存ファクトリは変更なし）
- **重要な発見**: `approve.ts` の防御的フォールバック分岐（`snapshotCategory`/`monsterLevels` 欠落時の旧データ互換処理）が、旧テストでは `as any` によるフィールド書き忘れによって偶然カバーされていたことが判明。型付け後にカバレッジが落ちないよう、旧データ互換テストを1件新規追加し、理由コメント付きの `as unknown as T` で意図的に欠落を再現した
- テスト件数 2511→2512、`expect(` 出現数は減少なし、coverageは低下なし（`approve.ts` のbranchはむしろ完全復元）

## Test plan
- [x] `npm test` パス（183 files / 2511→2512、+1新規テスト）
- [x] `npm run typecheck` 対象3ファイルのエラー0件
- [x] `code-reviewer` によるレビュー APPROVED 済み

Closes #37

🤖 Generated with [Claude Code](https://claude.com/claude-code)
