### PR TITLE
test(tasks): タスクCRUDテストのas anyを型付きモックに移行

### DIFF
--- a/src/__tests__/api/tasks/tasks-id-copy.test.ts
+++ b/src/__tests__/api/tasks/tasks-id-copy.test.ts
@@ -1,11 +1,10 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { POST } from "@/app/api/tasks/[id]/copy/route";
-import { prisma } from "@/lib/prisma";
 import { getCurrentUser } from "@/lib/auth";
 import { makeRequest, makeParams } from "../../helpers/request";
-import { parentUser, childUser, taskTemplate } from "../../helpers/fixtures";
+import { prismaMock as mockPrisma } from "../../helpers/prisma-mock";
+import { parentUserWithFamily, childUserWithFamily, taskTemplate } from "../../helpers/fixtures";
 
-const mockPrisma = vi.mocked(prisma);
 const mockGetCurrentUser = vi.mocked(getCurrentUser);
 
 beforeEach(() => {
@@ -26,13 +25,13 @@ describe("POST /api/tasks/[id]/copy", () => {
   });
 
   it("CHILDロールの場合、403を返すこと", async () => {
-    mockGetCurrentUser.mockResolvedValue(childUser() as any);
+    mockGetCurrentUser.mockResolvedValue(childUserWithFamily());
     const res = await POST(makeRequest("/api/tasks/t1/copy", {}), makeParams("t1"));
     expect(res.status).toBe(403);
   });
 
   it("タスクが見つからない場合、404を返すこと", async () => {
-    mockGetCurrentUser.mockResolvedValue(parentUser() as any);
+    mockGetCurrentUser.mockResolvedValue(parentUserWithFamily());
     mockPrisma.taskTemplate.findFirst.mockResolvedValue(null);
 
     const res = await POST(makeRequest("/api/tasks/t1/copy", {}), makeParams("t1"));
@@ -40,17 +39,15 @@ describe("POST /api/tasks/[id]/copy", () => {
   });
 
   it("一時タスクでない場合、400を返すこと", async () => {
-    mockGetCurrentUser.mockResolvedValue(parentUser() as any);
-    mockPrisma.taskTemplate.findFirst.mockResolvedValue(
-      taskTemplate({ isTemporary: false }) as any
-    );
+    mockGetCurrentUser.mockResolvedValue(parentUserWithFamily());
+    mockPrisma.taskTemplate.findFirst.mockResolvedValue(taskTemplate({ isTemporary: false }));
 
     const res = await POST(makeRequest("/api/tasks/t1/copy", {}), makeParams("t1"));
     expect(res.status).toBe(400);
   });
 
   it("targetDate未指定の場合、翌日の一時タスクをコピーすること", async () => {
-    mockGetCurrentUser.mockResolvedValue(parentUser() as any);
+    mockGetCurrentUser.mockResolvedValue(parentUserWithFamily());
     const original = taskTemplate({
       id: "tpl-1",
       title: "英語の宿題",
@@ -61,12 +58,13 @@ describe("POST /api/tasks/[id]/copy", () => {
       repeatDays: [],
       createdBy: "PARENT",
       familyId: "fam-1",
+      assignedChildId: "child-1",
     });
     mockPrisma.taskTemplate.findFirst
-      .mockResolvedValueOnce({ ...original, assignedChildId: "child-1" } as any)
+      .mockResolvedValueOnce(original)
       .mockResolvedValueOnce(null); // 重複なし
-    const newTask = { id: "tpl-2", title: "英語の宿題", isTemporary: true };
-    mockPrisma.taskTemplate.create.mockResolvedValue(newTask as any);
+    const newTask = taskTemplate({ id: "tpl-2", title: "英語の宿題", isTemporary: true });
+    mockPrisma.taskTemplate.create.mockResolvedValue(newTask);
 
     const res = await POST(makeRequest("/api/tasks/tpl-1/copy", {}), makeParams("tpl-1"));
     expect(res.status).toBe(200);
@@ -88,16 +86,17 @@ describe("POST /api/tasks/[id]/copy", () => {
   });
 
   it("targetDate指定の場合、その日の一時タスクをコピーすること", async () => {
-    mockGetCurrentUser.mockResolvedValue(parentUser() as any);
+    mockGetCurrentUser.mockResolvedValue(parentUserWithFamily());
     const original = taskTemplate({
       isTemporary: true,
       targetDate: new Date("2026-03-19"),
       repeatDays: [],
+      assignedChildId: "child-1",
     });
     mockPrisma.taskTemplate.findFirst
-      .mockResolvedValueOnce({ ...original, assignedChildId: "child-1" } as any)
+      .mockResolvedValueOnce(original)
       .mockResolvedValueOnce(null); // 重複なし
-    mockPrisma.taskTemplate.create.mockResolvedValue({ id: "tpl-new" } as any);
+    mockPrisma.taskTemplate.create.mockResolvedValue(taskTemplate({ id: "tpl-new" }));
 
     const res = await POST(
       makeRequest("/api/tasks/tpl-1/copy", { targetDate: "2026-03-21" }),
@@ -113,7 +112,7 @@ describe("POST /api/tasks/[id]/copy", () => {
   });
 
   it("同じtargetDateに同タイトル・同担当の一時タスクが既に存在する場合、新規作成せず既存タスクを返すこと", async () => {
-    mockGetCurrentUser.mockResolvedValue(parentUser() as any);
+    mockGetCurrentUser.mockResolvedValue(parentUserWithFamily());
     const original = taskTemplate({
       id: "tpl-1",
       title: "英語の宿題",
@@ -121,13 +120,19 @@ describe("POST /api/tasks/[id]/copy", () => {
       targetDate: new Date("2026-03-19"),
       repeatDays: [],
       familyId: "fam-1",
+      assignedChildId: "child-1",
     });
-    const existingCopy = { id: "tpl-existing", title: "英語の宿題", isTemporary: true, targetDate: new Date("2026-03-20") };
+    const existingCopy = taskTemplate({
+      id: "tpl-existing",
+      title: "英語の宿題",
+      isTemporary: true,
+      targetDate: new Date("2026-03-20"),
+    });
 
     // 1回目: 元タスク取得、2回目: 重複チェック
     mockPrisma.taskTemplate.findFirst
-      .mockResolvedValueOnce({ ...original, assignedChildId: "child-1" } as any)
-      .mockResolvedValueOnce(existingCopy as any);
+      .mockResolvedValueOnce(original)
+      .mockResolvedValueOnce(existingCopy);
 
     const res = await POST(
       makeRequest("/api/tasks/tpl-1/copy", { targetDate: "2026-03-20" }),
@@ -140,12 +145,17 @@ describe("POST /api/tasks/[id]/copy", () => {
   });
 
   it("コピーされた新タスクを返すこと", async () => {
-    mockGetCurrentUser.mockResolvedValue(parentUser() as any);
+    mockGetCurrentUser.mockResolvedValue(parentUserWithFamily());
     mockPrisma.taskTemplate.findFirst
-      .mockResolvedValueOnce(taskTemplate({ isTemporary: true, targetDate: new Date("2026-03-19"), repeatDays: [] }) as any)
+      .mockResolvedValueOnce(taskTemplate({ isTemporary: true, targetDate: new Date("2026-03-19"), repeatDays: [] }))
       .mockResolvedValueOnce(null); // 重複なし
-    const newTask = { id: "tpl-new", title: "宿題", isTemporary: true, targetDate: new Date("2026-03-20") };
-    mockPrisma.taskTemplate.create.mockResolvedValue(newTask as any);
+    const newTask = taskTemplate({
+      id: "tpl-new",
+      title: "宿題",
+      isTemporary: true,
+      targetDate: new Date("2026-03-20"),
+    });
+    mockPrisma.taskTemplate.create.mockResolvedValue(newTask);
 
     const res = await POST(makeRequest("/api/tasks/tpl-1/copy", {}), makeParams("tpl-1"));
     const json = await res.json();

--- a/src/__tests__/api/tasks/tasks-id.test.ts
+++ b/src/__tests__/api/tasks/tasks-id.test.ts
@@ -1,11 +1,10 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { PUT, PATCH, DELETE } from "@/app/api/tasks/[id]/route";
-import { prisma } from "@/lib/prisma";
 import { getCurrentUser } from "@/lib/auth";
 import { makeRequest, makeParams } from "../../helpers/request";
-import { parentUser, childUser } from "../../helpers/fixtures";
+import { prismaMock as mockPrisma } from "../../helpers/prisma-mock";
+import { parentUserWithFamily, childUserWithFamily, childUser, taskTemplate, questInstance } from "../../helpers/fixtures";
 
-const mockPrisma = vi.mocked(prisma);
 const mockGetCurrentUser = vi.mocked(getCurrentUser);
 
 beforeEach(() => {
@@ -22,15 +21,15 @@ describe("PUT /api/tasks/[id]", () => {
   });
 
   it("CHILDロールの場合、403を返すこと", async () => {
-    mockGetCurrentUser.mockResolvedValue(childUser() as any);
+    mockGetCurrentUser.mockResolvedValue(childUserWithFamily());
     const res = await PUT(makeRequest("/api/tasks/t1", { title: "test" }), makeParams("t1"));
     expect(res.status).toBe(403);
   });
 
   it("PARENTがタスクを更新できること", async () => {
-    mockGetCurrentUser.mockResolvedValue(parentUser() as any);
-    const updated = { id: "t1", title: "更新後" };
-    mockPrisma.taskTemplate.update.mockResolvedValue(updated as any);
+    mockGetCurrentUser.mockResolvedValue(parentUserWithFamily());
+    const updated = taskTemplate({ id: "t1", title: "更新後" });
+    mockPrisma.taskTemplate.update.mockResolvedValue(updated);
 
     const res = await PUT(
       makeRequest("/api/tasks/t1", {
@@ -57,8 +56,8 @@ describe("PUT /api/tasks/[id]", () => {
   });
 
   it("photoBonus=true を指定してタスクを更新できること", async () => {
-    mockGetCurrentUser.mockResolvedValue(parentUser() as any);
-    mockPrisma.taskTemplate.update.mockResolvedValue({ id: "t1", photoBonus: true } as any);
+    mockGetCurrentUser.mockResolvedValue(parentUserWithFamily());
+    mockPrisma.taskTemplate.update.mockResolvedValue(taskTemplate({ id: "t1", photoBonus: true }));
 
     const res = await PUT(
       makeRequest("/api/tasks/t1", {
@@ -80,7 +79,7 @@ describe("PUT /api/tasks/[id]", () => {
   });
 
   it("familyIdがnullのPARENTは403を返すこと", async () => {
-    mockGetCurrentUser.mockResolvedValue(parentUser({ familyId: null }) as any);
+    mockGetCurrentUser.mockResolvedValue(parentUserWithFamily({ familyId: null }, null));
     const res = await PUT(
       makeRequest("/api/tasks/t1", { title: "test" }),
       makeParams("t1")
@@ -99,14 +98,14 @@ describe("PATCH /api/tasks/[id]", () => {
   });
 
   it("CHILDロールの場合、403を返すこと", async () => {
-    mockGetCurrentUser.mockResolvedValue(childUser() as any);
+    mockGetCurrentUser.mockResolvedValue(childUserWithFamily());
     const res = await PATCH(makeRequest("/api/tasks/t1", {}), makeParams("t1"));
     expect(res.status).toBe(403);
   });
 
   it("PARENTが仮タスクを承認（createdBy→PARENT）できること", async () => {
-    mockGetCurrentUser.mockResolvedValue(parentUser() as any);
-    mockPrisma.taskTemplate.update.mockResolvedValue({ id: "t1", createdBy: "PARENT" } as any);
+    mockGetCurrentUser.mockResolvedValue(parentUserWithFamily());
+    mockPrisma.taskTemplate.update.mockResolvedValue(taskTemplate({ id: "t1", createdBy: "PARENT" }));
 
     const res = await PATCH(makeRequest("/api/tasks/t1", {}), makeParams("t1"));
     const json = await res.json();
@@ -129,9 +128,9 @@ describe("DELETE /api/tasks/[id]", () => {
   });
 
   it("子供が自分の一時タスクを削除できること", async () => {
-    mockGetCurrentUser.mockResolvedValue(childUser() as any);
-    mockPrisma.taskTemplate.findFirst.mockResolvedValue({ id: "t1", createdBy: "CHILD" } as any);
-    mockPrisma.taskTemplate.update.mockResolvedValue({ id: "t1", isActive: false } as any);
+    mockGetCurrentUser.mockResolvedValue(childUserWithFamily());
+    mockPrisma.taskTemplate.findFirst.mockResolvedValue(taskTemplate({ id: "t1", createdBy: "CHILD" }));
+    mockPrisma.taskTemplate.update.mockResolvedValue(taskTemplate({ id: "t1", isActive: false }));
 
     const res = await DELETE(makeRequest("/api/tasks/t1", {}), makeParams("t1"));
     const json = await res.json();
@@ -144,7 +143,7 @@ describe("DELETE /api/tasks/[id]", () => {
   });
 
   it("子供が他人のタスクを削除できないこと", async () => {
-    mockGetCurrentUser.mockResolvedValue(childUser() as any);
+    mockGetCurrentUser.mockResolvedValue(childUserWithFamily());
     mockPrisma.taskTemplate.findFirst.mockResolvedValue(null);
 
     const res = await DELETE(makeRequest("/api/tasks/t1", {}), makeParams("t1"));
@@ -152,40 +151,30 @@ describe("DELETE /api/tasks/[id]", () => {
   });
 
   it("親が仮タスクを却下する際、APPROVED済みクエストのXPのみ差し引くこと", async () => {
-    mockGetCurrentUser.mockResolvedValue(parentUser() as any);
+    mockGetCurrentUser.mockResolvedValue(parentUserWithFamily());
 
-    mockPrisma.taskTemplate.findFirst.mockResolvedValue({
-      id: "t1",
-      createdBy: "CHILD",
-      photoBonus: false,
-      category: "STUDY",
+    const taskWithQuests = {
+      ...taskTemplate({ id: "t1", createdBy: "CHILD", photoBonus: false, category: "STUDY" }),
       quests: [
         {
-          id: "q1",
-          childId: "child-1",
-          status: "REPORTED",
-          deadlineBonusEarned: false,
-          photoUrl: null,
-          child: { id: "child-1", studyPt: 10, staminaPt: 5, lifePt: 3 },
+          ...questInstance({ id: "q1", childId: "child-1", status: "REPORTED", deadlineBonusEarned: false, photoUrl: null }),
+          child: childUser({ id: "child-1", studyPt: 10, staminaPt: 5, lifePt: 3 }),
         },
         {
-          id: "q2",
-          childId: "child-1",
-          status: "APPROVED",
-          deadlineBonusEarned: false,
-          photoUrl: null,
-          child: { id: "child-1", studyPt: 10, staminaPt: 5, lifePt: 3 },
+          ...questInstance({ id: "q2", childId: "child-1", status: "APPROVED", deadlineBonusEarned: false, photoUrl: null }),
+          child: childUser({ id: "child-1", studyPt: 10, staminaPt: 5, lifePt: 3 }),
         },
       ],
-    } as any);
+    };
+    mockPrisma.taskTemplate.findFirst.mockResolvedValue(taskWithQuests);
 
     // findUnique で最新データを取得（stale data対策）
-    mockPrisma.user.findUnique.mockResolvedValue({
-      id: "child-1", studyPt: 10, staminaPt: 5, lifePt: 3,
-    } as any);
-    mockPrisma.user.update.mockResolvedValue({} as any);
-    mockPrisma.questInstance.updateMany.mockResolvedValue({ count: 2 } as any);
-    mockPrisma.taskTemplate.update.mockResolvedValue({} as any);
+    mockPrisma.user.findUnique.mockResolvedValue(
+      childUser({ id: "child-1", studyPt: 10, staminaPt: 5, lifePt: 3 })
+    );
+    mockPrisma.user.update.mockResolvedValue(childUser());
+    mockPrisma.questInstance.updateMany.mockResolvedValue({ count: 2 });
+    mockPrisma.taskTemplate.update.mockResolvedValue(taskTemplate());
 
     const res = await DELETE(makeRequest("/api/tasks/t1", {}), makeParams("t1"));
     const json = await res.json();
@@ -209,40 +198,30 @@ describe("DELETE /api/tasks/[id]", () => {
   });
 
   it("複数APPROVED クエストのXPが正しく累計で差し引かれること（stale data防止）", async () => {
-    mockGetCurrentUser.mockResolvedValue(parentUser() as any);
+    mockGetCurrentUser.mockResolvedValue(parentUserWithFamily());
 
-    mockPrisma.taskTemplate.findFirst.mockResolvedValue({
-      id: "t1-multi",
-      createdBy: "CHILD",
-      photoBonus: true,
-      category: "STUDY",
+    const taskWithQuests = {
+      ...taskTemplate({ id: "t1-multi", createdBy: "CHILD", photoBonus: true, category: "STUDY" }),
       quests: [
         {
-          id: "q-a1",
-          childId: "child-1",
-          status: "APPROVED",
-          deadlineBonusEarned: true,
-          photoUrl: "photo.jpg",
-          child: { id: "child-1", studyPt: 10, staminaPt: 5, lifePt: 3 },
+          ...questInstance({ id: "q-a1", childId: "child-1", status: "APPROVED", deadlineBonusEarned: true, photoUrl: "photo.jpg" }),
+          child: childUser({ id: "child-1", studyPt: 10, staminaPt: 5, lifePt: 3 }),
         },
         {
-          id: "q-a2",
-          childId: "child-1",
-          status: "APPROVED",
-          deadlineBonusEarned: false,
-          photoUrl: null,
-          child: { id: "child-1", studyPt: 10, staminaPt: 5, lifePt: 3 },
+          ...questInstance({ id: "q-a2", childId: "child-1", status: "APPROVED", deadlineBonusEarned: false, photoUrl: null }),
+          child: childUser({ id: "child-1", studyPt: 10, staminaPt: 5, lifePt: 3 }),
         },
       ],
-    } as any);
+    };
+    mockPrisma.taskTemplate.findFirst.mockResolvedValue(taskWithQuests);
 
     // 最新のchildデータ
-    mockPrisma.user.findUnique.mockResolvedValue({
-      id: "child-1", studyPt: 10, staminaPt: 5, lifePt: 3,
-    } as any);
-    mockPrisma.user.update.mockResolvedValue({} as any);
-    mockPrisma.questInstance.updateMany.mockResolvedValue({ count: 2 } as any);
-    mockPrisma.taskTemplate.update.mockResolvedValue({} as any);
+    mockPrisma.user.findUnique.mockResolvedValue(
+      childUser({ id: "child-1", studyPt: 10, staminaPt: 5, lifePt: 3 })
+    );
+    mockPrisma.user.update.mockResolvedValue(childUser());
+    mockPrisma.questInstance.updateMany.mockResolvedValue({ count: 2 });
+    mockPrisma.taskTemplate.update.mockResolvedValue(taskTemplate());
 
     await DELETE(makeRequest("/api/tasks/t1-multi", {}), makeParams("t1-multi"));
 
@@ -259,14 +238,14 @@ describe("DELETE /api/tasks/[id]", () => {
   });
 
   it("親がPARENT作成タスクを削除する際、XP差し引きしないこと", async () => {
-    mockGetCurrentUser.mockResolvedValue(parentUser() as any);
+    mockGetCurrentUser.mockResolvedValue(parentUserWithFamily());
 
-    mockPrisma.taskTemplate.findFirst.mockResolvedValue({
-      id: "t2",
-      createdBy: "PARENT",
-      quests: [],
-    } as any);
-    mockPrisma.taskTemplate.update.mockResolvedValue({} as any);
+    const taskWithQuests = {
+      ...taskTemplate({ id: "t2", createdBy: "PARENT" }),
+      quests: [] as unknown[],
+    };
+    mockPrisma.taskTemplate.findFirst.mockResolvedValue(taskWithQuests);
+    mockPrisma.taskTemplate.update.mockResolvedValue(taskTemplate());
 
     const res = await DELETE(makeRequest("/api/tasks/t2", {}), makeParams("t2"));
     const json = await res.json();
@@ -276,31 +255,25 @@ describe("DELETE /api/tasks/[id]", () => {
   });
 
   it("XP差し引きで負数にならないこと（Math.max(0, ...)）", async () => {
-    mockGetCurrentUser.mockResolvedValue(parentUser() as any);
+    mockGetCurrentUser.mockResolvedValue(parentUserWithFamily());
 
-    mockPrisma.taskTemplate.findFirst.mockResolvedValue({
-      id: "t3",
-      createdBy: "CHILD",
-      photoBonus: false,
-      category: "STAMINA",
+    const taskWithQuests = {
+      ...taskTemplate({ id: "t3", createdBy: "CHILD", photoBonus: false, category: "STAMINA" }),
       quests: [
         {
-          id: "q3",
-          childId: "child-2",
-          status: "APPROVED",
-          deadlineBonusEarned: false,
-          photoUrl: null,
-          child: { id: "child-2", studyPt: 2, staminaPt: 0, lifePt: 0 },
+          ...questInstance({ id: "q3", childId: "child-2", status: "APPROVED", deadlineBonusEarned: false, photoUrl: null }),
+          child: childUser({ id: "child-2", studyPt: 2, staminaPt: 0, lifePt: 0 }),
         },
       ],
-    } as any);
+    };
+    mockPrisma.taskTemplate.findFirst.mockResolvedValue(taskWithQuests);
 
-    mockPrisma.user.findUnique.mockResolvedValue({
-      id: "child-2", studyPt: 2, staminaPt: 0, lifePt: 0,
-    } as any);
-    mockPrisma.user.update.mockResolvedValue({} as any);
-    mockPrisma.questInstance.updateMany.mockResolvedValue({ count: 1 } as any);
-    mockPrisma.taskTemplate.update.mockResolvedValue({} as any);
+    mockPrisma.user.findUnique.mockResolvedValue(
+      childUser({ id: "child-2", studyPt: 2, staminaPt: 0, lifePt: 0 })
+    );
+    mockPrisma.user.update.mockResolvedValue(childUser());
+    mockPrisma.questInstance.updateMany.mockResolvedValue({ count: 1 });
+    mockPrisma.taskTemplate.update.mockResolvedValue(taskTemplate());
 
     await DELETE(makeRequest("/api/tasks/t3", {}), makeParams("t3"));
 
@@ -319,7 +292,7 @@ describe("DELETE /api/tasks/[id]", () => {
   // なく、親A が他 family のタスク ID を渡すと XP 剥奪 + REJECTED 反映が通ってしまう。
   // findUnique を family スコープ付きに変え、対象なしなら 404 を返す。
   it("親が他 family のタスクを削除しようとしても 404 を返す（IDOR 防止）", async () => {
-    mockGetCurrentUser.mockResolvedValue(parentUser() as any);
+    mockGetCurrentUser.mockResolvedValue(parentUserWithFamily());
     // 他 family のタスクは findFirst で null を返す
     mockPrisma.taskTemplate.findFirst.mockResolvedValue(null);
 
@@ -336,7 +309,7 @@ describe("DELETE /api/tasks/[id]", () => {
 
   // 親が familyId を持たない不整合状態でも DELETE を通してはいけない (Deep defense)
   it("PARENT で familyId=null の場合 403 を返す", async () => {
-    mockGetCurrentUser.mockResolvedValue(parentUser({ familyId: null }) as any);
+    mockGetCurrentUser.mockResolvedValue(parentUserWithFamily({ familyId: null }, null));
 
     const res = await DELETE(makeRequest("/api/tasks/t1", {}), makeParams("t1"));
     expect(res.status).toBe(403);
@@ -348,7 +321,7 @@ describe("DELETE /api/tasks/[id]", () => {
 // ─── IDOR 深層防御 (PATCH) ─────────────────────────
 describe("PATCH /api/tasks/[id] - IDOR 防御", () => {
   it("PARENT で familyId=null の場合 403 を返す (WHERE 句無効化 → 全件マッチ攻撃を防ぐ)", async () => {
-    mockGetCurrentUser.mockResolvedValue(parentUser({ familyId: null }) as any);
+    mockGetCurrentUser.mockResolvedValue(parentUserWithFamily({ familyId: null }, null));
     const res = await PATCH(makeRequest("/api/tasks/t1", {}), makeParams("t1"));
     expect(res.status).toBe(403);
     expect(mockPrisma.taskTemplate.update).not.toHaveBeenCalled();

--- a/src/__tests__/api/tasks/tasks.test.ts
+++ b/src/__tests__/api/tasks/tasks.test.ts
@@ -1,17 +1,42 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { GET, POST } from "@/app/api/tasks/route";
-import { prisma } from "@/lib/prisma";
 import { getCurrentUser } from "@/lib/auth";
+import type { Prisma } from "@/generated/prisma/client";
 import { makeRequest } from "../../helpers/request";
-import { parentUser, childUser } from "../../helpers/fixtures";
+import { prismaMock as mockPrisma } from "../../helpers/prisma-mock";
+import {
+  parentUserWithFamily,
+  childUserWithFamily,
+  childUser,
+  taskTemplate,
+  questInstance,
+} from "../../helpers/fixtures";
 
-const mockPrisma = vi.mocked(prisma);
 const mockGetCurrentUser = vi.mocked(getCurrentUser);
+
+/**
+ * `mockImplementation` の戻り値は実際の Prisma メソッドと同じ `PrismaPromise<T>` 型が
+ * 要求されるが、`vitest-mock-extended` の DeepMockProxy はジェネリックオーバーロードを
+ * 保持しないためテストコード側では通常の `Promise` しか作れない。
+ * `PrismaPromise` は実行時には通常の thenable として振る舞うため、型だけ合わせる。
+ */
+function asPrismaPromise<T>(value: T): Prisma.PrismaPromise<T> {
+  return Promise.resolve(value) as unknown as Prisma.PrismaPromise<T>;
+}
+
+/**
+ * `NextResponse.json()` は Date を ISO 文字列にシリアライズするため、フィクスチャ
+ * （`createdAt` 等が `Date`）と `res.json()` の結果をそのまま `toEqual` すると型不一致になる。
+ * 期待値側も同じ JSON ラウンドトリップを通して比較する。
+ */
+function toSerialized<T>(value: T): unknown {
+  return JSON.parse(JSON.stringify(value));
+}
 
 beforeEach(() => {
   vi.clearAllMocks();
   // ensureTodayQuests が user.findMany を呼ぶ。デフォルトでは子供なし（no-op）。
-  mockPrisma.user.findMany.mockResolvedValue([] as any);
+  mockPrisma.user.findMany.mockResolvedValue([]);
 });
 
 describe("GET /api/tasks", () => {
@@ -23,27 +48,27 @@ describe("GET /api/tasks", () => {
   });
 
   it("familyIdがない場合、空配列を返すこと", async () => {
-    mockGetCurrentUser.mockResolvedValue(parentUser({ familyId: null }) as any);
+    mockGetCurrentUser.mockResolvedValue(parentUserWithFamily({ familyId: null }, null));
     const res = await GET();
     const json = await res.json();
     expect(json).toEqual([]);
   });
 
   it("ファミリーのアクティブタスクを返すこと（completedToday付き）", async () => {
-    mockGetCurrentUser.mockResolvedValue(parentUser() as any);
+    mockGetCurrentUser.mockResolvedValue(parentUserWithFamily());
     const tasks = [
-      { id: "t1", title: "宿題", isActive: true },
-      { id: "t2", title: "運動", isActive: true },
+      taskTemplate({ id: "t1", title: "宿題", isActive: true }),
+      taskTemplate({ id: "t2", title: "運動", isActive: true }),
     ];
-    mockPrisma.taskTemplate.findMany.mockResolvedValue(tasks as any);
+    mockPrisma.taskTemplate.findMany.mockResolvedValue(tasks);
     mockPrisma.questInstance.findMany.mockResolvedValue([]);
 
     const res = await GET();
     const json = await res.json();
 
     expect(json).toEqual([
-      { ...tasks[0], completedToday: false, lastSkippedDate: null, carryOverMissedCount: null },
-      { ...tasks[1], completedToday: false, lastSkippedDate: null, carryOverMissedCount: null },
+      toSerialized({ ...tasks[0], completedToday: false, lastSkippedDate: null, carryOverMissedCount: null }),
+      toSerialized({ ...tasks[1], completedToday: false, lastSkippedDate: null, carryOverMissedCount: null }),
     ]);
     expect(mockPrisma.taskTemplate.findMany).toHaveBeenCalledWith({
       where: { familyId: "fam-1", isActive: true },
@@ -59,22 +84,26 @@ describe("GET /api/tasks", () => {
 
   it("当日にAPPROVEDのクエストがあるタスクはcompletedToday=trueになること", async () => {
     vi.setSystemTime(new Date("2026-03-18T10:00:00"));
-    mockGetCurrentUser.mockResolvedValue(parentUser() as any);
+    mockGetCurrentUser.mockResolvedValue(parentUserWithFamily());
     const tasks = [
-      { id: "t1", title: "宿題", isActive: true },
-      { id: "t2", title: "運動", isActive: true },
+      taskTemplate({ id: "t1", title: "宿題", isActive: true }),
+      taskTemplate({ id: "t2", title: "運動", isActive: true }),
     ];
-    mockPrisma.taskTemplate.findMany.mockResolvedValue(tasks as any);
-    mockPrisma.questInstance.findMany.mockResolvedValue([
-      { templateId: "t1" },
-    ] as any);
+    mockPrisma.taskTemplate.findMany.mockResolvedValue(tasks);
+    // completedQuests のみ t1 の APPROVED を返す。recentSkipped/recentApproved は空。
+    // (フィクスチャの questInstance() は date が既定で埋まっているため、これらを空にしないと
+    //  lastSkippedDate が誤って設定されてしまう)
+    mockPrisma.questInstance.findMany
+      .mockResolvedValueOnce([questInstance({ templateId: "t1" })])
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([]);
 
     const res = await GET();
     const json = await res.json();
 
     expect(json).toEqual([
-      { ...tasks[0], completedToday: true, lastSkippedDate: null, carryOverMissedCount: null },
-      { ...tasks[1], completedToday: false, lastSkippedDate: null, carryOverMissedCount: null },
+      toSerialized({ ...tasks[0], completedToday: true, lastSkippedDate: null, carryOverMissedCount: null }),
+      toSerialized({ ...tasks[1], completedToday: false, lastSkippedDate: null, carryOverMissedCount: null }),
     ]);
     const expectedToday = new Date("2026-03-18T00:00:00Z");
     expect(mockPrisma.questInstance.findMany).toHaveBeenCalledWith({
@@ -89,12 +118,12 @@ describe("GET /api/tasks", () => {
 
   it("当日にSKIPPEDのクエストがあるタスクもcompletedToday=trueになること", async () => {
     vi.setSystemTime(new Date("2026-03-18T10:00:00"));
-    mockGetCurrentUser.mockResolvedValue(parentUser() as any);
-    const tasks = [{ id: "t1", title: "宿題", isActive: true }];
-    mockPrisma.taskTemplate.findMany.mockResolvedValue(tasks as any);
+    mockGetCurrentUser.mockResolvedValue(parentUserWithFamily());
+    const tasks = [taskTemplate({ id: "t1", title: "宿題", isActive: true })];
+    mockPrisma.taskTemplate.findMany.mockResolvedValue(tasks);
     mockPrisma.questInstance.findMany.mockResolvedValue([
-      { templateId: "t1" },
-    ] as any);
+      questInstance({ templateId: "t1" }),
+    ]);
 
     const res = await GET();
     const json = await res.json();
@@ -104,19 +133,19 @@ describe("GET /api/tasks", () => {
 
   it("直近SKIPPEDがあるタスクには lastSkippedDate が設定されること", async () => {
     vi.setSystemTime(new Date("2026-03-18T10:00:00"));
-    mockGetCurrentUser.mockResolvedValue(parentUser() as any);
+    mockGetCurrentUser.mockResolvedValue(parentUserWithFamily());
     const tasks = [
-      { id: "t1", title: "宿題", isActive: true },
-      { id: "t2", title: "運動", isActive: true },
+      taskTemplate({ id: "t1", title: "宿題", isActive: true }),
+      taskTemplate({ id: "t2", title: "運動", isActive: true }),
     ];
-    mockPrisma.taskTemplate.findMany.mockResolvedValue(tasks as any);
+    mockPrisma.taskTemplate.findMany.mockResolvedValue(tasks);
 
     const skippedDate = new Date("2026-03-15T00:00:00Z");
     // 1回目: 今日のAPPROVED/SKIPPED（空）
     // 2回目: 直近SKIPPED（t1のみ3日前）
     mockPrisma.questInstance.findMany
-      .mockResolvedValueOnce([] as any)
-      .mockResolvedValueOnce([{ templateId: "t1", date: skippedDate }] as any);
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([questInstance({ templateId: "t1", date: skippedDate })]);
 
     const res = await GET();
     const json = await res.json();
@@ -127,10 +156,10 @@ describe("GET /api/tasks", () => {
 
   it("直近SKIPPEDクエリは過去7日間・SKIPPEDのみに限定されること", async () => {
     vi.setSystemTime(new Date("2026-03-18T10:00:00"));
-    mockGetCurrentUser.mockResolvedValue(parentUser() as any);
-    const tasks = [{ id: "t1", title: "宿題", isActive: true }];
-    mockPrisma.taskTemplate.findMany.mockResolvedValue(tasks as any);
-    mockPrisma.questInstance.findMany.mockResolvedValue([] as any);
+    mockGetCurrentUser.mockResolvedValue(parentUserWithFamily());
+    const tasks = [taskTemplate({ id: "t1", title: "宿題", isActive: true })];
+    mockPrisma.taskTemplate.findMany.mockResolvedValue(tasks);
+    mockPrisma.questInstance.findMany.mockResolvedValue([]);
 
     await GET();
 
@@ -150,19 +179,19 @@ describe("GET /api/tasks", () => {
 
   it("同じテンプレートに複数のSKIPPEDがある場合、最新の日付を返すこと", async () => {
     vi.setSystemTime(new Date("2026-03-18T10:00:00"));
-    mockGetCurrentUser.mockResolvedValue(parentUser() as any);
-    const tasks = [{ id: "t1", title: "宿題", isActive: true }];
-    mockPrisma.taskTemplate.findMany.mockResolvedValue(tasks as any);
+    mockGetCurrentUser.mockResolvedValue(parentUserWithFamily());
+    const tasks = [taskTemplate({ id: "t1", title: "宿題", isActive: true })];
+    mockPrisma.taskTemplate.findMany.mockResolvedValue(tasks);
 
     const recent = new Date("2026-03-17T00:00:00Z");
     const older = new Date("2026-03-13T00:00:00Z");
     mockPrisma.questInstance.findMany
-      .mockResolvedValueOnce([] as any)
+      .mockResolvedValueOnce([])
       // orderBy: date desc を前提に、先頭が最新
       .mockResolvedValueOnce([
-        { templateId: "t1", date: recent },
-        { templateId: "t1", date: older },
-      ] as any);
+        questInstance({ templateId: "t1", date: recent }),
+        questInstance({ templateId: "t1", date: older }),
+      ]);
 
     const res = await GET();
     const json = await res.json();
@@ -173,21 +202,21 @@ describe("GET /api/tasks", () => {
   it("carryOver=true の毎日タスクで PENDING が3日前なら carryOverMissedCount=4（出現回数 inclusive）", async () => {
     // 2026-03-18 は水曜（dayOfWeek=3）
     vi.setSystemTime(new Date("2026-03-18T10:00:00"));
-    mockGetCurrentUser.mockResolvedValue(parentUser() as any);
+    mockGetCurrentUser.mockResolvedValue(parentUserWithFamily());
     const tasks = [
       // 毎日タスク
-      { id: "t1", title: "宿題", isActive: true, carryOver: true, repeatDays: [0, 1, 2, 3, 4, 5, 6] },
-      { id: "t2", title: "運動", isActive: true, carryOver: false, repeatDays: [1, 2, 3, 4, 5] },
+      taskTemplate({ id: "t1", title: "宿題", isActive: true, carryOver: true, repeatDays: [0, 1, 2, 3, 4, 5, 6] }),
+      taskTemplate({ id: "t2", title: "運動", isActive: true, carryOver: false, repeatDays: [1, 2, 3, 4, 5] }),
     ];
-    mockPrisma.taskTemplate.findMany.mockResolvedValue(tasks as any);
+    mockPrisma.taskTemplate.findMany.mockResolvedValue(tasks);
 
     const oldPending = new Date("2026-03-15T00:00:00Z"); // 3日前（日曜）
     mockPrisma.questInstance.findMany
-      .mockResolvedValueOnce([] as any) // completedQuests (today)
-      .mockResolvedValueOnce([] as any) // recentSkipped (7日窓 SKIPPED)
-      .mockResolvedValueOnce([] as any) // recentApproved (7日窓 APPROVED, lastSkippedDate クリア判定用)
-      .mockResolvedValueOnce([{ templateId: "t1", date: oldPending }] as any) // carryOverPending
-      .mockResolvedValueOnce([] as any); // latestSettled
+      .mockResolvedValueOnce([]) // completedQuests (today)
+      .mockResolvedValueOnce([]) // recentSkipped (7日窓 SKIPPED)
+      .mockResolvedValueOnce([]) // recentApproved (7日窓 APPROVED, lastSkippedDate クリア判定用)
+      .mockResolvedValueOnce([questInstance({ templateId: "t1", date: oldPending })]) // carryOverPending
+      .mockResolvedValueOnce([]); // latestSettled
 
     const res = await GET();
     const json = await res.json();
@@ -200,19 +229,19 @@ describe("GET /api/tasks", () => {
   it("carryOver=true の週次タスク(月曜のみ)で先週月曜の PENDING なら carryOverMissedCount=2", async () => {
     // 2026-03-23 は月曜（dayOfWeek=1）
     vi.setSystemTime(new Date("2026-03-23T10:00:00"));
-    mockGetCurrentUser.mockResolvedValue(parentUser() as any);
+    mockGetCurrentUser.mockResolvedValue(parentUserWithFamily());
     const tasks = [
-      { id: "t1", title: "週次宿題", isActive: true, carryOver: true, repeatDays: [1] }, // 月曜のみ
+      taskTemplate({ id: "t1", title: "週次宿題", isActive: true, carryOver: true, repeatDays: [1] }), // 月曜のみ
     ];
-    mockPrisma.taskTemplate.findMany.mockResolvedValue(tasks as any);
+    mockPrisma.taskTemplate.findMany.mockResolvedValue(tasks);
 
     const oldPending = new Date("2026-03-16T00:00:00Z"); // 先週月曜
     mockPrisma.questInstance.findMany
-      .mockResolvedValueOnce([] as any)
-      .mockResolvedValueOnce([] as any)
-      .mockResolvedValueOnce([] as any)
-      .mockResolvedValueOnce([{ templateId: "t1", date: oldPending }] as any)
-      .mockResolvedValueOnce([] as any);
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([questInstance({ templateId: "t1", date: oldPending })])
+      .mockResolvedValueOnce([]);
 
     const res = await GET();
     const json = await res.json();
@@ -227,19 +256,19 @@ describe("GET /api/tasks", () => {
     // ここでは「先週月曜が PENDING で、今日が翌日火曜（=出現は1回のまま）」のケースを確認する。
     // 2026-03-17 は火曜
     vi.setSystemTime(new Date("2026-03-17T10:00:00"));
-    mockGetCurrentUser.mockResolvedValue(parentUser() as any);
+    mockGetCurrentUser.mockResolvedValue(parentUserWithFamily());
     const tasks = [
-      { id: "t1", title: "週次宿題", isActive: true, carryOver: true, repeatDays: [1] },
+      taskTemplate({ id: "t1", title: "週次宿題", isActive: true, carryOver: true, repeatDays: [1] }),
     ];
-    mockPrisma.taskTemplate.findMany.mockResolvedValue(tasks as any);
+    mockPrisma.taskTemplate.findMany.mockResolvedValue(tasks);
 
     const oldPending = new Date("2026-03-16T00:00:00Z"); // 月曜
     mockPrisma.questInstance.findMany
-      .mockResolvedValueOnce([] as any)
-      .mockResolvedValueOnce([] as any)
-      .mockResolvedValueOnce([] as any)
-      .mockResolvedValueOnce([{ templateId: "t1", date: oldPending }] as any)
-      .mockResolvedValueOnce([] as any);
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([questInstance({ templateId: "t1", date: oldPending })])
+      .mockResolvedValueOnce([]);
 
     const res = await GET();
     const json = await res.json();
@@ -250,23 +279,25 @@ describe("GET /api/tasks", () => {
 
   it("直近の APPROVED より古い PENDING は無視されること（stale データ対策）", async () => {
     vi.setSystemTime(new Date("2026-03-18T10:00:00"));
-    mockGetCurrentUser.mockResolvedValue(parentUser() as any);
-    const tasks = [{ id: "t1", title: "宿題", isActive: true, carryOver: true, repeatDays: [0, 1, 2, 3, 4, 5, 6] }];
-    mockPrisma.taskTemplate.findMany.mockResolvedValue(tasks as any);
+    mockGetCurrentUser.mockResolvedValue(parentUserWithFamily());
+    const tasks = [
+      taskTemplate({ id: "t1", title: "宿題", isActive: true, carryOver: true, repeatDays: [0, 1, 2, 3, 4, 5, 6] }),
+    ];
+    mockPrisma.taskTemplate.findMany.mockResolvedValue(tasks);
 
     const stalePending = new Date("2026-03-11T00:00:00Z"); // 7日前 (古い PENDING、stale)
     const approvedDate = new Date("2026-03-13T00:00:00Z"); // 5日前 (完了)
     const realPending = new Date("2026-03-15T00:00:00Z"); // 3日前 (本物の carryOver)
 
     mockPrisma.questInstance.findMany
-      .mockResolvedValueOnce([] as any)
-      .mockResolvedValueOnce([] as any)
-      .mockResolvedValueOnce([{ templateId: "t1", date: approvedDate }] as any) // recentApproved（7日窓内の APPROVED）
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([questInstance({ templateId: "t1", date: approvedDate })]) // recentApproved（7日窓内の APPROVED）
       .mockResolvedValueOnce([
-        { templateId: "t1", date: stalePending },
-        { templateId: "t1", date: realPending },
-      ] as any)
-      .mockResolvedValueOnce([{ templateId: "t1", date: approvedDate }] as any);
+        questInstance({ templateId: "t1", date: stalePending }),
+        questInstance({ templateId: "t1", date: realPending }),
+      ])
+      .mockResolvedValueOnce([questInstance({ templateId: "t1", date: approvedDate })]);
 
     const res = await GET();
     const json = await res.json();
@@ -277,19 +308,21 @@ describe("GET /api/tasks", () => {
 
   it("PENDING がすべて settled より古い場合は null になること", async () => {
     vi.setSystemTime(new Date("2026-03-18T10:00:00"));
-    mockGetCurrentUser.mockResolvedValue(parentUser() as any);
-    const tasks = [{ id: "t1", title: "宿題", isActive: true, carryOver: true, repeatDays: [0, 1, 2, 3, 4, 5, 6] }];
-    mockPrisma.taskTemplate.findMany.mockResolvedValue(tasks as any);
+    mockGetCurrentUser.mockResolvedValue(parentUserWithFamily());
+    const tasks = [
+      taskTemplate({ id: "t1", title: "宿題", isActive: true, carryOver: true, repeatDays: [0, 1, 2, 3, 4, 5, 6] }),
+    ];
+    mockPrisma.taskTemplate.findMany.mockResolvedValue(tasks);
 
     const stalePending = new Date("2026-03-11T00:00:00Z"); // 7日前
     const approvedDate = new Date("2026-03-15T00:00:00Z"); // 3日前 (PENDING より新しい)
 
     mockPrisma.questInstance.findMany
-      .mockResolvedValueOnce([] as any)
-      .mockResolvedValueOnce([] as any)
-      .mockResolvedValueOnce([{ templateId: "t1", date: approvedDate }] as any) // recentApproved
-      .mockResolvedValueOnce([{ templateId: "t1", date: stalePending }] as any)
-      .mockResolvedValueOnce([{ templateId: "t1", date: approvedDate }] as any);
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([questInstance({ templateId: "t1", date: approvedDate })]) // recentApproved
+      .mockResolvedValueOnce([questInstance({ templateId: "t1", date: stalePending })])
+      .mockResolvedValueOnce([questInstance({ templateId: "t1", date: approvedDate })]);
 
     const res = await GET();
     const json = await res.json();
@@ -299,13 +332,13 @@ describe("GET /api/tasks", () => {
 
   it("carryOver=false のタスクは carryOver PENDING クエリの対象外", async () => {
     vi.setSystemTime(new Date("2026-03-18T10:00:00"));
-    mockGetCurrentUser.mockResolvedValue(parentUser() as any);
+    mockGetCurrentUser.mockResolvedValue(parentUserWithFamily());
     const tasks = [
-      { id: "t1", title: "宿題", isActive: true, carryOver: false },
-      { id: "t2", title: "運動", isActive: true, carryOver: true },
+      taskTemplate({ id: "t1", title: "宿題", isActive: true, carryOver: false }),
+      taskTemplate({ id: "t2", title: "運動", isActive: true, carryOver: true }),
     ];
-    mockPrisma.taskTemplate.findMany.mockResolvedValue(tasks as any);
-    mockPrisma.questInstance.findMany.mockResolvedValue([] as any);
+    mockPrisma.taskTemplate.findMany.mockResolvedValue(tasks);
+    mockPrisma.questInstance.findMany.mockResolvedValue([]);
 
     await GET();
 
@@ -325,22 +358,24 @@ describe("GET /api/tasks", () => {
 
   it("同じテンプレートに複数のcarryOver PENDINGがある場合、最古の日付を起点に出現回数を数えること", async () => {
     vi.setSystemTime(new Date("2026-03-18T10:00:00"));
-    mockGetCurrentUser.mockResolvedValue(parentUser() as any);
-    const tasks = [{ id: "t1", title: "宿題", isActive: true, carryOver: true, repeatDays: [0, 1, 2, 3, 4, 5, 6] }];
-    mockPrisma.taskTemplate.findMany.mockResolvedValue(tasks as any);
+    mockGetCurrentUser.mockResolvedValue(parentUserWithFamily());
+    const tasks = [
+      taskTemplate({ id: "t1", title: "宿題", isActive: true, carryOver: true, repeatDays: [0, 1, 2, 3, 4, 5, 6] }),
+    ];
+    mockPrisma.taskTemplate.findMany.mockResolvedValue(tasks);
 
     const oldest = new Date("2026-03-13T00:00:00Z");
     const newer = new Date("2026-03-16T00:00:00Z");
     mockPrisma.questInstance.findMany
-      .mockResolvedValueOnce([] as any)
-      .mockResolvedValueOnce([] as any)
-      .mockResolvedValueOnce([] as any) // recentApproved
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([]) // recentApproved
       // orderBy: date asc を前提に、先頭が最古
       .mockResolvedValueOnce([
-        { templateId: "t1", date: oldest },
-        { templateId: "t1", date: newer },
-      ] as any)
-      .mockResolvedValueOnce([] as any); // 直近settled なし
+        questInstance({ templateId: "t1", date: oldest }),
+        questInstance({ templateId: "t1", date: newer }),
+      ])
+      .mockResolvedValueOnce([]); // 直近settled なし
 
     const res = await GET();
     const json = await res.json();
@@ -352,30 +387,38 @@ describe("GET /api/tasks", () => {
   it("親がアクセスした時、ファミリー内の各子供について ensureTodayQuests が呼ばれること", async () => {
     // 2026-03-12 は木曜 (day=4)
     vi.setSystemTime(new Date("2026-03-12T09:00:00"));
-    mockGetCurrentUser.mockResolvedValue(parentUser() as any);
+    mockGetCurrentUser.mockResolvedValue(parentUserWithFamily());
 
     // ファミリーの子供を2人返す
     mockPrisma.user.findMany.mockResolvedValue([
-      { id: "child-1" },
-      { id: "child-2" },
-    ] as any);
+      childUser({ id: "child-1" }),
+      childUser({ id: "child-2" }),
+    ]);
 
     // ensureTodayQuests が child-1 の今日のテンプレートを返す想定
     // child-2 の呼び出しではテンプレートなし
-    mockPrisma.taskTemplate.findMany.mockImplementation(((args: any) => {
+    mockPrisma.taskTemplate.findMany.mockImplementation((args?: Prisma.TaskTemplateFindManyArgs) => {
       if (args?.where?.assignedChildId === "child-1") {
-        return Promise.resolve([
-          { id: "tpl-1", title: "宿題", emoji: "📚", category: "STUDY", repeatDays: [4], isTemporary: false, carryOver: false },
-        ] as any);
+        return asPrismaPromise([
+          taskTemplate({
+            id: "tpl-1",
+            title: "宿題",
+            emoji: "📚",
+            category: "STUDY",
+            repeatDays: [4],
+            isTemporary: false,
+            carryOver: false,
+          }),
+        ]);
       }
       if (args?.where?.assignedChildId === "child-2") {
-        return Promise.resolve([] as any);
+        return asPrismaPromise([]);
       }
       // 親画面のタスク一覧取得
-      return Promise.resolve([] as any);
-    }) as any);
-    mockPrisma.questInstance.upsert.mockResolvedValue({} as any);
-    mockPrisma.questInstance.findMany.mockResolvedValue([] as any);
+      return asPrismaPromise([]);
+    });
+    mockPrisma.questInstance.upsert.mockResolvedValue(questInstance());
+    mockPrisma.questInstance.findMany.mockResolvedValue([]);
 
     await GET();
 
@@ -400,15 +443,15 @@ describe("GET /api/tasks", () => {
 
 describe("POST /api/tasks", () => {
   it("タスク名が空の場合、400を返すこと", async () => {
-    mockGetCurrentUser.mockResolvedValue(parentUser() as any);
+    mockGetCurrentUser.mockResolvedValue(parentUserWithFamily());
     const res = await POST(makeRequest("/api/tasks", { title: "", assignedChildId: "child-1" }));
     expect(res.status).toBe(400);
     const json = await res.json();
     expect(json.error).toBe("タスク名は必須です");
   });
-  
+
   it("タスク名が32文字を超える場合、400を返すこと", async () => {
-    mockGetCurrentUser.mockResolvedValue(parentUser() as any);
+    mockGetCurrentUser.mockResolvedValue(parentUserWithFamily());
     const res = await POST(
       makeRequest("/api/tasks", {
         title: "あ".repeat(33),
@@ -420,10 +463,10 @@ describe("POST /api/tasks", () => {
     const json = await res.json();
     expect(json.error).toBe("タスク名は32文字以内にしてください");
   });
-  
+
   it("タスク名が32文字ちょうどなら作成できること", async () => {
-    mockGetCurrentUser.mockResolvedValue(parentUser() as any);
-    mockPrisma.taskTemplate.create.mockResolvedValue({ id: "t-exact32" } as any);
+    mockGetCurrentUser.mockResolvedValue(parentUserWithFamily());
+    mockPrisma.taskTemplate.create.mockResolvedValue(taskTemplate({ id: "t-exact32" }));
     const res = await POST(
       makeRequest("/api/tasks", {
         title: "あ".repeat(32),
@@ -441,15 +484,15 @@ describe("POST /api/tasks", () => {
   });
 
   it("familyIdなしの場合、403を返すこと", async () => {
-    mockGetCurrentUser.mockResolvedValue(parentUser({ familyId: null }) as any);
+    mockGetCurrentUser.mockResolvedValue(parentUserWithFamily({ familyId: null }, null));
     const res = await POST(makeRequest("/api/tasks", { title: "test" }));
     expect(res.status).toBe(403);
   });
 
   it("通常タスクを作成できること（PARENT）", async () => {
-    mockGetCurrentUser.mockResolvedValue(parentUser() as any);
-    const created = { id: "t-new", title: "漢字練習", isTemporary: false };
-    mockPrisma.taskTemplate.create.mockResolvedValue(created as any);
+    mockGetCurrentUser.mockResolvedValue(parentUserWithFamily());
+    const created = taskTemplate({ id: "t-new", title: "漢字練習", isTemporary: false });
+    mockPrisma.taskTemplate.create.mockResolvedValue(created);
 
     const res = await POST(
       makeRequest("/api/tasks", {
@@ -483,8 +526,8 @@ describe("POST /api/tasks", () => {
   });
 
   it("photoBonus=true を指定してタスクを作成できること", async () => {
-    mockGetCurrentUser.mockResolvedValue(parentUser() as any);
-    mockPrisma.taskTemplate.create.mockResolvedValue({ id: "t-photo" } as any);
+    mockGetCurrentUser.mockResolvedValue(parentUserWithFamily());
+    mockPrisma.taskTemplate.create.mockResolvedValue(taskTemplate({ id: "t-photo" }));
 
     await POST(
       makeRequest("/api/tasks", {
@@ -503,8 +546,8 @@ describe("POST /api/tasks", () => {
   });
 
   it("一時タスクを作成できること", async () => {
-    mockGetCurrentUser.mockResolvedValue(childUser() as any);
-    mockPrisma.taskTemplate.create.mockResolvedValue({ id: "t-temp" } as any);
+    mockGetCurrentUser.mockResolvedValue(childUserWithFamily());
+    mockPrisma.taskTemplate.create.mockResolvedValue(taskTemplate({ id: "t-temp" }));
 
     await POST(
       makeRequest("/api/tasks", {
@@ -527,8 +570,8 @@ describe("POST /api/tasks", () => {
 
   it("一時タスクでtargetDateがない場合、当日の日付が設定されること", async () => {
     vi.setSystemTime(new Date("2026-03-12T09:00:00"));
-    mockGetCurrentUser.mockResolvedValue(childUser() as any);
-    mockPrisma.taskTemplate.create.mockResolvedValue({ id: "t-temp2" } as any);
+    mockGetCurrentUser.mockResolvedValue(childUserWithFamily());
+    mockPrisma.taskTemplate.create.mockResolvedValue(taskTemplate({ id: "t-temp2" }));
 
     await POST(
       makeRequest("/api/tasks", {
@@ -548,8 +591,8 @@ describe("POST /api/tasks", () => {
   });
 
   it("emojiが未指定の場合、デフォルト ⚔️ を使用すること", async () => {
-    mockGetCurrentUser.mockResolvedValue(parentUser() as any);
-    mockPrisma.taskTemplate.create.mockResolvedValue({ id: "t-def" } as any);
+    mockGetCurrentUser.mockResolvedValue(parentUserWithFamily());
+    mockPrisma.taskTemplate.create.mockResolvedValue(taskTemplate({ id: "t-def" }));
 
     await POST(
       makeRequest("/api/tasks", { title: "テスト", category: "STUDY", assignedChildId: "child-1" })
@@ -561,8 +604,8 @@ describe("POST /api/tasks", () => {
   });
 
   it("repeatDaysが未指定かつ非一時タスクの場合、空配列になること", async () => {
-    mockGetCurrentUser.mockResolvedValue(parentUser() as any);
-    mockPrisma.taskTemplate.create.mockResolvedValue({ id: "t-norep" } as any);
+    mockGetCurrentUser.mockResolvedValue(parentUserWithFamily());
+    mockPrisma.taskTemplate.create.mockResolvedValue(taskTemplate({ id: "t-norep" }));
 
     await POST(
       makeRequest("/api/tasks", { title: "テスト", category: "STUDY", assignedChildId: "child-1" })


### PR DESCRIPTION
## Summary
- `src/__tests__/api/tasks/{tasks,tasks-id,tasks-id-copy}.test.ts` の `as any` 144件を全廃し、型付きモック `prismaMock`(#35) に移行。`fixtures.ts` は既存フィクスチャで足りたため無変更
- **重要な発見1（実装への影響なし）**: `taskSummary.ts` の `repeatDays` フォールバック分岐（`?? []`）が、型付け後は実行されなくなった（branch coverage 97.05% → 94.11%）。旧テストのモックが `repeatDays` 欠落により偶然この分岐をカバーしていただけで、実装自体は変更していない
- **重要な発見2（テスト品質改善）**: 「当日にAPPROVEDのクエストがあるタスクは `completedToday=true` になること」テストにおいて、旧テストは `questInstance.findMany` を全呼び出しで同一値を返す実装になっており、`date` フィールド欠落により `computeLastSkippedDates` の `if (!q.date) continue` ガードに引っかかって偶然テストが通っていた。型付け後にこの不備が顕在化してテストが実際に落ちたため、`mockResolvedValueOnce` を実際のPrisma呼び出し順序（completedQuests → recentSkipped → recentApproved）に沿って明示的に3回連鎖させる形に修正。code-reviewerが `src/lib/taskSummary.ts` の実装と突き合わせて呼び出し順序・値の正確性を検証済み。**assertion自体は一切変更していない**
- テスト件数変化なし、`expect(` 出現数も減少なし

## Test plan
- [x] `npm test` パス（183 test files / 2512 tests, 全対象パス）
- [ ] `npm run lint` — 本PRのスコープ外の既存ファイル（`src/app/...`）で `react-hooks/set-state-in-effect` 等の既存エラーが多数あり全体では失敗するが、本PRで変更したテストファイル自体に起因するものではない
- [x] code-reviewer による APPROVED 済み

Closes #40

🤖 Generated with [Claude Code](https://claude.com/claude-code)
