### PR TITLE
test(quests): api/quests残り5ファイルのas anyを型付きモックに移行

### DIFF
--- a/src/__tests__/api/quests/completed-today.test.ts
+++ b/src/__tests__/api/quests/completed-today.test.ts
@@ -1,10 +1,25 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { GET } from "@/app/api/quests/completed-today/route";
-import { prisma } from "@/lib/prisma";
 import { getCurrentUser } from "@/lib/auth";
-import { parentUser, childUser } from "../../helpers/fixtures";
+import { prismaMock } from "../../helpers/prisma-mock";
+import { parentUserWithFamily, childUserWithFamily, questInstance } from "../../helpers/fixtures";
+import type { Prisma } from "@/generated/prisma/client";
 
-const mockPrisma = vi.mocked(prisma);
+type CompletedTodayQuest = Prisma.QuestInstanceGetPayload<{
+  include: {
+    child: { select: { name: true; monsterName: true; side: true } };
+    template: {
+      select: {
+        title: true;
+        emoji: true;
+        category: true;
+        isTemporary: true;
+        photoBonus: true;
+      };
+    };
+  };
+}>;
+
 const mockGetCurrentUser = vi.mocked(getCurrentUser);
 
 beforeEach(() => {
@@ -25,31 +40,38 @@ describe("GET /api/quests/completed-today", () => {
   });
 
   it("CHILDロールの場合、空配列を返すこと", async () => {
-    mockGetCurrentUser.mockResolvedValue(childUser() as any);
+    mockGetCurrentUser.mockResolvedValue(childUserWithFamily());
     const res = await GET();
     expect(await res.json()).toEqual([]);
   });
 
   it("familyIdがない場合、空配列を返すこと", async () => {
-    mockGetCurrentUser.mockResolvedValue(parentUser({ familyId: null }) as any);
+    mockGetCurrentUser.mockResolvedValue(parentUserWithFamily({ familyId: null }));
     const res = await GET();
     expect(await res.json()).toEqual([]);
   });
 
   it("今日報告済みのクエストを返すこと", async () => {
-    mockGetCurrentUser.mockResolvedValue(parentUser() as any);
+    mockGetCurrentUser.mockResolvedValue(parentUserWithFamily());
 
-    const quests = [
+    // snapshotTitle/Emoji/Category は旧データ（スキーマ導入前）を再現するため
+    // undefined 指定で欠落させ、template フォールバック分岐のカバレッジを維持する
+    const quests: CompletedTodayQuest[] = [
       {
-        id: "q1",
-        status: "APPROVED",
-        reportedAt: new Date("2026-03-12T10:00:00"),
-        approvedAt: new Date("2026-03-13T08:00:00"), // 翌日承認でも今日報告なら表示
+        ...questInstance({
+          id: "q1",
+          status: "APPROVED",
+          reportedAt: new Date("2026-03-12T10:00:00"),
+          approvedAt: new Date("2026-03-13T08:00:00"), // 翌日承認でも今日報告なら表示
+          snapshotTitle: undefined,
+          snapshotEmoji: undefined,
+          snapshotCategory: undefined,
+        }),
         child: { name: "太郎", monsterName: "ドラゴン", side: "DARK" },
-        template: { title: "宿題", emoji: "📚", category: "STUDY" },
+        template: { title: "宿題", emoji: "📚", category: "STUDY", isTemporary: false, photoBonus: false },
       },
     ];
-    mockPrisma.questInstance.findMany.mockResolvedValue(quests as any);
+    prismaMock.questInstance.findMany.mockResolvedValue(quests);
 
     const res = await GET();
     const json = await res.json();
@@ -59,20 +81,25 @@ describe("GET /api/quests/completed-today", () => {
   });
 
   it("templateにisTemporaryが含まれること", async () => {
-    mockGetCurrentUser.mockResolvedValue(parentUser() as any);
+    mockGetCurrentUser.mockResolvedValue(parentUserWithFamily());
 
-    const quests = [
+    const quests: CompletedTodayQuest[] = [
       {
-        id: "q1",
-        templateId: "tpl-1",
-        status: "SKIPPED",
-        reportedAt: new Date("2026-03-12T10:00:00"),
-        approvedAt: new Date("2026-03-12T11:00:00"),
+        ...questInstance({
+          id: "q1",
+          templateId: "tpl-1",
+          status: "SKIPPED",
+          reportedAt: new Date("2026-03-12T10:00:00"),
+          approvedAt: new Date("2026-03-12T11:00:00"),
+          snapshotTitle: undefined,
+          snapshotEmoji: undefined,
+          snapshotCategory: undefined,
+        }),
         child: { name: "太郎", monsterName: "ドラゴン", side: "DARK" },
-        template: { title: "英語", emoji: "📖", category: "STUDY", isTemporary: true },
+        template: { title: "英語", emoji: "📖", category: "STUDY", isTemporary: true, photoBonus: false },
       },
     ];
-    mockPrisma.questInstance.findMany.mockResolvedValue(quests as any);
+    prismaMock.questInstance.findMany.mockResolvedValue(quests);
 
     const res = await GET();
     const json = await res.json();
@@ -82,15 +109,15 @@ describe("GET /api/quests/completed-today", () => {
   });
 
   it("今日の日付範囲（00:00〜翌日00:00）でreportedAtをフィルタすること", async () => {
-    mockGetCurrentUser.mockResolvedValue(parentUser() as any);
-    mockPrisma.questInstance.findMany.mockResolvedValue([] as any);
+    mockGetCurrentUser.mockResolvedValue(parentUserWithFamily());
+    prismaMock.questInstance.findMany.mockResolvedValue([]);
 
     await GET();
 
     const today = new Date("2026-03-12T00:00:00");
     const tomorrow = new Date("2026-03-13T00:00:00");
 
-    expect(mockPrisma.questInstance.findMany).toHaveBeenCalledWith(
+    expect(prismaMock.questInstance.findMany).toHaveBeenCalledWith(
       expect.objectContaining({
         where: expect.objectContaining({
           status: { in: ["APPROVED", "SKIPPED"] },

--- a/src/__tests__/api/quests/declare.test.ts
+++ b/src/__tests__/api/quests/declare.test.ts
@@ -1,11 +1,15 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { POST } from "@/app/api/quests/[id]/declare/route";
-import { prisma } from "@/lib/prisma";
 import { getCurrentUser } from "@/lib/auth";
 import { makeRequest, makeParams } from "../../helpers/request";
-import { childUser, parentUser } from "../../helpers/fixtures";
+import { prismaMock } from "../../helpers/prisma-mock";
+import { childUserWithFamily, parentUserWithFamily, questInstance, taskTemplate, questDeclaration } from "../../helpers/fixtures";
+import type { Prisma } from "@/generated/prisma/client";
 
-const mockPrisma = vi.mocked(prisma);
+type DeclareQuest = Prisma.QuestInstanceGetPayload<{
+  include: { template: { select: { carryOver: true } } };
+}>;
+
 const mockGetCurrentUser = vi.mocked(getCurrentUser);
 
 beforeEach(() => {
@@ -14,126 +18,125 @@ beforeEach(() => {
 
 const day = (s: string) => new Date(s + "T00:00:00.000Z");
 
+/**
+ * findMany の select: { date, status } 相当のルックバック用データ。
+ * DeepMockProxy の mockResolvedValue はベースの QuestInstance 完全型を要求するため、
+ * questInstance() フィクスチャで他フィールドを埋める。
+ */
+function lookback(overrides: { date: Date; status: NonNullable<Parameters<typeof questInstance>[0]>["status"] }) {
+  return questInstance(overrides);
+}
+
 describe("POST /api/quests/[id]/declare", () => {
   it("未認証なら 401 を返す", async () => {
     mockGetCurrentUser.mockResolvedValue(null);
     const res = await POST(makeRequest("/api/quests/q1/declare", {}), makeParams("q1"));
     expect(res.status).toBe(401);
-    expect(mockPrisma.questDeclaration.upsert).not.toHaveBeenCalled();
+    expect(prismaMock.questDeclaration.upsert).not.toHaveBeenCalled();
   });
 
   it("親ロールは 403", async () => {
-    mockGetCurrentUser.mockResolvedValue(parentUser() as any);
+    mockGetCurrentUser.mockResolvedValue(parentUserWithFamily());
     const res = await POST(makeRequest("/api/quests/q1/declare", {}), makeParams("q1"));
     expect(res.status).toBe(403);
-    expect(mockPrisma.questDeclaration.upsert).not.toHaveBeenCalled();
+    expect(prismaMock.questDeclaration.upsert).not.toHaveBeenCalled();
   });
 
   it("自分のクエストでなければ 404", async () => {
-    mockGetCurrentUser.mockResolvedValue(childUser() as any);
-    mockPrisma.questInstance.findUnique.mockResolvedValue(null);
+    mockGetCurrentUser.mockResolvedValue(childUserWithFamily());
+    prismaMock.questInstance.findUnique.mockResolvedValue(null);
     const res = await POST(makeRequest("/api/quests/q-other/declare", {}), makeParams("q-other"));
     expect(res.status).toBe(404);
-    expect(mockPrisma.questDeclaration.upsert).not.toHaveBeenCalled();
+    expect(prismaMock.questDeclaration.upsert).not.toHaveBeenCalled();
   });
 
   it("status が REPORTED の場合は 400（既にアクション済み）", async () => {
-    mockGetCurrentUser.mockResolvedValue(childUser() as any);
-    mockPrisma.questInstance.findUnique.mockResolvedValue({
-      id: "q1",
-      status: "REPORTED",
-      templateId: "tpl-1",
-      childId: "child-1",
-      template: { carryOver: false },
-    } as any);
-    mockPrisma.questInstance.findMany.mockResolvedValue([] as any);
+    mockGetCurrentUser.mockResolvedValue(childUserWithFamily());
+    const quest: DeclareQuest = {
+      ...questInstance({ id: "q1", status: "REPORTED", templateId: "tpl-1", childId: "child-1" }),
+      template: taskTemplate({ carryOver: false }),
+    };
+    prismaMock.questInstance.findUnique.mockResolvedValue(quest);
+    prismaMock.questInstance.findMany.mockResolvedValue([]);
     const res = await POST(makeRequest("/api/quests/q1/declare", {}), makeParams("q1"));
     expect(res.status).toBe(400);
-    expect(mockPrisma.questDeclaration.upsert).not.toHaveBeenCalled();
+    expect(prismaMock.questDeclaration.upsert).not.toHaveBeenCalled();
   });
 
   it("週次タスクで先週スキップしただけの場合は 400（missedExposures=2 < 3）", async () => {
-    mockGetCurrentUser.mockResolvedValue(childUser() as any);
-    mockPrisma.questInstance.findUnique.mockResolvedValue({
-      id: "q-week",
-      status: "PENDING",
-      templateId: "tpl-week",
-      childId: "child-1",
-      template: { carryOver: false },
-    } as any);
+    mockGetCurrentUser.mockResolvedValue(childUserWithFamily());
+    const quest: DeclareQuest = {
+      ...questInstance({ id: "q-week", status: "PENDING", templateId: "tpl-week", childId: "child-1" }),
+      template: taskTemplate({ carryOver: false }),
+    };
+    prismaMock.questInstance.findUnique.mockResolvedValue(quest);
     // 今日(月) PENDING + 先週(月) SKIPPED + 先々週(月) APPROVED
-    mockPrisma.questInstance.findMany.mockResolvedValue([
-      { date: day("2026-05-11"), status: "PENDING" },
-      { date: day("2026-05-04"), status: "SKIPPED" },
-      { date: day("2026-04-27"), status: "APPROVED" },
-    ] as any);
+    prismaMock.questInstance.findMany.mockResolvedValue([
+      lookback({ date: day("2026-05-11"), status: "PENDING" }),
+      lookback({ date: day("2026-05-04"), status: "SKIPPED" }),
+      lookback({ date: day("2026-04-27"), status: "APPROVED" }),
+    ]);
     const res = await POST(makeRequest("/api/quests/q-week/declare", {}), makeParams("q-week"));
     expect(res.status).toBe(400);
-    expect(mockPrisma.questDeclaration.upsert).not.toHaveBeenCalled();
+    expect(prismaMock.questDeclaration.upsert).not.toHaveBeenCalled();
   });
 
   it("3週連続非APPROVED なら宣言成功（missedExposures=3）", async () => {
-    mockGetCurrentUser.mockResolvedValue(childUser() as any);
-    mockPrisma.questInstance.findUnique.mockResolvedValue({
-      id: "q-week",
-      status: "PENDING",
-      templateId: "tpl-week",
-      childId: "child-1",
-      template: { carryOver: false },
-    } as any);
-    mockPrisma.questInstance.findMany.mockResolvedValue([
-      { date: day("2026-05-11"), status: "PENDING" },
-      { date: day("2026-05-04"), status: "SKIPPED" },
-      { date: day("2026-04-27"), status: "SKIPPED" },
-      { date: day("2026-04-20"), status: "APPROVED" },
-    ] as any);
-    mockPrisma.questDeclaration.upsert.mockResolvedValue({} as any);
+    mockGetCurrentUser.mockResolvedValue(childUserWithFamily());
+    const quest: DeclareQuest = {
+      ...questInstance({ id: "q-week", status: "PENDING", templateId: "tpl-week", childId: "child-1" }),
+      template: taskTemplate({ carryOver: false }),
+    };
+    prismaMock.questInstance.findUnique.mockResolvedValue(quest);
+    prismaMock.questInstance.findMany.mockResolvedValue([
+      lookback({ date: day("2026-05-11"), status: "PENDING" }),
+      lookback({ date: day("2026-05-04"), status: "SKIPPED" }),
+      lookback({ date: day("2026-04-27"), status: "SKIPPED" }),
+      lookback({ date: day("2026-04-20"), status: "APPROVED" }),
+    ]);
+    prismaMock.questDeclaration.upsert.mockResolvedValue(questDeclaration());
 
     const res = await POST(makeRequest("/api/quests/q-week/declare", {}), makeParams("q-week"));
     expect(res.status).toBe(200);
-    expect(mockPrisma.questDeclaration.upsert).toHaveBeenCalled();
+    expect(prismaMock.questDeclaration.upsert).toHaveBeenCalled();
   });
 
   it("毎日タスクで3日連続非APPROVED なら宣言成功", async () => {
-    mockGetCurrentUser.mockResolvedValue(childUser() as any);
-    mockPrisma.questInstance.findUnique.mockResolvedValue({
-      id: "q-daily",
-      status: "PENDING",
-      templateId: "tpl-daily",
-      childId: "child-1",
-      template: { carryOver: false },
-    } as any);
-    mockPrisma.questInstance.findMany.mockResolvedValue([
-      { date: day("2026-05-09"), status: "PENDING" },
-      { date: day("2026-05-08"), status: "PENDING" },
-      { date: day("2026-05-07"), status: "PENDING" },
-      { date: day("2026-05-06"), status: "APPROVED" },
-    ] as any);
-    mockPrisma.questDeclaration.upsert.mockResolvedValue({} as any);
+    mockGetCurrentUser.mockResolvedValue(childUserWithFamily());
+    const quest: DeclareQuest = {
+      ...questInstance({ id: "q-daily", status: "PENDING", templateId: "tpl-daily", childId: "child-1" }),
+      template: taskTemplate({ carryOver: false }),
+    };
+    prismaMock.questInstance.findUnique.mockResolvedValue(quest);
+    prismaMock.questInstance.findMany.mockResolvedValue([
+      lookback({ date: day("2026-05-09"), status: "PENDING" }),
+      lookback({ date: day("2026-05-08"), status: "PENDING" }),
+      lookback({ date: day("2026-05-07"), status: "PENDING" }),
+      lookback({ date: day("2026-05-06"), status: "APPROVED" }),
+    ]);
+    prismaMock.questDeclaration.upsert.mockResolvedValue(questDeclaration());
 
     const res = await POST(makeRequest("/api/quests/q-daily/declare", {}), makeParams("q-daily"));
     expect(res.status).toBe(200);
   });
 
   it("carryOver: instance.date が3日以上前なら宣言成功（暦日基準）", async () => {
-    mockGetCurrentUser.mockResolvedValue(childUser() as any);
+    mockGetCurrentUser.mockResolvedValue(childUserWithFamily());
     // 今日のシステム時刻を 5/9 に固定
     vi.useFakeTimers();
     vi.setSystemTime(new Date("2026-05-09T09:00:00"));
 
-    mockPrisma.questInstance.findUnique.mockResolvedValue({
-      id: "q-carry",
-      status: "PENDING",
-      templateId: "tpl-carry",
-      childId: "child-1",
-      template: { carryOver: true },
-    } as any);
+    const quest: DeclareQuest = {
+      ...questInstance({ id: "q-carry", status: "PENDING", templateId: "tpl-carry", childId: "child-1" }),
+      template: taskTemplate({ carryOver: true }),
+    };
+    prismaMock.questInstance.findUnique.mockResolvedValue(quest);
     // carryOver で 5/7 に作成された PENDING が今日まで残っている
-    mockPrisma.questInstance.findMany.mockResolvedValue([
-      { date: day("2026-05-07"), status: "PENDING" },
-      { date: day("2026-05-06"), status: "APPROVED" },
-    ] as any);
-    mockPrisma.questDeclaration.upsert.mockResolvedValue({} as any);
+    prismaMock.questInstance.findMany.mockResolvedValue([
+      lookback({ date: day("2026-05-07"), status: "PENDING" }),
+      lookback({ date: day("2026-05-06"), status: "APPROVED" }),
+    ]);
+    prismaMock.questDeclaration.upsert.mockResolvedValue(questDeclaration());
 
     const res = await POST(makeRequest("/api/quests/q-carry/declare", {}), makeParams("q-carry"));
     expect(res.status).toBe(200);
@@ -141,44 +144,40 @@ describe("POST /api/quests/[id]/declare", () => {
   });
 
   it("REJECTED かつ閾値到達なら宣言可能", async () => {
-    mockGetCurrentUser.mockResolvedValue(childUser() as any);
-    mockPrisma.questInstance.findUnique.mockResolvedValue({
-      id: "q-rej",
-      status: "REJECTED",
-      templateId: "tpl-1",
-      childId: "child-1",
-      template: { carryOver: false },
-    } as any);
-    mockPrisma.questInstance.findMany.mockResolvedValue([
-      { date: day("2026-05-09"), status: "REJECTED" },
-      { date: day("2026-05-08"), status: "PENDING" },
-      { date: day("2026-05-07"), status: "PENDING" },
-    ] as any);
-    mockPrisma.questDeclaration.upsert.mockResolvedValue({} as any);
+    mockGetCurrentUser.mockResolvedValue(childUserWithFamily());
+    const quest: DeclareQuest = {
+      ...questInstance({ id: "q-rej", status: "REJECTED", templateId: "tpl-1", childId: "child-1" }),
+      template: taskTemplate({ carryOver: false }),
+    };
+    prismaMock.questInstance.findUnique.mockResolvedValue(quest);
+    prismaMock.questInstance.findMany.mockResolvedValue([
+      lookback({ date: day("2026-05-09"), status: "REJECTED" }),
+      lookback({ date: day("2026-05-08"), status: "PENDING" }),
+      lookback({ date: day("2026-05-07"), status: "PENDING" }),
+    ]);
+    prismaMock.questDeclaration.upsert.mockResolvedValue(questDeclaration());
     const res = await POST(makeRequest("/api/quests/q-rej/declare", {}), makeParams("q-rej"));
     expect(res.status).toBe(200);
   });
 
   it("二重押しでも upsert なので冪等（200）", async () => {
-    mockGetCurrentUser.mockResolvedValue(childUser() as any);
-    mockPrisma.questInstance.findUnique.mockResolvedValue({
-      id: "q1",
-      status: "PENDING",
-      templateId: "tpl-1",
-      childId: "child-1",
-      template: { carryOver: false },
-    } as any);
-    mockPrisma.questInstance.findMany.mockResolvedValue([
-      { date: day("2026-05-09"), status: "PENDING" },
-      { date: day("2026-05-08"), status: "PENDING" },
-      { date: day("2026-05-07"), status: "PENDING" },
-    ] as any);
-    mockPrisma.questDeclaration.upsert.mockResolvedValue({} as any);
+    mockGetCurrentUser.mockResolvedValue(childUserWithFamily());
+    const quest: DeclareQuest = {
+      ...questInstance({ id: "q1", status: "PENDING", templateId: "tpl-1", childId: "child-1" }),
+      template: taskTemplate({ carryOver: false }),
+    };
+    prismaMock.questInstance.findUnique.mockResolvedValue(quest);
+    prismaMock.questInstance.findMany.mockResolvedValue([
+      lookback({ date: day("2026-05-09"), status: "PENDING" }),
+      lookback({ date: day("2026-05-08"), status: "PENDING" }),
+      lookback({ date: day("2026-05-07"), status: "PENDING" }),
+    ]);
+    prismaMock.questDeclaration.upsert.mockResolvedValue(questDeclaration());
 
     const res1 = await POST(makeRequest("/api/quests/q1/declare", {}), makeParams("q1"));
     const res2 = await POST(makeRequest("/api/quests/q1/declare", {}), makeParams("q1"));
     expect(res1.status).toBe(200);
     expect(res2.status).toBe(200);
-    expect(mockPrisma.questDeclaration.upsert).toHaveBeenCalledTimes(2);
+    expect(prismaMock.questDeclaration.upsert).toHaveBeenCalledTimes(2);
   });
 });

--- a/src/__tests__/api/quests/history.test.ts
+++ b/src/__tests__/api/quests/history.test.ts
@@ -1,11 +1,41 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { NextRequest } from "next/server";
 import { GET } from "@/app/api/quests/history/route";
-import { prisma } from "@/lib/prisma";
 import { getCurrentUser } from "@/lib/auth";
-import { parentUser, childUser } from "../../helpers/fixtures";
+import { prismaMock } from "../../helpers/prisma-mock";
+import { parentUserWithFamily, childUserWithFamily, questInstance, taskTemplate } from "../../helpers/fixtures";
+import type { Prisma } from "@/generated/prisma/client";
 
-const mockPrisma = vi.mocked(prisma);
+type HistoryInstance = Prisma.QuestInstanceGetPayload<{
+  include: {
+    child: { select: { id: true; name: true; monsterName: true; side: true } };
+    template: { select: { title: true; emoji: true; category: true; isActive: true; photoBonus: true } };
+  };
+}>;
+
+type HistoryTemplate = Prisma.TaskTemplateGetPayload<{
+  include: {
+    assignedChild: { select: { id: true; name: true; monsterName: true; side: true } };
+  };
+}>;
+
+/** questInstance.findMany(include: { child: {select...}, template: {select...} }) 相当 */
+function historyInstance(
+  overrides: Parameters<typeof questInstance>[0],
+  child: HistoryInstance["child"],
+  template: HistoryInstance["template"],
+): HistoryInstance {
+  return { ...questInstance(overrides), child, template };
+}
+
+/** taskTemplate.findMany(include: { assignedChild: {select...} }) 相当 */
+function historyTemplate(
+  overrides: Parameters<typeof taskTemplate>[0],
+  assignedChild: HistoryTemplate["assignedChild"],
+): HistoryTemplate {
+  return { ...taskTemplate(overrides), assignedChild };
+}
+
 const mockGetCurrentUser = vi.mocked(getCurrentUser);
 
 function makeRequest(params?: Record<string, string>) {
@@ -34,26 +64,26 @@ describe("GET /api/quests/history", () => {
   });
 
   it("CHILDロールの場合、空配列を返すこと", async () => {
-    mockGetCurrentUser.mockResolvedValue(childUser() as any);
+    mockGetCurrentUser.mockResolvedValue(childUserWithFamily());
     const res = await GET(makeRequest());
     expect(await res.json()).toEqual([]);
   });
 
   it("familyIdがない場合、空配列を返すこと", async () => {
-    mockGetCurrentUser.mockResolvedValue(parentUser({ familyId: null }) as any);
+    mockGetCurrentUser.mockResolvedValue(parentUserWithFamily({ familyId: null }));
     const res = await GET(makeRequest());
     expect(await res.json()).toEqual([]);
   });
 
   it("date未指定の場合、今日の日付でクエリすること", async () => {
-    mockGetCurrentUser.mockResolvedValue(parentUser() as any);
-    mockPrisma.questInstance.findMany.mockResolvedValue([] as any);
-    mockPrisma.taskTemplate.findMany.mockResolvedValue([] as any);
+    mockGetCurrentUser.mockResolvedValue(parentUserWithFamily());
+    prismaMock.questInstance.findMany.mockResolvedValue([]);
+    prismaMock.taskTemplate.findMany.mockResolvedValue([]);
 
     await GET(makeRequest());
 
     const today = new Date("2026-03-12T00:00:00Z");
-    expect(mockPrisma.questInstance.findMany).toHaveBeenCalledWith(
+    expect(prismaMock.questInstance.findMany).toHaveBeenCalledWith(
       expect.objectContaining({
         where: expect.objectContaining({ date: today }),
       })
@@ -61,14 +91,14 @@ describe("GET /api/quests/history", () => {
   });
 
   it("dateパラメータで指定した日付のデータを返すこと", async () => {
-    mockGetCurrentUser.mockResolvedValue(parentUser() as any);
-    mockPrisma.questInstance.findMany.mockResolvedValue([] as any);
-    mockPrisma.taskTemplate.findMany.mockResolvedValue([] as any);
+    mockGetCurrentUser.mockResolvedValue(parentUserWithFamily());
+    prismaMock.questInstance.findMany.mockResolvedValue([]);
+    prismaMock.taskTemplate.findMany.mockResolvedValue([]);
 
     await GET(makeRequest({ date: "2026-03-10" }));
 
     const targetDate = new Date("2026-03-10T00:00:00Z");
-    expect(mockPrisma.questInstance.findMany).toHaveBeenCalledWith(
+    expect(prismaMock.questInstance.findMany).toHaveBeenCalledWith(
       expect.objectContaining({
         where: expect.objectContaining({ date: targetDate }),
       })
@@ -76,26 +106,28 @@ describe("GET /api/quests/history", () => {
   });
 
   it("snapshotTitleがある場合、レスポンスのtemplate.titleにスナップショットを使用すること", async () => {
-    mockGetCurrentUser.mockResolvedValue(parentUser() as any);
-    mockPrisma.questInstance.findMany.mockResolvedValue([
-      {
-        id: "q1",
-        status: "APPROVED",
-        date: new Date("2026-03-12"),
-        approvedAt: new Date("2026-03-12T10:00:00"),
-        comment: null,
-        deadlineBonusEarned: false,
-        photoUrl: null,
-        snapshotTitle: "宿題（旧名）",
-        snapshotEmoji: "📖",
-        snapshotCategory: "LIFE",
-        templateId: "tpl-1",
-        childId: "child-1",
-        child: { id: "child-1", name: "太郎", monsterName: "ドラゴン", side: "LIGHT" },
-        template: { title: "宿題（新名）", emoji: "📚", category: "STUDY", isActive: true, photoBonus: false },
-      },
-    ] as any);
-    mockPrisma.taskTemplate.findMany.mockResolvedValue([] as any);
+    mockGetCurrentUser.mockResolvedValue(parentUserWithFamily());
+    prismaMock.questInstance.findMany.mockResolvedValue([
+      historyInstance(
+        {
+          id: "q1",
+          status: "APPROVED",
+          date: new Date("2026-03-12"),
+          approvedAt: new Date("2026-03-12T10:00:00"),
+          comment: null,
+          deadlineBonusEarned: false,
+          photoUrl: null,
+          snapshotTitle: "宿題（旧名）",
+          snapshotEmoji: "📖",
+          snapshotCategory: "LIFE",
+          templateId: "tpl-1",
+          childId: "child-1",
+        },
+        { id: "child-1", name: "太郎", monsterName: "ドラゴン", side: "LIGHT" },
+        { title: "宿題（新名）", emoji: "📚", category: "STUDY", isActive: true, photoBonus: false },
+      ),
+    ]);
+    prismaMock.taskTemplate.findMany.mockResolvedValue([]);
 
     const res = await GET(makeRequest({ date: "2026-03-12" }));
     const json = await res.json();
@@ -106,21 +138,28 @@ describe("GET /api/quests/history", () => {
   });
 
   it("APPROVEDクエストをそのまま返すこと", async () => {
-    mockGetCurrentUser.mockResolvedValue(parentUser() as any);
-    mockPrisma.questInstance.findMany.mockResolvedValue([
-      {
-        id: "q1",
-        status: "APPROVED",
-        date: new Date("2026-03-12"),
-        approvedAt: new Date("2026-03-12T10:00:00"),
-        comment: null,
-        templateId: "tpl-1",
-        childId: "child-1",
-        child: { id: "child-1", name: "太郎", monsterName: "ドラゴン", side: "LIGHT" },
-        template: { title: "宿題", emoji: "📚", category: "STUDY", isActive: true },
-      },
-    ] as any);
-    mockPrisma.taskTemplate.findMany.mockResolvedValue([] as any);
+    mockGetCurrentUser.mockResolvedValue(parentUserWithFamily());
+    // snapshotTitle/Emoji/Category は旧データを再現するため undefined にし、
+    // template フォールバック分岐のカバレッジを維持する
+    prismaMock.questInstance.findMany.mockResolvedValue([
+      historyInstance(
+        {
+          id: "q1",
+          status: "APPROVED",
+          date: new Date("2026-03-12"),
+          approvedAt: new Date("2026-03-12T10:00:00"),
+          comment: null,
+          templateId: "tpl-1",
+          childId: "child-1",
+          snapshotTitle: undefined,
+          snapshotEmoji: undefined,
+          snapshotCategory: undefined,
+        },
+        { id: "child-1", name: "太郎", monsterName: "ドラゴン", side: "LIGHT" },
+        { title: "宿題", emoji: "📚", category: "STUDY", isActive: true, photoBonus: false },
+      ),
+    ]);
+    prismaMock.taskTemplate.findMany.mockResolvedValue([]);
 
     const res = await GET(makeRequest({ date: "2026-03-12" }));
     const json = await res.json();
@@ -131,21 +170,26 @@ describe("GET /api/quests/history", () => {
   });
 
   it("SKIPPEDクエストをそのまま返すこと", async () => {
-    mockGetCurrentUser.mockResolvedValue(parentUser() as any);
-    mockPrisma.questInstance.findMany.mockResolvedValue([
-      {
-        id: "q2",
-        status: "SKIPPED",
-        date: new Date("2026-03-12"),
-        approvedAt: new Date("2026-03-12T11:00:00"),
-        comment: "体調不良",
-        templateId: "tpl-2",
-        childId: "child-1",
-        child: { id: "child-1", name: "太郎", monsterName: "ドラゴン", side: "LIGHT" },
-        template: { title: "運動", emoji: "🏃", category: "STAMINA", isActive: true },
-      },
-    ] as any);
-    mockPrisma.taskTemplate.findMany.mockResolvedValue([] as any);
+    mockGetCurrentUser.mockResolvedValue(parentUserWithFamily());
+    prismaMock.questInstance.findMany.mockResolvedValue([
+      historyInstance(
+        {
+          id: "q2",
+          status: "SKIPPED",
+          date: new Date("2026-03-12"),
+          approvedAt: new Date("2026-03-12T11:00:00"),
+          comment: "体調不良",
+          templateId: "tpl-2",
+          childId: "child-1",
+          snapshotTitle: undefined,
+          snapshotEmoji: undefined,
+          snapshotCategory: undefined,
+        },
+        { id: "child-1", name: "太郎", monsterName: "ドラゴン", side: "LIGHT" },
+        { title: "運動", emoji: "🏃", category: "STAMINA", isActive: true, photoBonus: false },
+      ),
+    ]);
+    prismaMock.taskTemplate.findMany.mockResolvedValue([]);
 
     const res = await GET(makeRequest({ date: "2026-03-12" }));
     const json = await res.json();
@@ -156,21 +200,26 @@ describe("GET /api/quests/history", () => {
   });
 
   it("PENDINGクエストはNO_ACTIONとして返すこと", async () => {
-    mockGetCurrentUser.mockResolvedValue(parentUser() as any);
-    mockPrisma.questInstance.findMany.mockResolvedValue([
-      {
-        id: "q3",
-        status: "PENDING",
-        date: new Date("2026-03-12"),
-        approvedAt: null,
-        comment: null,
-        templateId: "tpl-3",
-        childId: "child-1",
-        child: { id: "child-1", name: "太郎", monsterName: "ドラゴン", side: "LIGHT" },
-        template: { title: "読書", emoji: "📖", category: "STUDY", isActive: true },
-      },
-    ] as any);
-    mockPrisma.taskTemplate.findMany.mockResolvedValue([] as any);
+    mockGetCurrentUser.mockResolvedValue(parentUserWithFamily());
+    prismaMock.questInstance.findMany.mockResolvedValue([
+      historyInstance(
+        {
+          id: "q3",
+          status: "PENDING",
+          date: new Date("2026-03-12"),
+          approvedAt: null,
+          comment: null,
+          templateId: "tpl-3",
+          childId: "child-1",
+          snapshotTitle: undefined,
+          snapshotEmoji: undefined,
+          snapshotCategory: undefined,
+        },
+        { id: "child-1", name: "太郎", monsterName: "ドラゴン", side: "LIGHT" },
+        { title: "読書", emoji: "📖", category: "STUDY", isActive: true, photoBonus: false },
+      ),
+    ]);
+    prismaMock.taskTemplate.findMany.mockResolvedValue([]);
 
     const res = await GET(makeRequest({ date: "2026-03-12" }));
     const json = await res.json();
@@ -181,21 +230,26 @@ describe("GET /api/quests/history", () => {
   });
 
   it("REPORTEDクエストはNO_ACTIONとして返すこと", async () => {
-    mockGetCurrentUser.mockResolvedValue(parentUser() as any);
-    mockPrisma.questInstance.findMany.mockResolvedValue([
-      {
-        id: "q4",
-        status: "REPORTED",
-        date: new Date("2026-03-12"),
-        approvedAt: null,
-        comment: null,
-        templateId: "tpl-4",
-        childId: "child-1",
-        child: { id: "child-1", name: "太郎", monsterName: "ドラゴン", side: "LIGHT" },
-        template: { title: "片付け", emoji: "🧹", category: "LIFE", isActive: true },
-      },
-    ] as any);
-    mockPrisma.taskTemplate.findMany.mockResolvedValue([] as any);
+    mockGetCurrentUser.mockResolvedValue(parentUserWithFamily());
+    prismaMock.questInstance.findMany.mockResolvedValue([
+      historyInstance(
+        {
+          id: "q4",
+          status: "REPORTED",
+          date: new Date("2026-03-12"),
+          approvedAt: null,
+          comment: null,
+          templateId: "tpl-4",
+          childId: "child-1",
+          snapshotTitle: undefined,
+          snapshotEmoji: undefined,
+          snapshotCategory: undefined,
+        },
+        { id: "child-1", name: "太郎", monsterName: "ドラゴン", side: "LIGHT" },
+        { title: "片付け", emoji: "🧹", category: "LIFE", isActive: true, photoBonus: false },
+      ),
+    ]);
+    prismaMock.taskTemplate.findMany.mockResolvedValue([]);
 
     const res = await GET(makeRequest({ date: "2026-03-12" }));
     const json = await res.json();
@@ -205,18 +259,14 @@ describe("GET /api/quests/history", () => {
   });
 
   it("QuestInstanceのないテンプレートをNO_ACTIONとして返すこと", async () => {
-    mockGetCurrentUser.mockResolvedValue(parentUser() as any);
-    mockPrisma.questInstance.findMany.mockResolvedValue([] as any);
-    mockPrisma.taskTemplate.findMany.mockResolvedValue([
-      {
-        id: "tpl-5",
-        title: "お手伝い",
-        emoji: "🧹",
-        category: "LIFE",
-        assignedChildId: "child-1",
-        assignedChild: { id: "child-1", name: "太郎", monsterName: "ドラゴン", side: "LIGHT" },
-      },
-    ] as any);
+    mockGetCurrentUser.mockResolvedValue(parentUserWithFamily());
+    prismaMock.questInstance.findMany.mockResolvedValue([]);
+    prismaMock.taskTemplate.findMany.mockResolvedValue([
+      historyTemplate(
+        { id: "tpl-5", title: "お手伝い", emoji: "🧹", category: "LIFE", assignedChildId: "child-1" },
+        { id: "child-1", name: "太郎", monsterName: "ドラゴン", side: "LIGHT" },
+      ),
+    ]);
 
     const res = await GET(makeRequest({ date: "2026-03-12" }));
     const json = await res.json();
@@ -229,31 +279,32 @@ describe("GET /api/quests/history", () => {
   });
 
   it("すでにQuestInstanceがあるテンプレートはNO_ACTIONとして重複しないこと", async () => {
-    mockGetCurrentUser.mockResolvedValue(parentUser() as any);
-    mockPrisma.questInstance.findMany.mockResolvedValue([
-      {
-        id: "q5",
-        status: "PENDING",
-        date: new Date("2026-03-12"),
-        approvedAt: null,
-        comment: null,
-        templateId: "tpl-6",
-        childId: "child-1",
-        child: { id: "child-1", name: "太郎", monsterName: "ドラゴン", side: "LIGHT" },
-        template: { title: "宿題", emoji: "📚", category: "STUDY", isActive: true },
-      },
-    ] as any);
+    mockGetCurrentUser.mockResolvedValue(parentUserWithFamily());
+    prismaMock.questInstance.findMany.mockResolvedValue([
+      historyInstance(
+        {
+          id: "q5",
+          status: "PENDING",
+          date: new Date("2026-03-12"),
+          approvedAt: null,
+          comment: null,
+          templateId: "tpl-6",
+          childId: "child-1",
+          snapshotTitle: undefined,
+          snapshotEmoji: undefined,
+          snapshotCategory: undefined,
+        },
+        { id: "child-1", name: "太郎", monsterName: "ドラゴン", side: "LIGHT" },
+        { title: "宿題", emoji: "📚", category: "STUDY", isActive: true, photoBonus: false },
+      ),
+    ]);
     // Same template also returned by taskTemplate query
-    mockPrisma.taskTemplate.findMany.mockResolvedValue([
-      {
-        id: "tpl-6",
-        title: "宿題",
-        emoji: "📚",
-        category: "STUDY",
-        assignedChildId: "child-1",
-        assignedChild: { id: "child-1", name: "太郎", monsterName: "ドラゴン", side: "LIGHT" },
-      },
-    ] as any);
+    prismaMock.taskTemplate.findMany.mockResolvedValue([
+      historyTemplate(
+        { id: "tpl-6", title: "宿題", emoji: "📚", category: "STUDY", assignedChildId: "child-1" },
+        { id: "child-1", name: "太郎", monsterName: "ドラゴン", side: "LIGHT" },
+      ),
+    ]);
 
     const res = await GET(makeRequest({ date: "2026-03-12" }));
     const json = await res.json();
@@ -264,14 +315,14 @@ describe("GET /api/quests/history", () => {
   });
 
   it("正しい曜日でテンプレートをフィルタすること（2026-03-12は木曜=4）", async () => {
-    mockGetCurrentUser.mockResolvedValue(parentUser() as any);
-    mockPrisma.questInstance.findMany.mockResolvedValue([] as any);
-    mockPrisma.taskTemplate.findMany.mockResolvedValue([] as any);
+    mockGetCurrentUser.mockResolvedValue(parentUserWithFamily());
+    prismaMock.questInstance.findMany.mockResolvedValue([]);
+    prismaMock.taskTemplate.findMany.mockResolvedValue([]);
 
     // 2026-03-12 is Thursday (day 4)
     await GET(makeRequest({ date: "2026-03-12" }));
 
-    expect(mockPrisma.taskTemplate.findMany).toHaveBeenCalledWith(
+    expect(prismaMock.taskTemplate.findMany).toHaveBeenCalledWith(
       expect.objectContaining({
         where: expect.objectContaining({
           familyId: "fam-1",
@@ -284,13 +335,13 @@ describe("GET /api/quests/history", () => {
   });
 
   it("familyIdでQuestInstanceをフィルタすること", async () => {
-    mockGetCurrentUser.mockResolvedValue(parentUser() as any);
-    mockPrisma.questInstance.findMany.mockResolvedValue([] as any);
-    mockPrisma.taskTemplate.findMany.mockResolvedValue([] as any);
+    mockGetCurrentUser.mockResolvedValue(parentUserWithFamily());
+    prismaMock.questInstance.findMany.mockResolvedValue([]);
+    prismaMock.taskTemplate.findMany.mockResolvedValue([]);
 
     await GET(makeRequest({ date: "2026-03-12" }));
 
-    expect(mockPrisma.questInstance.findMany).toHaveBeenCalledWith(
+    expect(prismaMock.questInstance.findMany).toHaveBeenCalledWith(
       expect.objectContaining({
         where: expect.objectContaining({
           template: { familyId: "fam-1" },
@@ -300,10 +351,10 @@ describe("GET /api/quests/history", () => {
   });
 
   it("削除済みテンプレート（isActive:false）でQuestInstanceがない場合はNO_ACTIONに含めないこと", async () => {
-    mockGetCurrentUser.mockResolvedValue(parentUser() as any);
-    mockPrisma.questInstance.findMany.mockResolvedValue([] as any);
+    mockGetCurrentUser.mockResolvedValue(parentUserWithFamily());
+    prismaMock.questInstance.findMany.mockResolvedValue([]);
     // テンプレートクエリはisActive:trueのみ返すので、削除済みは含まれない
-    mockPrisma.taskTemplate.findMany.mockResolvedValue([] as any);
+    prismaMock.taskTemplate.findMany.mockResolvedValue([]);
 
     const res = await GET(makeRequest({ date: "2026-03-12" }));
     const json = await res.json();
@@ -312,32 +363,37 @@ describe("GET /api/quests/history", () => {
   });
 
   it("テンプレートクエリでisActive:trueでフィルタすること", async () => {
-    mockGetCurrentUser.mockResolvedValue(parentUser() as any);
-    mockPrisma.questInstance.findMany.mockResolvedValue([] as any);
-    mockPrisma.taskTemplate.findMany.mockResolvedValue([] as any);
+    mockGetCurrentUser.mockResolvedValue(parentUserWithFamily());
+    prismaMock.questInstance.findMany.mockResolvedValue([]);
+    prismaMock.taskTemplate.findMany.mockResolvedValue([]);
 
     await GET(makeRequest({ date: "2026-03-12" }));
 
-    const call = mockPrisma.taskTemplate.findMany.mock.calls[0][0] as any;
-    expect(call.where.isActive).toBe(true);
+    const call = prismaMock.taskTemplate.findMany.mock.calls[0][0];
+    expect(call?.where?.isActive).toBe(true);
   });
 
   it("削除済みテンプレート（isActive:false）のAPPROVEDクエストは表示すること", async () => {
-    mockGetCurrentUser.mockResolvedValue(parentUser() as any);
-    mockPrisma.questInstance.findMany.mockResolvedValue([
-      {
-        id: "q-approved-deleted",
-        status: "APPROVED",
-        date: new Date("2026-03-12"),
-        approvedAt: new Date("2026-03-12T10:00:00"),
-        comment: null,
-        templateId: "tpl-del",
-        childId: "child-1",
-        child: { id: "child-1", name: "太郎", monsterName: "ドラゴン", side: "LIGHT" },
-        template: { title: "削除タスク", emoji: "🗑️", category: "LIFE", isActive: false },
-      },
-    ] as any);
-    mockPrisma.taskTemplate.findMany.mockResolvedValue([] as any);
+    mockGetCurrentUser.mockResolvedValue(parentUserWithFamily());
+    prismaMock.questInstance.findMany.mockResolvedValue([
+      historyInstance(
+        {
+          id: "q-approved-deleted",
+          status: "APPROVED",
+          date: new Date("2026-03-12"),
+          approvedAt: new Date("2026-03-12T10:00:00"),
+          comment: null,
+          templateId: "tpl-del",
+          childId: "child-1",
+          snapshotTitle: undefined,
+          snapshotEmoji: undefined,
+          snapshotCategory: undefined,
+        },
+        { id: "child-1", name: "太郎", monsterName: "ドラゴン", side: "LIGHT" },
+        { title: "削除タスク", emoji: "🗑️", category: "LIFE", isActive: false, photoBonus: false },
+      ),
+    ]);
+    prismaMock.taskTemplate.findMany.mockResolvedValue([]);
 
     const res = await GET(makeRequest({ date: "2026-03-12" }));
     const json = await res.json();
@@ -347,21 +403,26 @@ describe("GET /api/quests/history", () => {
   });
 
   it("削除済みテンプレート（isActive:false）のSKIPPEDクエストも表示すること", async () => {
-    mockGetCurrentUser.mockResolvedValue(parentUser() as any);
-    mockPrisma.questInstance.findMany.mockResolvedValue([
-      {
-        id: "q-skipped-deleted",
-        status: "SKIPPED",
-        date: new Date("2026-03-12"),
-        approvedAt: new Date("2026-03-12T10:00:00"),
-        comment: null,
-        templateId: "tpl-del",
-        childId: "child-1",
-        child: { id: "child-1", name: "太郎", monsterName: "ドラゴン", side: "LIGHT" },
-        template: { title: "削除タスク", emoji: "🗑️", category: "LIFE", isActive: false },
-      },
-    ] as any);
-    mockPrisma.taskTemplate.findMany.mockResolvedValue([] as any);
+    mockGetCurrentUser.mockResolvedValue(parentUserWithFamily());
+    prismaMock.questInstance.findMany.mockResolvedValue([
+      historyInstance(
+        {
+          id: "q-skipped-deleted",
+          status: "SKIPPED",
+          date: new Date("2026-03-12"),
+          approvedAt: new Date("2026-03-12T10:00:00"),
+          comment: null,
+          templateId: "tpl-del",
+          childId: "child-1",
+          snapshotTitle: undefined,
+          snapshotEmoji: undefined,
+          snapshotCategory: undefined,
+        },
+        { id: "child-1", name: "太郎", monsterName: "ドラゴン", side: "LIGHT" },
+        { title: "削除タスク", emoji: "🗑️", category: "LIFE", isActive: false, photoBonus: false },
+      ),
+    ]);
+    prismaMock.taskTemplate.findMany.mockResolvedValue([]);
 
     const res = await GET(makeRequest({ date: "2026-03-12" }));
     const json = await res.json();
@@ -372,21 +433,26 @@ describe("GET /api/quests/history", () => {
   });
 
   it("削除済みテンプレート（isActive:false）のPENDINGクエストは表示しないこと", async () => {
-    mockGetCurrentUser.mockResolvedValue(parentUser() as any);
-    mockPrisma.questInstance.findMany.mockResolvedValue([
-      {
-        id: "q-pending-deleted",
-        status: "PENDING",
-        date: new Date("2026-03-12"),
-        approvedAt: null,
-        comment: null,
-        templateId: "tpl-del",
-        childId: "child-1",
-        child: { id: "child-1", name: "太郎", monsterName: "ドラゴン", side: "LIGHT" },
-        template: { title: "削除タスク", emoji: "🗑️", category: "LIFE", isActive: false },
-      },
-    ] as any);
-    mockPrisma.taskTemplate.findMany.mockResolvedValue([] as any);
+    mockGetCurrentUser.mockResolvedValue(parentUserWithFamily());
+    prismaMock.questInstance.findMany.mockResolvedValue([
+      historyInstance(
+        {
+          id: "q-pending-deleted",
+          status: "PENDING",
+          date: new Date("2026-03-12"),
+          approvedAt: null,
+          comment: null,
+          templateId: "tpl-del",
+          childId: "child-1",
+          snapshotTitle: undefined,
+          snapshotEmoji: undefined,
+          snapshotCategory: undefined,
+        },
+        { id: "child-1", name: "太郎", monsterName: "ドラゴン", side: "LIGHT" },
+        { title: "削除タスク", emoji: "🗑️", category: "LIFE", isActive: false, photoBonus: false },
+      ),
+    ]);
+    prismaMock.taskTemplate.findMany.mockResolvedValue([]);
 
     const res = await GET(makeRequest({ date: "2026-03-12" }));
     const json = await res.json();
@@ -395,15 +461,15 @@ describe("GET /api/quests/history", () => {
   });
 
   it("対象日より後に作成されたテンプレートはNO_ACTIONに含まれないこと", async () => {
-    mockGetCurrentUser.mockResolvedValue(parentUser() as any);
-    mockPrisma.questInstance.findMany.mockResolvedValue([] as any);
-    mockPrisma.taskTemplate.findMany.mockResolvedValue([] as any);
+    mockGetCurrentUser.mockResolvedValue(parentUserWithFamily());
+    prismaMock.questInstance.findMany.mockResolvedValue([]);
+    prismaMock.taskTemplate.findMany.mockResolvedValue([]);
 
     // 2026-03-10 を対象日とする
     await GET(makeRequest({ date: "2026-03-10" }));
 
     const nextDay = new Date("2026-03-11T00:00:00Z");
-    expect(mockPrisma.taskTemplate.findMany).toHaveBeenCalledWith(
+    expect(prismaMock.taskTemplate.findMany).toHaveBeenCalledWith(
       expect.objectContaining({
         where: expect.objectContaining({
           createdAt: { lt: nextDay },

--- a/src/__tests__/api/quests/monthly-summary.test.ts
+++ b/src/__tests__/api/quests/monthly-summary.test.ts
@@ -1,11 +1,20 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { NextRequest } from "next/server";
 import { GET } from "@/app/api/quests/monthly-summary/route";
-import { prisma } from "@/lib/prisma";
 import { getCurrentUser } from "@/lib/auth";
-import { parentUser, childUser } from "../../helpers/fixtures";
+import { prismaMock } from "../../helpers/prisma-mock";
+import { parentUserWithFamily, childUserWithFamily, questInstance } from "../../helpers/fixtures";
+/**
+ * questInstance.findMany(select: { date, status, deadlineBonusEarned, photoUrl,
+ * template: { select: { photoBonus } } }) 相当。
+ * DeepMockProxy の mockResolvedValue は select 限定の Prisma.XGetPayload ではなく
+ * ベースの QuestInstance 完全型を要求するため、questInstance() フィクスチャで
+ * 他フィールドを埋めた上で template select を追加する。
+ */
+function monthlyInstance(overrides: Parameters<typeof questInstance>[0], photoBonus: boolean) {
+  return { ...questInstance(overrides), template: { photoBonus } };
+}
 
-const mockPrisma = vi.mocked(prisma);
 const mockGetCurrentUser = vi.mocked(getCurrentUser);
 
 function makeRequest(params: Record<string, string> = {}) {
@@ -30,74 +39,65 @@ describe("GET /api/quests/monthly-summary", () => {
   });
 
   it("CHILDロールの場合、空レスポンスを返すこと", async () => {
-    mockGetCurrentUser.mockResolvedValue(childUser() as any);
+    mockGetCurrentUser.mockResolvedValue(childUserWithFamily());
     const res = await GET(makeRequest({ year: "2026", month: "4", childId: "child-1" }));
     const json = await res.json();
     expect(json.achievedDays).toBe(0);
   });
 
   it("familyIdがない場合、空レスポンスを返すこと", async () => {
-    mockGetCurrentUser.mockResolvedValue(parentUser({ familyId: null }) as any);
+    mockGetCurrentUser.mockResolvedValue(parentUserWithFamily({ familyId: null }));
     const res = await GET(makeRequest({ year: "2026", month: "4", childId: "child-1" }));
     const json = await res.json();
     expect(json.achievedDays).toBe(0);
   });
 
   it("childIdが欠けている場合、400を返すこと", async () => {
-    mockGetCurrentUser.mockResolvedValue(parentUser() as any);
+    mockGetCurrentUser.mockResolvedValue(parentUserWithFamily());
     const res = await GET(makeRequest({ year: "2026", month: "4" }));
     expect(res.status).toBe(400);
   });
 
   it("yearが欠けている場合、400を返すこと", async () => {
-    mockGetCurrentUser.mockResolvedValue(parentUser() as any);
+    mockGetCurrentUser.mockResolvedValue(parentUserWithFamily());
     const res = await GET(makeRequest({ month: "4", childId: "child-1" }));
     expect(res.status).toBe(400);
   });
 
   it("monthが欠けている場合、400を返すこと", async () => {
-    mockGetCurrentUser.mockResolvedValue(parentUser() as any);
+    mockGetCurrentUser.mockResolvedValue(parentUserWithFamily());
     const res = await GET(makeRequest({ year: "2026", childId: "child-1" }));
     expect(res.status).toBe(400);
   });
 
   it("monthが13の場合（範囲外）、400を返すこと", async () => {
-    mockGetCurrentUser.mockResolvedValue(parentUser() as any);
+    mockGetCurrentUser.mockResolvedValue(parentUserWithFamily());
     const res = await GET(makeRequest({ year: "2026", month: "13", childId: "child-1" }));
     expect(res.status).toBe(400);
   });
 
   it("monthが0の場合（範囲外）、400を返すこと", async () => {
-    mockGetCurrentUser.mockResolvedValue(parentUser() as any);
+    mockGetCurrentUser.mockResolvedValue(parentUserWithFamily());
     const res = await GET(makeRequest({ year: "2026", month: "0", childId: "child-1" }));
     expect(res.status).toBe(400);
   });
 
   it("APPROVEDクエストを日別に集計すること", async () => {
-    mockGetCurrentUser.mockResolvedValue(parentUser() as any);
-    mockPrisma.questInstance.findMany.mockResolvedValue([
-      {
-        date: new Date("2026-04-01T00:00:00Z"),
-        status: "APPROVED",
-        deadlineBonusEarned: false,
-        photoUrl: null,
-        template: { photoBonus: false },
-      },
-      {
-        date: new Date("2026-04-01T00:00:00Z"),
-        status: "APPROVED",
-        deadlineBonusEarned: false,
-        photoUrl: null,
-        template: { photoBonus: false },
-      },
-      {
-        date: new Date("2026-04-02T00:00:00Z"),
-        status: "APPROVED",
-        deadlineBonusEarned: false,
-        photoUrl: null,
-        template: { photoBonus: false },
-      },
-    ] as any);
+    mockGetCurrentUser.mockResolvedValue(parentUserWithFamily());
+    prismaMock.questInstance.findMany.mockResolvedValue([
+      monthlyInstance(
+        { date: new Date("2026-04-01T00:00:00Z"), status: "APPROVED", deadlineBonusEarned: false, photoUrl: null },
+        false,
+      ),
+      monthlyInstance(
+        { date: new Date("2026-04-01T00:00:00Z"), status: "APPROVED", deadlineBonusEarned: false, photoUrl: null },
+        false,
+      ),
+      monthlyInstance(
+        { date: new Date("2026-04-02T00:00:00Z"), status: "APPROVED", deadlineBonusEarned: false, photoUrl: null },
+        false,
+      ),
+    ]);
 
     const res = await GET(makeRequest({ year: "2026", month: "4", childId: "child-1" }));
     const json = await res.json();
@@ -111,16 +111,13 @@ describe("GET /api/quests/monthly-summary", () => {
   });
 
   it("SKIPPEDクエストを日別に集計すること", async () => {
-    mockGetCurrentUser.mockResolvedValue(parentUser() as any);
-    mockPrisma.questInstance.findMany.mockResolvedValue([
-      {
-        date: new Date("2026-04-03T00:00:00Z"),
-        status: "SKIPPED",
-        deadlineBonusEarned: false,
-        photoUrl: null,
-        template: { photoBonus: false },
-      },
-    ] as any);
+    mockGetCurrentUser.mockResolvedValue(parentUserWithFamily());
+    prismaMock.questInstance.findMany.mockResolvedValue([
+      monthlyInstance(
+        { date: new Date("2026-04-03T00:00:00Z"), status: "SKIPPED", deadlineBonusEarned: false, photoUrl: null },
+        false,
+      ),
+    ]);
 
     const res = await GET(makeRequest({ year: "2026", month: "4", childId: "child-1" }));
     const json = await res.json();
@@ -131,23 +128,17 @@ describe("GET /api/quests/monthly-summary", () => {
   });
 
   it("PENDINGはtotalにカウントされapproved/skippedにはカウントされないこと", async () => {
-    mockGetCurrentUser.mockResolvedValue(parentUser() as any);
-    mockPrisma.questInstance.findMany.mockResolvedValue([
-      {
-        date: new Date("2026-04-01T00:00:00Z"),
-        status: "APPROVED",
-        deadlineBonusEarned: false,
-        photoUrl: null,
-        template: { photoBonus: false },
-      },
-      {
-        date: new Date("2026-04-01T00:00:00Z"),
-        status: "PENDING",
-        deadlineBonusEarned: false,
-        photoUrl: null,
-        template: { photoBonus: false },
-      },
-    ] as any);
+    mockGetCurrentUser.mockResolvedValue(parentUserWithFamily());
+    prismaMock.questInstance.findMany.mockResolvedValue([
+      monthlyInstance(
+        { date: new Date("2026-04-01T00:00:00Z"), status: "APPROVED", deadlineBonusEarned: false, photoUrl: null },
+        false,
+      ),
+      monthlyInstance(
+        { date: new Date("2026-04-01T00:00:00Z"), status: "PENDING", deadlineBonusEarned: false, photoUrl: null },
+        false,
+      ),
+    ]);
 
     const res = await GET(makeRequest({ year: "2026", month: "4", childId: "child-1" }));
     const json = await res.json();
@@ -158,23 +149,17 @@ describe("GET /api/quests/monthly-summary", () => {
   });
 
   it("REPORTED/SKIP_REPORTEDもtotalにカウントされること", async () => {
-    mockGetCurrentUser.mockResolvedValue(parentUser() as any);
-    mockPrisma.questInstance.findMany.mockResolvedValue([
-      {
-        date: new Date("2026-04-02T00:00:00Z"),
-        status: "REPORTED",
-        deadlineBonusEarned: false,
-        photoUrl: null,
-        template: { photoBonus: false },
-      },
-      {
-        date: new Date("2026-04-02T00:00:00Z"),
-        status: "SKIP_REPORTED",
-        deadlineBonusEarned: false,
-        photoUrl: null,
-        template: { photoBonus: false },
-      },
-    ] as any);
+    mockGetCurrentUser.mockResolvedValue(parentUserWithFamily());
+    prismaMock.questInstance.findMany.mockResolvedValue([
+      monthlyInstance(
+        { date: new Date("2026-04-02T00:00:00Z"), status: "REPORTED", deadlineBonusEarned: false, photoUrl: null },
+        false,
+      ),
+      monthlyInstance(
+        { date: new Date("2026-04-02T00:00:00Z"), status: "SKIP_REPORTED", deadlineBonusEarned: false, photoUrl: null },
+        false,
+      ),
+    ]);
 
     const res = await GET(makeRequest({ year: "2026", month: "4", childId: "child-1" }));
     const json = await res.json();
@@ -185,22 +170,19 @@ describe("GET /api/quests/monthly-summary", () => {
   });
 
   it("REJECTEDはtotalにカウントされないこと（無効化されたタスク）", async () => {
-    mockGetCurrentUser.mockResolvedValue(parentUser() as any);
+    mockGetCurrentUser.mockResolvedValue(parentUserWithFamily());
     // REJECTEDはクエリで除外されるためmockには含まれない想定
     // クエリにstatus: { notIn: ["REJECTED"] }が含まれることを確認
-    mockPrisma.questInstance.findMany.mockResolvedValue([
-      {
-        date: new Date("2026-04-01T00:00:00Z"),
-        status: "APPROVED",
-        deadlineBonusEarned: false,
-        photoUrl: null,
-        template: { photoBonus: false },
-      },
-    ] as any);
+    prismaMock.questInstance.findMany.mockResolvedValue([
+      monthlyInstance(
+        { date: new Date("2026-04-01T00:00:00Z"), status: "APPROVED", deadlineBonusEarned: false, photoUrl: null },
+        false,
+      ),
+    ]);
 
     await GET(makeRequest({ year: "2026", month: "4", childId: "child-1" }));
 
-    expect(mockPrisma.questInstance.findMany).toHaveBeenCalledWith(
+    expect(prismaMock.questInstance.findMany).toHaveBeenCalledWith(
       expect.objectContaining({
         where: expect.objectContaining({
           status: { notIn: ["REJECTED"] },
@@ -210,38 +192,26 @@ describe("GET /api/quests/monthly-summary", () => {
   });
 
   it("achievedDaysはapproved >= 1の日数のみをカウントすること（SKIPPEDのみの日は含まない）", async () => {
-    mockGetCurrentUser.mockResolvedValue(parentUser() as any);
-    mockPrisma.questInstance.findMany.mockResolvedValue([
-      {
-        date: new Date("2026-04-01T00:00:00Z"),
-        status: "APPROVED",
-        deadlineBonusEarned: false,
-        photoUrl: null,
-        template: { photoBonus: false },
-      },
-      {
-        date: new Date("2026-04-01T00:00:00Z"),
-        status: "APPROVED",
-        deadlineBonusEarned: false,
-        photoUrl: null,
-        template: { photoBonus: false },
-      },
-      {
-        date: new Date("2026-04-03T00:00:00Z"),
-        status: "APPROVED",
-        deadlineBonusEarned: false,
-        photoUrl: null,
-        template: { photoBonus: false },
-      },
-      {
-        // SKIPPEDのみの日は達成にカウントしない
-        date: new Date("2026-04-05T00:00:00Z"),
-        status: "SKIPPED",
-        deadlineBonusEarned: false,
-        photoUrl: null,
-        template: { photoBonus: false },
-      },
-    ] as any);
+    mockGetCurrentUser.mockResolvedValue(parentUserWithFamily());
+    prismaMock.questInstance.findMany.mockResolvedValue([
+      monthlyInstance(
+        { date: new Date("2026-04-01T00:00:00Z"), status: "APPROVED", deadlineBonusEarned: false, photoUrl: null },
+        false,
+      ),
+      monthlyInstance(
+        { date: new Date("2026-04-01T00:00:00Z"), status: "APPROVED", deadlineBonusEarned: false, photoUrl: null },
+        false,
+      ),
+      monthlyInstance(
+        { date: new Date("2026-04-03T00:00:00Z"), status: "APPROVED", deadlineBonusEarned: false, photoUrl: null },
+        false,
+      ),
+      // SKIPPEDのみの日は達成にカウントしない
+      monthlyInstance(
+        { date: new Date("2026-04-05T00:00:00Z"), status: "SKIPPED", deadlineBonusEarned: false, photoUrl: null },
+        false,
+      ),
+    ]);
 
     const res = await GET(makeRequest({ year: "2026", month: "4", childId: "child-1" }));
     const json = await res.json();
@@ -250,25 +220,24 @@ describe("GET /api/quests/monthly-summary", () => {
   });
 
   it("totalXpをcalcActualXPで正しく計算すること（期限ボーナス+写真ボーナス）", async () => {
-    mockGetCurrentUser.mockResolvedValue(parentUser() as any);
-    mockPrisma.questInstance.findMany.mockResolvedValue([
-      {
-        // +3pt: base(1) + deadline(1) + photo(1)
-        date: new Date("2026-04-01T00:00:00Z"),
-        status: "APPROVED",
-        deadlineBonusEarned: true,
-        photoUrl: "https://example.com/photo.jpg",
-        template: { photoBonus: true },
-      },
-      {
-        // +1pt: base(1)
-        date: new Date("2026-04-01T00:00:00Z"),
-        status: "APPROVED",
-        deadlineBonusEarned: false,
-        photoUrl: null,
-        template: { photoBonus: false },
-      },
-    ] as any);
+    mockGetCurrentUser.mockResolvedValue(parentUserWithFamily());
+    prismaMock.questInstance.findMany.mockResolvedValue([
+      // +3pt: base(1) + deadline(1) + photo(1)
+      monthlyInstance(
+        {
+          date: new Date("2026-04-01T00:00:00Z"),
+          status: "APPROVED",
+          deadlineBonusEarned: true,
+          photoUrl: "https://example.com/photo.jpg",
+        },
+        true,
+      ),
+      // +1pt: base(1)
+      monthlyInstance(
+        { date: new Date("2026-04-01T00:00:00Z"), status: "APPROVED", deadlineBonusEarned: false, photoUrl: null },
+        false,
+      ),
+    ]);
 
     const res = await GET(makeRequest({ year: "2026", month: "4", childId: "child-1" }));
     const json = await res.json();
@@ -277,16 +246,13 @@ describe("GET /api/quests/monthly-summary", () => {
   });
 
   it("SKIPPEDクエストのXPはカウントしないこと", async () => {
-    mockGetCurrentUser.mockResolvedValue(parentUser() as any);
-    mockPrisma.questInstance.findMany.mockResolvedValue([
-      {
-        date: new Date("2026-04-01T00:00:00Z"),
-        status: "SKIPPED",
-        deadlineBonusEarned: false,
-        photoUrl: null,
-        template: { photoBonus: false },
-      },
-    ] as any);
+    mockGetCurrentUser.mockResolvedValue(parentUserWithFamily());
+    prismaMock.questInstance.findMany.mockResolvedValue([
+      monthlyInstance(
+        { date: new Date("2026-04-01T00:00:00Z"), status: "SKIPPED", deadlineBonusEarned: false, photoUrl: null },
+        false,
+      ),
+    ]);
 
     const res = await GET(makeRequest({ year: "2026", month: "4", childId: "child-1" }));
     const json = await res.json();
@@ -295,12 +261,12 @@ describe("GET /api/quests/monthly-summary", () => {
   });
 
   it("月の範囲（4月なら4/1〜4/30、5/1は含まない）でクエリすること", async () => {
-    mockGetCurrentUser.mockResolvedValue(parentUser() as any);
-    mockPrisma.questInstance.findMany.mockResolvedValue([] as any);
+    mockGetCurrentUser.mockResolvedValue(parentUserWithFamily());
+    prismaMock.questInstance.findMany.mockResolvedValue([]);
 
     await GET(makeRequest({ year: "2026", month: "4", childId: "child-1" }));
 
-    expect(mockPrisma.questInstance.findMany).toHaveBeenCalledWith(
+    expect(prismaMock.questInstance.findMany).toHaveBeenCalledWith(
       expect.objectContaining({
         where: expect.objectContaining({
           date: {
@@ -313,12 +279,12 @@ describe("GET /api/quests/monthly-summary", () => {
   });
 
   it("2月（28日）の月末範囲が正しいこと", async () => {
-    mockGetCurrentUser.mockResolvedValue(parentUser() as any);
-    mockPrisma.questInstance.findMany.mockResolvedValue([] as any);
+    mockGetCurrentUser.mockResolvedValue(parentUserWithFamily());
+    prismaMock.questInstance.findMany.mockResolvedValue([]);
 
     await GET(makeRequest({ year: "2026", month: "2", childId: "child-1" }));
 
-    expect(mockPrisma.questInstance.findMany).toHaveBeenCalledWith(
+    expect(prismaMock.questInstance.findMany).toHaveBeenCalledWith(
       expect.objectContaining({
         where: expect.objectContaining({
           date: {
@@ -331,12 +297,12 @@ describe("GET /api/quests/monthly-summary", () => {
   });
 
   it("familyIdでテンプレートをフィルタすること", async () => {
-    mockGetCurrentUser.mockResolvedValue(parentUser() as any);
-    mockPrisma.questInstance.findMany.mockResolvedValue([] as any);
+    mockGetCurrentUser.mockResolvedValue(parentUserWithFamily());
+    prismaMock.questInstance.findMany.mockResolvedValue([]);
 
     await GET(makeRequest({ year: "2026", month: "4", childId: "child-1" }));
 
-    expect(mockPrisma.questInstance.findMany).toHaveBeenCalledWith(
+    expect(prismaMock.questInstance.findMany).toHaveBeenCalledWith(
       expect.objectContaining({
         where: expect.objectContaining({
           childId: "child-1",
@@ -347,8 +313,8 @@ describe("GET /api/quests/monthly-summary", () => {
   });
 
   it("データなしの場合、空のdaysと0の統計を返すこと", async () => {
-    mockGetCurrentUser.mockResolvedValue(parentUser() as any);
-    mockPrisma.questInstance.findMany.mockResolvedValue([] as any);
+    mockGetCurrentUser.mockResolvedValue(parentUserWithFamily());
+    prismaMock.questInstance.findMany.mockResolvedValue([]);
 
     const res = await GET(makeRequest({ year: "2026", month: "4", childId: "child-1" }));
     const json = await res.json();

--- a/src/__tests__/api/quests/skip.test.ts
+++ b/src/__tests__/api/quests/skip.test.ts
@@ -1,12 +1,13 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { after } from "next/server";
 import { POST } from "@/app/api/quests/[id]/skip/route";
-import { prisma } from "@/lib/prisma";
 import { getCurrentUser } from "@/lib/auth";
 import { triggerTaskProgressLog } from "@/lib/bulletinLog";
 import { generateTreasuresOnReport } from "@/lib/treasureService";
 import { makeParams } from "../../helpers/request";
-import { childUser, questInstance } from "../../helpers/fixtures";
+import { prismaMock } from "../../helpers/prisma-mock";
+import { childUserWithFamily, questInstance, taskTemplate } from "../../helpers/fixtures";
+import type { Prisma } from "@/generated/prisma/client";
 
 vi.mock("@/lib/bulletinLog", () => ({
   triggerTaskProgressLog: vi.fn().mockResolvedValue(undefined),
@@ -16,7 +17,8 @@ vi.mock("@/lib/treasureService", () => ({
   generateTreasuresOnReport: vi.fn().mockResolvedValue([]),
 }));
 
-const mockPrisma = vi.mocked(prisma);
+type SkipQuest = Prisma.QuestInstanceGetPayload<{ include: { template: true } }>;
+
 const mockGetCurrentUser = vi.mocked(getCurrentUser);
 const mockTriggerTaskProgressLog = vi.mocked(triggerTaskProgressLog);
 const mockAfter = vi.mocked(after);
@@ -24,7 +26,7 @@ const mockGenerateTreasures = vi.mocked(generateTreasuresOnReport);
 
 beforeEach(() => {
   vi.clearAllMocks();
-  mockPrisma.questInstance.findMany.mockResolvedValue([]);
+  prismaMock.questInstance.findMany.mockResolvedValue([]);
   mockGenerateTreasures.mockResolvedValue([]);
 });
 
@@ -36,6 +38,14 @@ function makeSkipRequest(body: { comment?: string } = { comment: "体調が悪�
   });
 }
 
+/** findUnique(include: { template: true }) 相当。デフォルトは非 carryOver のテンプレート。 */
+function skipQuest(overrides: Parameters<typeof questInstance>[0], templateOverrides?: Parameters<typeof taskTemplate>[0]): SkipQuest {
+  return {
+    ...questInstance(overrides),
+    template: taskTemplate(templateOverrides),
+  };
+}
+
 describe("POST /api/quests/[id]/skip", () => {
   it("未認証の場合、401を返すこと", async () => {
     mockGetCurrentUser.mockResolvedValue(null);
@@ -44,39 +54,39 @@ describe("POST /api/quests/[id]/skip", () => {
   });
 
   it("存在しないクエストで404を返すこと", async () => {
-    mockGetCurrentUser.mockResolvedValue(childUser() as any);
-    mockPrisma.questInstance.findUnique.mockResolvedValue(null);
+    mockGetCurrentUser.mockResolvedValue(childUserWithFamily());
+    prismaMock.questInstance.findUnique.mockResolvedValue(null);
 
     const res = await POST(makeSkipRequest(), makeParams("q-none"));
     expect(res.status).toBe(404);
   });
 
   it("コメントなしの場合、400を返すこと", async () => {
-    mockGetCurrentUser.mockResolvedValue(childUser() as any);
+    mockGetCurrentUser.mockResolvedValue(childUserWithFamily());
     const res = await POST(makeSkipRequest({ comment: "" }), makeParams("q1"));
     expect(res.status).toBe(400);
-    expect(mockPrisma.questInstance.update).not.toHaveBeenCalled();
+    expect(prismaMock.questInstance.update).not.toHaveBeenCalled();
   });
 
   it("コメントがない（bodyなし）場合、400を返すこと", async () => {
-    mockGetCurrentUser.mockResolvedValue(childUser() as any);
+    mockGetCurrentUser.mockResolvedValue(childUserWithFamily());
     const req = new Request("http://localhost/api/quests/q1/skip", { method: "POST" });
     const res = await POST(req, makeParams("q1"));
     expect(res.status).toBe(400);
   });
 
   it("PENDINGのクエストをSKIP_REPORTEDに更新しコメントを保存すること", async () => {
-    mockGetCurrentUser.mockResolvedValue(childUser() as any);
-    mockPrisma.questInstance.findUnique.mockResolvedValue(
-      questInstance({ id: "q1", status: "PENDING" }) as any,
+    mockGetCurrentUser.mockResolvedValue(childUserWithFamily());
+    prismaMock.questInstance.findUnique.mockResolvedValue(
+      skipQuest({ id: "q1", status: "PENDING" }),
     );
-    mockPrisma.questInstance.update.mockResolvedValue({} as any);
+    prismaMock.questInstance.update.mockResolvedValue(questInstance({ id: "q1", status: "SKIP_REPORTED" }));
 
     const res = await POST(makeSkipRequest({ comment: "体調が悪い" }), makeParams("q1"));
     const json = await res.json();
 
     expect(json.ok).toBe(true);
-    expect(mockPrisma.questInstance.update).toHaveBeenCalledWith({
+    expect(prismaMock.questInstance.update).toHaveBeenCalledWith({
       where: { id: "q1" },
       data: {
         status: "SKIP_REPORTED",
@@ -88,20 +98,20 @@ describe("POST /api/quests/[id]/skip", () => {
   });
 
   it("REPORTED のクエストは400を返すこと（親承認待ち中はスキップ不可）", async () => {
-    mockGetCurrentUser.mockResolvedValue(childUser() as any);
-    mockPrisma.questInstance.findUnique.mockResolvedValue(
-      questInstance({ id: "q2", status: "REPORTED" }) as any,
+    mockGetCurrentUser.mockResolvedValue(childUserWithFamily());
+    prismaMock.questInstance.findUnique.mockResolvedValue(
+      skipQuest({ id: "q2", status: "REPORTED" }),
     );
 
     const res = await POST(makeSkipRequest(), makeParams("q2"));
     expect(res.status).toBe(400);
-    expect(mockPrisma.questInstance.update).not.toHaveBeenCalled();
+    expect(prismaMock.questInstance.update).not.toHaveBeenCalled();
   });
 
   it("APPROVEDのクエストもスキップできないこと", async () => {
-    mockGetCurrentUser.mockResolvedValue(childUser() as any);
-    mockPrisma.questInstance.findUnique.mockResolvedValue(
-      questInstance({ id: "q3", status: "APPROVED" }) as any,
+    mockGetCurrentUser.mockResolvedValue(childUserWithFamily());
+    prismaMock.questInstance.findUnique.mockResolvedValue(
+      skipQuest({ id: "q3", status: "APPROVED" }),
     );
 
     const res = await POST(makeSkipRequest(), makeParams("q3"));
@@ -111,22 +121,22 @@ describe("POST /api/quests/[id]/skip", () => {
   // 差し戻し後のスキップ申請: REJECTED → SKIP_REPORTED を許可し、
   // rejectionReason はクリアする（report ルートと同じ挙動）。
   it("REJECTED のクエストは SKIP_REPORTED に更新し rejectionReason をクリアすること", async () => {
-    mockGetCurrentUser.mockResolvedValue(childUser() as any);
-    mockPrisma.questInstance.findUnique.mockResolvedValue(
-      questInstance({
+    mockGetCurrentUser.mockResolvedValue(childUserWithFamily());
+    prismaMock.questInstance.findUnique.mockResolvedValue(
+      skipQuest({
         id: "q4",
         status: "REJECTED",
         rejectionReason: "写真が不鮮明",
-      }) as any,
+      }),
     );
-    mockPrisma.questInstance.update.mockResolvedValue({} as any);
+    prismaMock.questInstance.update.mockResolvedValue(questInstance({ id: "q4", status: "SKIP_REPORTED" }));
 
     const res = await POST(makeSkipRequest({ comment: "やっぱり無理" }), makeParams("q4"));
     const json = await res.json();
 
     expect(res.status).toBe(200);
     expect(json.ok).toBe(true);
-    expect(mockPrisma.questInstance.update).toHaveBeenCalledWith({
+    expect(prismaMock.questInstance.update).toHaveBeenCalledWith({
       where: { id: "q4" },
       data: {
         status: "SKIP_REPORTED",
@@ -138,11 +148,11 @@ describe("POST /api/quests/[id]/skip", () => {
   });
 
   it("スキップ成功時に進捗マイルストーンの掲示板ログをトリガーすること", async () => {
-    mockGetCurrentUser.mockResolvedValue(childUser() as any);
-    mockPrisma.questInstance.findUnique.mockResolvedValue(
-      questInstance({ id: "q1", status: "PENDING" }) as any,
+    mockGetCurrentUser.mockResolvedValue(childUserWithFamily());
+    prismaMock.questInstance.findUnique.mockResolvedValue(
+      skipQuest({ id: "q1", status: "PENDING" }),
     );
-    mockPrisma.questInstance.update.mockResolvedValue({} as any);
+    prismaMock.questInstance.update.mockResolvedValue(questInstance({ id: "q1", status: "SKIP_REPORTED" }));
 
     const res = await POST(makeSkipRequest({ comment: "気分が乗らない" }), makeParams("q1"));
     expect(res.status).toBe(200);
@@ -150,9 +160,9 @@ describe("POST /api/quests/[id]/skip", () => {
   });
 
   it("PENDING以外でスキップ拒否した場合は進捗ログをトリガーしないこと", async () => {
-    mockGetCurrentUser.mockResolvedValue(childUser() as any);
-    mockPrisma.questInstance.findUnique.mockResolvedValue(
-      questInstance({ id: "q2", status: "REPORTED" }) as any,
+    mockGetCurrentUser.mockResolvedValue(childUserWithFamily());
+    prismaMock.questInstance.findUnique.mockResolvedValue(
+      skipQuest({ id: "q2", status: "REPORTED" }),
     );
 
     await POST(makeSkipRequest(), makeParams("q2"));
@@ -160,11 +170,11 @@ describe("POST /api/quests/[id]/skip", () => {
   });
 
   it("掲示板ログは next/server の after() 経由でスケジュールされる（fire-and-forget だとサーバレスで取りこぼされる）", async () => {
-    mockGetCurrentUser.mockResolvedValue(childUser() as any);
-    mockPrisma.questInstance.findUnique.mockResolvedValue(
-      questInstance({ id: "q1", status: "PENDING" }) as any,
+    mockGetCurrentUser.mockResolvedValue(childUserWithFamily());
+    prismaMock.questInstance.findUnique.mockResolvedValue(
+      skipQuest({ id: "q1", status: "PENDING" }),
     );
-    mockPrisma.questInstance.update.mockResolvedValue({} as any);
+    prismaMock.questInstance.update.mockResolvedValue(questInstance({ id: "q1", status: "SKIP_REPORTED" }));
 
     await POST(makeSkipRequest({ comment: "ねむい" }), makeParams("q1"));
 
@@ -175,17 +185,17 @@ describe("POST /api/quests/[id]/skip", () => {
   // 宝箱生成: スキップも SKIP_REPORTED として「完了扱い」に含まれるため、
   // 全タスクスキップでも STREAK + ALL_COMPLETE 宝箱が出ることを担保する
   it("全タスクスキップ達成で generateTreasuresOnReport を totalCount===reportedCount で呼ぶ", async () => {
-    mockGetCurrentUser.mockResolvedValue(childUser({ minTasksForStreak: 1 }) as any);
-    mockPrisma.questInstance.findUnique.mockResolvedValue(
-      questInstance({ id: "q1", status: "PENDING", date: new Date("2026-07-15") }) as any,
+    mockGetCurrentUser.mockResolvedValue(childUserWithFamily({ minTasksForStreak: 1 }));
+    prismaMock.questInstance.findUnique.mockResolvedValue(
+      skipQuest({ id: "q1", status: "PENDING", date: new Date("2026-07-15") }),
     );
-    mockPrisma.questInstance.update.mockResolvedValue({} as any);
+    prismaMock.questInstance.update.mockResolvedValue(questInstance({ id: "q1", status: "SKIP_REPORTED" }));
     // 当日のクエスト = 3 件すべて SKIP_REPORTED（このスキップ完了で 3 件目）
-    mockPrisma.questInstance.findMany.mockResolvedValue([
-      { status: "SKIP_REPORTED" },
-      { status: "SKIP_REPORTED" },
-      { status: "SKIP_REPORTED" },
-    ] as any);
+    prismaMock.questInstance.findMany.mockResolvedValue([
+      questInstance({ status: "SKIP_REPORTED" }),
+      questInstance({ status: "SKIP_REPORTED" }),
+      questInstance({ status: "SKIP_REPORTED" }),
+    ]);
 
     await POST(makeSkipRequest({ comment: "全部スキップ" }), makeParams("q1"));
 
@@ -202,33 +212,33 @@ describe("POST /api/quests/[id]/skip", () => {
   });
 
   it("sameDateQuests は template.isActive: true, pausedAt: null でフィルタする（paused/inactive の幽霊タスクを除外）", async () => {
-    mockGetCurrentUser.mockResolvedValue(childUser({ minTasksForStreak: 1 }) as any);
-    mockPrisma.questInstance.findUnique.mockResolvedValue(
-      questInstance({ id: "q1", status: "PENDING" }) as any,
+    mockGetCurrentUser.mockResolvedValue(childUserWithFamily({ minTasksForStreak: 1 }));
+    prismaMock.questInstance.findUnique.mockResolvedValue(
+      skipQuest({ id: "q1", status: "PENDING" }),
     );
-    mockPrisma.questInstance.update.mockResolvedValue({} as any);
-    mockPrisma.questInstance.findMany.mockResolvedValue([
-      { status: "SKIP_REPORTED" } as any,
+    prismaMock.questInstance.update.mockResolvedValue(questInstance({ id: "q1", status: "SKIP_REPORTED" }));
+    prismaMock.questInstance.findMany.mockResolvedValue([
+      questInstance({ status: "SKIP_REPORTED" }),
     ]);
 
     await POST(makeSkipRequest({ comment: "テスト" }), makeParams("q1"));
 
-    const call = (mockPrisma.questInstance.findMany as any).mock.calls[0][0];
-    expect(call.where.template).toEqual({ isActive: true, pausedAt: null });
+    const call = prismaMock.questInstance.findMany.mock.calls[0][0];
+    expect(call?.where?.template).toEqual({ isActive: true, pausedAt: null });
   });
 
   it("一部スキップでも minTasks 達成すれば generateTreasuresOnReport を呼ぶ", async () => {
-    mockGetCurrentUser.mockResolvedValue(childUser({ minTasksForStreak: 1 }) as any);
-    mockPrisma.questInstance.findUnique.mockResolvedValue(
-      questInstance({ id: "q1", status: "PENDING" }) as any,
+    mockGetCurrentUser.mockResolvedValue(childUserWithFamily({ minTasksForStreak: 1 }));
+    prismaMock.questInstance.findUnique.mockResolvedValue(
+      skipQuest({ id: "q1", status: "PENDING" }),
     );
-    mockPrisma.questInstance.update.mockResolvedValue({} as any);
+    prismaMock.questInstance.update.mockResolvedValue(questInstance({ id: "q1", status: "SKIP_REPORTED" }));
     // 3 件中 1 件 SKIP_REPORTED、残り PENDING
-    mockPrisma.questInstance.findMany.mockResolvedValue([
-      { status: "SKIP_REPORTED" },
-      { status: "PENDING" },
-      { status: "PENDING" },
-    ] as any);
+    prismaMock.questInstance.findMany.mockResolvedValue([
+      questInstance({ status: "SKIP_REPORTED" }),
+      questInstance({ status: "PENDING" }),
+      questInstance({ status: "PENDING" }),
+    ]);
 
     await POST(makeSkipRequest({ comment: "ひとつだけスキップ" }), makeParams("q1"));
 
@@ -250,24 +260,21 @@ describe("POST /api/quests/[id]/skip", () => {
       const today = new Date("2026-03-28T00:00:00.000Z");
       const oldDate = new Date("2026-03-19T00:00:00.000Z"); // 9日前
 
-      mockGetCurrentUser.mockResolvedValue(childUser({ minTasksForStreak: 1 }) as any);
-      mockPrisma.questInstance.findUnique.mockResolvedValue(
-        {
-          ...questInstance({ id: "q1", status: "PENDING", date: oldDate }),
-          template: { id: "tpl-1", carryOver: true },
-        } as any,
+      mockGetCurrentUser.mockResolvedValue(childUserWithFamily({ minTasksForStreak: 1 }));
+      prismaMock.questInstance.findUnique.mockResolvedValue(
+        skipQuest({ id: "q1", status: "PENDING", date: oldDate }, { id: "tpl-1", carryOver: true }),
       );
-      mockPrisma.questInstance.update.mockResolvedValue({} as any);
+      prismaMock.questInstance.update.mockResolvedValue(questInstance({ id: "q1", status: "SKIP_REPORTED" }));
       // 今日（2026-03-28）には PENDING タスクが 2件（carryOver 自身は別日付なので含まれない）
-      mockPrisma.questInstance.findMany.mockResolvedValue([
-        { status: "PENDING" } as any,
-        { status: "PENDING" } as any,
+      prismaMock.questInstance.findMany.mockResolvedValue([
+        questInstance({ status: "PENDING" }),
+        questInstance({ status: "PENDING" }),
       ]);
 
       await POST(makeSkipRequest({ comment: "やっぱり今日できない" }), makeParams("q1"));
 
       // findMany は今日の date で呼ばれること
-      expect(mockPrisma.questInstance.findMany).toHaveBeenCalledWith(
+      expect(prismaMock.questInstance.findMany).toHaveBeenCalledWith(
         expect.objectContaining({
           where: expect.objectContaining({
             childId: "child-1",
@@ -292,16 +299,13 @@ describe("POST /api/quests/[id]/skip", () => {
       vi.setSystemTime(new Date("2026-03-28T03:00:00Z"));
       const oldDate = new Date("2026-03-19T00:00:00.000Z");
 
-      mockGetCurrentUser.mockResolvedValue(childUser({ minTasksForStreak: 1 }) as any);
-      mockPrisma.questInstance.findUnique.mockResolvedValue(
-        {
-          ...questInstance({ id: "q1", status: "PENDING", date: oldDate }),
-          template: { id: "tpl-1", carryOver: false },
-        } as any,
+      mockGetCurrentUser.mockResolvedValue(childUserWithFamily({ minTasksForStreak: 1 }));
+      prismaMock.questInstance.findUnique.mockResolvedValue(
+        skipQuest({ id: "q1", status: "PENDING", date: oldDate }, { id: "tpl-1", carryOver: false }),
       );
-      mockPrisma.questInstance.update.mockResolvedValue({} as any);
-      mockPrisma.questInstance.findMany.mockResolvedValue([
-        { status: "SKIP_REPORTED" } as any,
+      prismaMock.questInstance.update.mockResolvedValue(questInstance({ id: "q1", status: "SKIP_REPORTED" }));
+      prismaMock.questInstance.findMany.mockResolvedValue([
+        questInstance({ status: "SKIP_REPORTED" }),
       ]);
 
       await POST(makeSkipRequest({ comment: "skip" }), makeParams("q1"));


### PR DESCRIPTION
## Summary
- `as any`計164件を全廃し、`prismaMock`に移行した(`completed-today`/`declare`/`history`/`monthly-summary`/`skip`の5ファイル)。`fixtures.ts`は既存フィクスチャで足りたため無変更。
- `completed-today`/`history`では旧データフォールバック分岐のカバレッジ復元のため`snapshotTitle`等を明示的に`undefined`指定している(過去のPRで採用した手法を踏襲、code-reviewerでも検証済み)。
- `monthly-summary`は`Prisma.XGetPayload<{select:...}>`型注釈が`DeepMockProxy`と相性が悪かったため、型注釈を付けず型推論のみで解決した。
- `history.test.ts`は調査の結果すでに`NextRequest`化済みであることを確認し、#36で懸念されていた実装漏れは無かった。

## Test plan
- [x] `npm test` パス(対象72件/フルスイート2512件、件数変化なし)
- [x] `npm run typecheck`(prisma generate後、対象5ファイル0件)
- [x] code-reviewer による APPROVED 済み

Closes #43

🤖 Generated with [Claude Code](https://claude.com/claude-code)
