### PR TITLE
test(parent): child-view残り8ファイルのas anyを型付きモックに移行

### DIFF
--- a/src/__tests__/api/parent/checkin/calendar.test.ts
+++ b/src/__tests__/api/parent/checkin/calendar.test.ts
@@ -1,10 +1,9 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { prisma } from "@/lib/prisma";
 import { getCurrentUser } from "@/lib/auth";
 import { GET } from "@/app/api/parent/checkin/calendar/route";
-import { childUser, parentUser, streak } from "../../../helpers/fixtures";
+import { prismaMock as mockPrisma } from "../../../helpers/prisma-mock";
+import { childUserWithFamily, parentUserWithFamily, childUser, streak, checkinLog } from "../../../helpers/fixtures";
 
-const mockPrisma = vi.mocked(prisma);
 const mockGetCurrentUser = vi.mocked(getCurrentUser);
 
 function makeRequest(qs: string): Request {
@@ -29,35 +28,35 @@ describe("GET /api/parent/checkin/calendar", () => {
   });
 
   it("month 未指定 / 不正は 400", async () => {
-    mockGetCurrentUser.mockResolvedValue(parentUser() as any);
+    mockGetCurrentUser.mockResolvedValue(parentUserWithFamily());
     expect((await GET(makeRequest("childId=child-1"))).status).toBe(400);
     expect((await GET(makeRequest("childId=child-1&month=2026-13"))).status).toBe(400);
     expect((await GET(makeRequest("childId=child-1&month=abc"))).status).toBe(400);
   });
 
   it("CHILD ロールは 403（resolveTargetChild 経由）", async () => {
-    mockGetCurrentUser.mockResolvedValue(childUser() as any);
+    mockGetCurrentUser.mockResolvedValue(childUserWithFamily());
     const res = await GET(makeRequest("childId=child-1&month=2026-06"));
     expect(res.status).toBe(403);
   });
 
   it("childId 未指定は 400", async () => {
-    mockGetCurrentUser.mockResolvedValue(parentUser() as any);
+    mockGetCurrentUser.mockResolvedValue(parentUserWithFamily());
     const res = await GET(makeRequest("month=2026-06"));
     expect(res.status).toBe(400);
   });
 
   it("他 family の子は 404", async () => {
-    mockGetCurrentUser.mockResolvedValue(parentUser() as any);
+    mockGetCurrentUser.mockResolvedValue(parentUserWithFamily());
     mockPrisma.user.findFirst.mockResolvedValue(null);
     const res = await GET(makeRequest("childId=other-family-child&month=2026-06"));
     expect(res.status).toBe(404);
   });
 
   it("checkinDeadlineTime 未設定なら enabled=false", async () => {
-    mockGetCurrentUser.mockResolvedValue(parentUser() as any);
+    mockGetCurrentUser.mockResolvedValue(parentUserWithFamily());
     mockPrisma.user.findFirst.mockResolvedValue(
-      childUser({ id: "child-1", checkinDeadlineTime: null }) as any,
+      childUser({ id: "child-1", checkinDeadlineTime: null }),
     );
     const res = await GET(makeRequest("childId=child-1&month=2026-06"));
     const json = await res.json();
@@ -67,19 +66,21 @@ describe("GET /api/parent/checkin/calendar", () => {
   });
 
   it("月内ログ + enabledSince + ストリークを返す", async () => {
-    mockGetCurrentUser.mockResolvedValue(parentUser() as any);
+    mockGetCurrentUser.mockResolvedValue(parentUserWithFamily());
     mockPrisma.user.findFirst.mockResolvedValue(
-      childUser({ id: "child-1", checkinDeadlineTime: "16:00" }) as any,
+      childUser({ id: "child-1", checkinDeadlineTime: "16:00" }),
     );
+    // `select: { date, success }` クエリでも mockResolvedValue はベースの CheckinLog 完全型を
+    // 要求するため、checkinLog フィクスチャで完全な値を用意する。
     mockPrisma.checkinLog.findMany.mockResolvedValue([
-      { date: new Date("2026-06-10T00:00:00Z"), success: true },
-      { date: new Date("2026-06-11T00:00:00Z"), success: false },
-    ] as any);
-    mockPrisma.checkinLog.findFirst.mockResolvedValue({
-      date: new Date("2026-06-05T00:00:00Z"),
-    } as any);
+      checkinLog({ date: new Date("2026-06-10T00:00:00Z"), success: true }),
+      checkinLog({ date: new Date("2026-06-11T00:00:00Z"), success: false }),
+    ]);
+    mockPrisma.checkinLog.findFirst.mockResolvedValue(
+      checkinLog({ date: new Date("2026-06-05T00:00:00Z") }),
+    );
     mockPrisma.streak.findUnique.mockResolvedValue(
-      streak({ checkinCurrentStreak: 3, checkinBestStreak: 7 }) as any,
+      streak({ checkinCurrentStreak: 3, checkinBestStreak: 7 }),
     );
 
     const res = await GET(makeRequest("childId=child-1&month=2026-06"));
@@ -100,13 +101,13 @@ describe("GET /api/parent/checkin/calendar", () => {
   });
 
   it("月内 1〜末日の範囲のみクエリすること", async () => {
-    mockGetCurrentUser.mockResolvedValue(parentUser() as any);
+    mockGetCurrentUser.mockResolvedValue(parentUserWithFamily());
     mockPrisma.user.findFirst.mockResolvedValue(
-      childUser({ id: "child-1", checkinDeadlineTime: "16:00" }) as any,
+      childUser({ id: "child-1", checkinDeadlineTime: "16:00" }),
     );
-    mockPrisma.checkinLog.findMany.mockResolvedValue([] as any);
+    mockPrisma.checkinLog.findMany.mockResolvedValue([]);
     mockPrisma.checkinLog.findFirst.mockResolvedValue(null);
-    mockPrisma.streak.findUnique.mockResolvedValue(streak() as any);
+    mockPrisma.streak.findUnique.mockResolvedValue(streak());
 
     await GET(makeRequest("childId=child-1&month=2026-06"));
 
@@ -124,13 +125,13 @@ describe("GET /api/parent/checkin/calendar", () => {
   });
 
   it("ログが 1 件もない子供は enabledSince=今日 (過去全部を empty にする)", async () => {
-    mockGetCurrentUser.mockResolvedValue(parentUser() as any);
+    mockGetCurrentUser.mockResolvedValue(parentUserWithFamily());
     mockPrisma.user.findFirst.mockResolvedValue(
-      childUser({ id: "child-1", checkinDeadlineTime: "16:00" }) as any,
+      childUser({ id: "child-1", checkinDeadlineTime: "16:00" }),
     );
-    mockPrisma.checkinLog.findMany.mockResolvedValue([] as any);
+    mockPrisma.checkinLog.findMany.mockResolvedValue([]);
     mockPrisma.checkinLog.findFirst.mockResolvedValue(null);
-    mockPrisma.streak.findUnique.mockResolvedValue(streak() as any);
+    mockPrisma.streak.findUnique.mockResolvedValue(streak());
 
     const res = await GET(makeRequest("childId=child-1&month=2026-06"));
     const json = await res.json();

--- a/src/__tests__/api/parent/child-view/badges.test.ts
+++ b/src/__tests__/api/parent/child-view/badges.test.ts
@@ -1,10 +1,10 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { prisma } from "@/lib/prisma";
 import { getCurrentUser } from "@/lib/auth";
-import { checkAndUnlockBadges } from "@/lib/badges";
+import { checkAndUnlockBadges, type Badge } from "@/lib/badges";
 import { triggerBadgeLog } from "@/lib/bulletinLog";
 import { GET } from "@/app/api/parent/child-view/badges/route";
-import { childUser, parentUser } from "../../../helpers/fixtures";
+import { prismaMock as mockPrisma } from "../../../helpers/prisma-mock";
+import { childUserWithFamily, parentUserWithFamily, childUser, userBadge } from "../../../helpers/fixtures";
 
 vi.mock("@/lib/badges", async () => {
   const actual = await vi.importActual<typeof import("@/lib/badges")>("@/lib/badges");
@@ -38,7 +38,6 @@ vi.mock("@/lib/bulletinLog", () => ({
   triggerBadgeLog: vi.fn().mockResolvedValue(undefined),
 }));
 
-const mockPrisma = vi.mocked(prisma);
 const mockGetCurrentUser = vi.mocked(getCurrentUser);
 const mockCheckAndUnlockBadges = vi.mocked(checkAndUnlockBadges);
 const mockTriggerBadgeLog = vi.mocked(triggerBadgeLog);
@@ -63,31 +62,34 @@ describe("GET /api/parent/child-view/badges", () => {
   });
 
   it("CHILD ロールで403", async () => {
-    mockGetCurrentUser.mockResolvedValue(childUser() as any);
+    mockGetCurrentUser.mockResolvedValue(childUserWithFamily());
     const res = await GET(makeReq("child-1"));
     expect(res.status).toBe(403);
   });
 
   it("childId 未指定で400", async () => {
-    mockGetCurrentUser.mockResolvedValue(parentUser() as any);
+    mockGetCurrentUser.mockResolvedValue(parentUserWithFamily());
     const res = await GET(makeReq(""));
     expect(res.status).toBe(400);
   });
 
   it("別 family の子を指定された場合、404", async () => {
-    mockGetCurrentUser.mockResolvedValue(parentUser() as any);
+    mockGetCurrentUser.mockResolvedValue(parentUserWithFamily());
     mockPrisma.user.findFirst.mockResolvedValue(null);
     const res = await GET(makeReq("child-other"));
     expect(res.status).toBe(404);
   });
 
   it("正常系: 子供の childId で checkAndUnlockBadges / userBadge.findMany を呼ぶ", async () => {
-    mockGetCurrentUser.mockResolvedValue(parentUser() as any);
-    mockPrisma.user.findFirst.mockResolvedValue(childUser({ id: "child-1" }) as any);
+    mockGetCurrentUser.mockResolvedValue(parentUserWithFamily());
+    mockPrisma.user.findFirst.mockResolvedValue(childUser({ id: "child-1" }));
     mockCheckAndUnlockBadges.mockResolvedValue([]);
-    mockPrisma.userBadge.findMany.mockResolvedValue([
-      { badgeId: "first_quest", unlockedAt: new Date("2026-05-01") },
-    ] as any);
+    // `select: { badgeId, unlockedAt }` クエリでも mockResolvedValue はベースの UserBadge 完全型を
+    // 要求するため、userBadge フィクスチャで完全な値を用意する（select で絞るので余剰フィールドは無視される）。
+    const unlocked = [
+      userBadge({ badgeId: "first_quest", unlockedAt: new Date("2026-05-01") }),
+    ];
+    mockPrisma.userBadge.findMany.mockResolvedValue(unlocked);
 
     const res = await GET(makeReq("child-1"));
     expect(res.status).toBe(200);
@@ -97,38 +99,40 @@ describe("GET /api/parent/child-view/badges", () => {
     expect(Array.isArray(json.badges)).toBe(true);
 
     expect(mockCheckAndUnlockBadges).toHaveBeenCalledWith("child-1");
-    const findManyCall = (mockPrisma.userBadge.findMany as any).mock.calls[0][0];
-    expect(findManyCall.where.userId).toBe("child-1");
+    const findManyCall = mockPrisma.userBadge.findMany.mock.calls[0][0];
+    expect(findManyCall?.where?.userId).toBe("child-1");
   });
 
   it("UserBadge に廃止された旧ID が残っていても unlockedCount は ALL_BADGES の ID のみ数える", async () => {
-    mockGetCurrentUser.mockResolvedValue(parentUser() as any);
-    mockPrisma.user.findFirst.mockResolvedValue(childUser({ id: "child-1" }) as any);
+    mockGetCurrentUser.mockResolvedValue(parentUserWithFamily());
+    mockPrisma.user.findFirst.mockResolvedValue(childUser({ id: "child-1" }));
     mockCheckAndUnlockBadges.mockResolvedValue([]);
-    mockPrisma.userBadge.findMany.mockResolvedValue([
-      { badgeId: "first_quest", unlockedAt: new Date("2026-06-01") },
-      { badgeId: "first_approval", unlockedAt: new Date("2026-04-10") }, // 廃止ID
-      { badgeId: "streak_3", unlockedAt: new Date("2026-04-11") },       // 廃止ID
-      { badgeId: "xp_10", unlockedAt: new Date("2026-04-12") },          // 廃止ID
-    ] as any);
+    const unlocked = [
+      userBadge({ badgeId: "first_quest", unlockedAt: new Date("2026-06-01") }),
+      userBadge({ badgeId: "first_approval", unlockedAt: new Date("2026-04-10") }), // 廃止ID
+      userBadge({ badgeId: "streak_3", unlockedAt: new Date("2026-04-11") }),       // 廃止ID
+      userBadge({ badgeId: "xp_10", unlockedAt: new Date("2026-04-12") }),          // 廃止ID
+    ];
+    mockPrisma.userBadge.findMany.mockResolvedValue(unlocked);
 
     const res = await GET(makeReq("child-1"));
     const json = await res.json();
     expect(res.status).toBe(200);
     expect(json.unlockedCount).toBe(1);
     expect(json.totalCount).toBe(100);
-    const ids = json.badges.map((b: any) => b.id);
+    const ids = (json.badges as Array<{ id: string }>).map((b) => b.id);
     expect(ids).not.toContain("first_approval");
     expect(ids).not.toContain("streak_3");
     expect(ids).not.toContain("xp_10");
   });
 
   it("新規解除されたバッジを掲示板に流す（triggerBadgeLog 呼び出し）", async () => {
-    mockGetCurrentUser.mockResolvedValue(parentUser() as any);
-    mockPrisma.user.findFirst.mockResolvedValue(childUser({ id: "child-1" }) as any);
-    mockCheckAndUnlockBadges.mockResolvedValue([
-      { id: "first_step", name: "はじめの一歩", emoji: "🌱", description: "..." } as any,
-    ]);
+    mockGetCurrentUser.mockResolvedValue(parentUserWithFamily());
+    mockPrisma.user.findFirst.mockResolvedValue(childUser({ id: "child-1" }));
+    const newlyUnlocked: Badge[] = [
+      { id: "first_step", name: "はじめの一歩", emoji: "🌱", description: "..." },
+    ];
+    mockCheckAndUnlockBadges.mockResolvedValue(newlyUnlocked);
 
     const res = await GET(makeReq("child-1"));
     expect(res.status).toBe(200);

--- a/src/__tests__/api/parent/child-view/children.test.ts
+++ b/src/__tests__/api/parent/child-view/children.test.ts
@@ -1,10 +1,9 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { GET } from "@/app/api/parent/child-view/children/route";
-import { prisma } from "@/lib/prisma";
 import { getCurrentUser } from "@/lib/auth";
-import { parentUser, childUser } from "../../../helpers/fixtures";
+import { prismaMock as mockPrisma } from "../../../helpers/prisma-mock";
+import { parentUserWithFamily, childUserWithFamily, childUser } from "../../../helpers/fixtures";
 
-const mockPrisma = vi.mocked(prisma);
 const mockGetCurrentUser = vi.mocked(getCurrentUser);
 
 beforeEach(() => {
@@ -19,21 +18,23 @@ describe("GET /api/parent/child-view/children", () => {
   });
 
   it("CHILD ロールの場合、403 を返す", async () => {
-    mockGetCurrentUser.mockResolvedValue(childUser() as any);
+    mockGetCurrentUser.mockResolvedValue(childUserWithFamily());
     const res = await GET();
     expect(res.status).toBe(403);
   });
 
   it("familyId が無い親の場合、403 を返す", async () => {
-    mockGetCurrentUser.mockResolvedValue(parentUser({ familyId: null }) as any);
+    mockGetCurrentUser.mockResolvedValue(parentUserWithFamily({ familyId: null }, null));
     const res = await GET();
     expect(res.status).toBe(403);
   });
 
   it("正常系: 家族内の CHILD を返し、モンスター画像とXPバー描画に必要なフィールドを含む", async () => {
-    mockGetCurrentUser.mockResolvedValue(parentUser() as any);
-    mockPrisma.user.findMany.mockResolvedValue([
-      {
+    mockGetCurrentUser.mockResolvedValue(parentUserWithFamily());
+    // `select` クエリでも DeepMockProxy の mockResolvedValue はベースの User 完全型を要求するため、
+    // childUser フィクスチャで完全な値を用意する（実装は select で絞るので余剰フィールドは無視される）。
+    const children = [
+      childUser({
         id: "child-1",
         name: "太郎",
         monsterName: "ドラゴン",
@@ -45,8 +46,8 @@ describe("GET /api/parent/child-view/children", () => {
         lifePt: 0,
         collectedPaths: "[]",
         rebirthEggBonus: null,
-      },
-      {
+      }),
+      childUser({
         id: "child-2",
         name: "花子",
         monsterName: "ユニコーン",
@@ -58,8 +59,9 @@ describe("GET /api/parent/child-view/children", () => {
         lifePt: 0,
         collectedPaths: "[]",
         rebirthEggBonus: null,
-      },
-    ] as any);
+      }),
+    ];
+    mockPrisma.user.findMany.mockResolvedValue(children);
 
     const res = await GET();
     expect(res.status).toBe(200);
@@ -88,7 +90,7 @@ describe("GET /api/parent/child-view/children", () => {
   });
 
   it("子供が居ない場合、空配列を返す", async () => {
-    mockGetCurrentUser.mockResolvedValue(parentUser() as any);
+    mockGetCurrentUser.mockResolvedValue(parentUserWithFamily());
     mockPrisma.user.findMany.mockResolvedValue([]);
 
     const res = await GET();

--- a/src/__tests__/api/parent/child-view/monster-status.test.ts
+++ b/src/__tests__/api/parent/child-view/monster-status.test.ts
@@ -1,10 +1,16 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { GET } from "@/app/api/parent/child-view/monster-status/route";
-import { prisma } from "@/lib/prisma";
 import { getCurrentUser } from "@/lib/auth";
-import { parentUser, childUser } from "../../../helpers/fixtures";
+import { prismaMock as mockPrisma } from "../../../helpers/prisma-mock";
+import {
+  parentUserWithFamily,
+  childUserWithFamily,
+  childUser,
+  streak,
+  questWithTemplate,
+  questInstance,
+} from "../../../helpers/fixtures";
 
-const mockPrisma = vi.mocked(prisma);
 const mockGetCurrentUser = vi.mocked(getCurrentUser);
 
 beforeEach(() => {
@@ -26,26 +32,26 @@ describe("GET /api/parent/child-view/monster-status", () => {
   });
 
   it("CHILD ロールの場合、403 を返す", async () => {
-    mockGetCurrentUser.mockResolvedValue(childUser() as any);
+    mockGetCurrentUser.mockResolvedValue(childUserWithFamily());
     const res = await GET(makeReq("child-1"));
     expect(res.status).toBe(403);
   });
 
   it("childId 未指定の場合、400 を返す", async () => {
-    mockGetCurrentUser.mockResolvedValue(parentUser() as any);
+    mockGetCurrentUser.mockResolvedValue(parentUserWithFamily());
     const res = await GET(makeReq(""));
     expect(res.status).toBe(400);
   });
 
   it("別 family の子を指定された場合、404 を返す", async () => {
-    mockGetCurrentUser.mockResolvedValue(parentUser() as any);
+    mockGetCurrentUser.mockResolvedValue(parentUserWithFamily());
     mockPrisma.user.findFirst.mockResolvedValue(null);
     const res = await GET(makeReq("child-other"));
     expect(res.status).toBe(404);
   });
 
   it("正常系: モンスター・ストリーク・月間達成を返す", async () => {
-    mockGetCurrentUser.mockResolvedValue(parentUser() as any);
+    mockGetCurrentUser.mockResolvedValue(parentUserWithFamily());
     mockPrisma.user.findFirst.mockResolvedValue(
       childUser({
         id: "child-1",
@@ -56,18 +62,23 @@ describe("GET /api/parent/child-view/monster-status", () => {
         studyPt: 5,
         staminaPt: 3,
         lifePt: 2,
-      }) as any,
+      }),
     );
-    mockPrisma.questInstance.findMany.mockResolvedValueOnce([] as any); // pending REPORTED
-    mockPrisma.streak.findUnique.mockResolvedValue({
-      currentStreak: 7,
-      bestStreak: 10,
-      lastAchievedDate: new Date("2026-03-11"),
-    } as any);
-    mockPrisma.questInstance.findMany.mockResolvedValueOnce([
-      { date: new Date("2026-03-10") },
-      { date: new Date("2026-03-11") },
-    ] as any);
+    mockPrisma.questInstance.findMany.mockResolvedValueOnce([]); // pending REPORTED
+    mockPrisma.streak.findUnique.mockResolvedValue(
+      streak({
+        currentStreak: 7,
+        bestStreak: 10,
+        lastAchievedDate: new Date("2026-03-11"),
+      }),
+    );
+    // `select: { date: true }` クエリでも mockResolvedValue はベースの QuestInstance 完全型を要求するため、
+    // questInstance フィクスチャで完全な値を用意する（実装は select で絞るので余剰フィールドは無視される）。
+    const monthlyQuests = [
+      questInstance({ date: new Date("2026-03-10") }),
+      questInstance({ date: new Date("2026-03-11") }),
+    ];
+    mockPrisma.questInstance.findMany.mockResolvedValueOnce(monthlyQuests);
 
     const res = await GET(makeReq("child-1"));
     expect(res.status).toBe(200);
@@ -82,26 +93,20 @@ describe("GET /api/parent/child-view/monster-status", () => {
   });
 
   it("REPORTED の pending XP を集計してカテゴリ別 pending* に入れる", async () => {
-    mockGetCurrentUser.mockResolvedValue(parentUser() as any);
-    mockPrisma.user.findFirst.mockResolvedValue(childUser({ id: "child-1" }) as any);
+    mockGetCurrentUser.mockResolvedValue(parentUserWithFamily());
+    mockPrisma.user.findFirst.mockResolvedValue(childUser({ id: "child-1" }));
     mockPrisma.questInstance.findMany.mockResolvedValueOnce([
-      {
-        id: "q1",
-        deadlineBonusEarned: false,
-        photoUrl: null,
-        snapshotCategory: "STUDY",
-        template: { category: "STUDY", photoBonus: false },
-      },
-      {
-        id: "q2",
-        deadlineBonusEarned: true,
-        photoUrl: null,
-        snapshotCategory: "STAMINA",
-        template: { category: "STAMINA", photoBonus: false },
-      },
-    ] as any);
+      questWithTemplate(
+        { id: "q1", deadlineBonusEarned: false, photoUrl: null, snapshotCategory: "STUDY" },
+        { category: "STUDY", photoBonus: false },
+      ),
+      questWithTemplate(
+        { id: "q2", deadlineBonusEarned: true, photoUrl: null, snapshotCategory: "STAMINA" },
+        { category: "STAMINA", photoBonus: false },
+      ),
+    ]);
     mockPrisma.streak.findUnique.mockResolvedValue(null);
-    mockPrisma.questInstance.findMany.mockResolvedValueOnce([] as any);
+    mockPrisma.questInstance.findMany.mockResolvedValueOnce([]);
 
     const res = await GET(makeReq("child-1"));
     const json = await res.json();

--- a/src/__tests__/api/parent/child-view/monster.test.ts
+++ b/src/__tests__/api/parent/child-view/monster.test.ts
@@ -1,10 +1,9 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { GET } from "@/app/api/parent/child-view/monster/route";
-import { prisma } from "@/lib/prisma";
 import { getCurrentUser } from "@/lib/auth";
-import { parentUser, childUser } from "../../../helpers/fixtures";
+import { prismaMock as mockPrisma } from "../../../helpers/prisma-mock";
+import { parentUserWithFamily, childUserWithFamily, childUser } from "../../../helpers/fixtures";
 
-const mockPrisma = vi.mocked(prisma);
 const mockGetCurrentUser = vi.mocked(getCurrentUser);
 
 beforeEach(() => {
@@ -26,26 +25,26 @@ describe("GET /api/parent/child-view/monster", () => {
   });
 
   it("CHILD ロールで403", async () => {
-    mockGetCurrentUser.mockResolvedValue(childUser() as any);
+    mockGetCurrentUser.mockResolvedValue(childUserWithFamily());
     const res = await GET(makeReq("child-1"));
     expect(res.status).toBe(403);
   });
 
   it("childId 未指定で400", async () => {
-    mockGetCurrentUser.mockResolvedValue(parentUser() as any);
+    mockGetCurrentUser.mockResolvedValue(parentUserWithFamily());
     const res = await GET(makeReq(""));
     expect(res.status).toBe(400);
   });
 
   it("別 family の子を指定された場合、404", async () => {
-    mockGetCurrentUser.mockResolvedValue(parentUser() as any);
+    mockGetCurrentUser.mockResolvedValue(parentUserWithFamily());
     mockPrisma.user.findFirst.mockResolvedValue(null);
     const res = await GET(makeReq("child-other"));
     expect(res.status).toBe(404);
   });
 
   it("正常系: 図鑑描画に必要な side / collectedPaths / monsterLevels / usedEggBonuses を返す", async () => {
-    mockGetCurrentUser.mockResolvedValue(parentUser() as any);
+    mockGetCurrentUser.mockResolvedValue(parentUserWithFamily());
     mockPrisma.user.findFirst.mockResolvedValue(
       childUser({
         id: "child-1",
@@ -55,9 +54,9 @@ describe("GET /api/parent/child-view/monster", () => {
         collectedPaths: '["STUDY","STUDY_STUDY"]',
         monsterLevels: '{"STUDY_STUDY_STUDY":2}',
         usedEggBonuses: '["STUDY"]',
-      }) as any,
+      }),
     );
-    mockPrisma.questInstance.findMany.mockResolvedValue([] as any);
+    mockPrisma.questInstance.findMany.mockResolvedValue([]);
 
     const res = await GET(makeReq("child-1"));
     expect(res.status).toBe(200);

--- a/src/__tests__/api/parent/child-view/rebirth.test.ts
+++ b/src/__tests__/api/parent/child-view/rebirth.test.ts
@@ -1,16 +1,15 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { after } from "next/server";
 import { POST } from "@/app/api/parent/child-view/rebirth/route";
-import { prisma } from "@/lib/prisma";
 import { getCurrentUser } from "@/lib/auth";
 import { triggerMonsterRebornLog } from "@/lib/bulletinLog";
-import { parentUser, childUser } from "../../../helpers/fixtures";
+import { prismaMock as mockPrisma } from "../../../helpers/prisma-mock";
+import { parentUserWithFamily, childUserWithFamily, childUser } from "../../../helpers/fixtures";
 
 vi.mock("@/lib/bulletinLog", () => ({
   triggerMonsterRebornLog: vi.fn().mockResolvedValue(undefined),
 }));
 
-const mockPrisma = vi.mocked(prisma);
 const mockGetCurrentUser = vi.mocked(getCurrentUser);
 const mockAfter = vi.mocked(after);
 const mockTriggerRebornLog = vi.mocked(triggerMonsterRebornLog);
@@ -34,28 +33,28 @@ describe("POST /api/parent/child-view/rebirth", () => {
   });
 
   it("CHILD ロールでは 403 を返す", async () => {
-    mockGetCurrentUser.mockResolvedValue(childUser() as any);
+    mockGetCurrentUser.mockResolvedValue(childUserWithFamily());
     const res = await POST(makeReq({ childId: "child-1" }));
     expect(res.status).toBe(403);
   });
 
   it("childId 未指定で 400 を返す", async () => {
-    mockGetCurrentUser.mockResolvedValue(parentUser() as any);
+    mockGetCurrentUser.mockResolvedValue(parentUserWithFamily());
     const res = await POST(makeReq({}));
     expect(res.status).toBe(400);
   });
 
   it("別 family の childId で 404 を返す", async () => {
-    mockGetCurrentUser.mockResolvedValue(parentUser() as any);
+    mockGetCurrentUser.mockResolvedValue(parentUserWithFamily());
     mockPrisma.user.findFirst.mockResolvedValue(null);
     const res = await POST(makeReq({ childId: "child-other" }));
     expect(res.status).toBe(404);
   });
 
   it("rebirthPending=false の子供では 400 を返す（転生待ちでない）", async () => {
-    mockGetCurrentUser.mockResolvedValue(parentUser() as any);
+    mockGetCurrentUser.mockResolvedValue(parentUserWithFamily());
     mockPrisma.user.findFirst.mockResolvedValue(
-      childUser({ id: "child-1", rebirthPending: false }) as any,
+      childUser({ id: "child-1", rebirthPending: false }),
     );
     const res = await POST(makeReq({ childId: "child-1" }));
     expect(res.status).toBe(400);
@@ -63,7 +62,7 @@ describe("POST /api/parent/child-view/rebirth", () => {
   });
 
   it("正常系: 卵ボーナス無し（NORMAL 卵）でステージ・ポイントをリセットする", async () => {
-    mockGetCurrentUser.mockResolvedValue(parentUser() as any);
+    mockGetCurrentUser.mockResolvedValue(parentUserWithFamily());
     mockPrisma.user.findFirst.mockResolvedValue(
       childUser({
         id: "child-1",
@@ -73,9 +72,9 @@ describe("POST /api/parent/child-view/rebirth", () => {
         studyPt: 10,
         staminaPt: 5,
         lifePt: 5,
-      }) as any,
+      }),
     );
-    mockPrisma.user.updateMany.mockResolvedValue({ count: 1 } as any);
+    mockPrisma.user.updateMany.mockResolvedValue({ count: 1 });
 
     const res = await POST(makeReq({ childId: "child-1" }));
     expect(res.status).toBe(200);
@@ -95,15 +94,15 @@ describe("POST /api/parent/child-view/rebirth", () => {
   });
 
   it("usedEggBonuses は触らない（NORMAL なので使用済みに記録しない）", async () => {
-    mockGetCurrentUser.mockResolvedValue(parentUser() as any);
+    mockGetCurrentUser.mockResolvedValue(parentUserWithFamily());
     mockPrisma.user.findFirst.mockResolvedValue(
       childUser({
         id: "child-1",
         rebirthPending: true,
         usedEggBonuses: '["STUDY"]',
-      }) as any,
+      }),
     );
-    mockPrisma.user.updateMany.mockResolvedValue({ count: 1 } as any);
+    mockPrisma.user.updateMany.mockResolvedValue({ count: 1 });
 
     await POST(makeReq({ childId: "child-1" }));
 
@@ -113,23 +112,23 @@ describe("POST /api/parent/child-view/rebirth", () => {
   });
 
   it("rebirthPending=trueで読み込んだ後、update時には他経路で既に転生済み(count=0)の場合は400を返す（TOCTOUレース）", async () => {
-    mockGetCurrentUser.mockResolvedValue(parentUser() as any);
+    mockGetCurrentUser.mockResolvedValue(parentUserWithFamily());
     mockPrisma.user.findFirst.mockResolvedValue(
-      childUser({ id: "child-1", rebirthPending: true, usedEggBonuses: "[]" }) as any,
+      childUser({ id: "child-1", rebirthPending: true, usedEggBonuses: "[]" }),
     );
     // 子供本人が同時に転生実行済みのケースを模擬
-    mockPrisma.user.updateMany.mockResolvedValue({ count: 0 } as any);
+    mockPrisma.user.updateMany.mockResolvedValue({ count: 0 });
 
     const res = await POST(makeReq({ childId: "child-1" }));
     expect(res.status).toBe(400);
   });
 
   it("after() で MonsterReborn 掲示板ログをスケジュールする", async () => {
-    mockGetCurrentUser.mockResolvedValue(parentUser() as any);
+    mockGetCurrentUser.mockResolvedValue(parentUserWithFamily());
     mockPrisma.user.findFirst.mockResolvedValue(
-      childUser({ id: "child-1", rebirthPending: true, usedEggBonuses: "[]" }) as any,
+      childUser({ id: "child-1", rebirthPending: true, usedEggBonuses: "[]" }),
     );
-    mockPrisma.user.updateMany.mockResolvedValue({ count: 1 } as any);
+    mockPrisma.user.updateMany.mockResolvedValue({ count: 1 });
 
     await POST(makeReq({ childId: "child-1" }));
 

--- a/src/__tests__/api/parent/child-view/treasures-open.test.ts
+++ b/src/__tests__/api/parent/child-view/treasures-open.test.ts
@@ -1,12 +1,12 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { POST } from "@/app/api/parent/child-view/treasures/open/route";
-import { prisma } from "@/lib/prisma";
 import { getCurrentUser } from "@/lib/auth";
 import { openOldestTreasure } from "@/lib/treasureService";
 import { sendPushToParent } from "@/lib/push";
 import { checkAndUnlockBadges } from "@/lib/badges";
 import { triggerBadgeLog } from "@/lib/bulletinLog";
-import { childUser, parentUser } from "../../../helpers/fixtures";
+import { prismaMock as mockPrisma } from "../../../helpers/prisma-mock";
+import { childUserWithFamily, parentUserWithFamily, childUser } from "../../../helpers/fixtures";
 
 vi.mock("@/lib/treasureService", () => ({
   openOldestTreasure: vi.fn(),
@@ -24,7 +24,6 @@ vi.mock("@/lib/bulletinLog", () => ({
   triggerBadgeLog: vi.fn().mockResolvedValue(undefined),
 }));
 
-const mockPrisma = vi.mocked(prisma);
 const mockGetCurrentUser = vi.mocked(getCurrentUser);
 const mockOpen = vi.mocked(openOldestTreasure);
 const mockSendPushToParent = vi.mocked(sendPushToParent);
@@ -52,36 +51,36 @@ describe("POST /api/parent/child-view/treasures/open", () => {
   });
 
   it("CHILD ロールで403", async () => {
-    mockGetCurrentUser.mockResolvedValue(childUser() as any);
+    mockGetCurrentUser.mockResolvedValue(childUserWithFamily());
     const res = await POST(makeReq({ childId: "child-1" }));
     expect(res.status).toBe(403);
   });
 
   it("childId 未指定で400", async () => {
-    mockGetCurrentUser.mockResolvedValue(parentUser() as any);
+    mockGetCurrentUser.mockResolvedValue(parentUserWithFamily());
     const res = await POST(makeReq({}));
     expect(res.status).toBe(400);
   });
 
   it("別 family の子を指定された場合、404", async () => {
-    mockGetCurrentUser.mockResolvedValue(parentUser() as any);
+    mockGetCurrentUser.mockResolvedValue(parentUserWithFamily());
     mockPrisma.user.findFirst.mockResolvedValue(null);
     const res = await POST(makeReq({ childId: "child-other" }));
     expect(res.status).toBe(404);
   });
 
   it("UNLOCKED 宝箱が無いと400", async () => {
-    mockGetCurrentUser.mockResolvedValue(parentUser() as any);
-    mockPrisma.user.findFirst.mockResolvedValue(childUser({ id: "child-1" }) as any);
+    mockGetCurrentUser.mockResolvedValue(parentUserWithFamily());
+    mockPrisma.user.findFirst.mockResolvedValue(childUser({ id: "child-1" }));
     mockOpen.mockResolvedValue(null);
     const res = await POST(makeReq({ childId: "child-1" }));
     expect(res.status).toBe(400);
   });
 
   it("親ごほうび当選でも親への Push は送らない（親が自分で操作しているため通知不要）", async () => {
-    mockGetCurrentUser.mockResolvedValue(parentUser() as any);
+    mockGetCurrentUser.mockResolvedValue(parentUserWithFamily());
     mockPrisma.user.findFirst.mockResolvedValue(
-      childUser({ id: "child-1", name: "太郎" }) as any,
+      childUser({ id: "child-1", name: "太郎" }),
     );
     mockOpen.mockResolvedValue({
       logId: "log-1",
@@ -104,8 +103,8 @@ describe("POST /api/parent/child-view/treasures/open", () => {
   });
 
   it("コレクション獲得時もハンドリング (item=null, collectionItem 付与) を返す", async () => {
-    mockGetCurrentUser.mockResolvedValue(parentUser() as any);
-    mockPrisma.user.findFirst.mockResolvedValue(childUser({ id: "child-1" }) as any);
+    mockGetCurrentUser.mockResolvedValue(parentUserWithFamily());
+    mockPrisma.user.findFirst.mockResolvedValue(childUser({ id: "child-1" }));
     mockOpen.mockResolvedValue({
       logId: "log-2",
       item: null,
@@ -129,8 +128,8 @@ describe("POST /api/parent/child-view/treasures/open", () => {
   });
 
   it("レスポンスに pityTriggered フィールドは含まない (pity 廃止)", async () => {
-    mockGetCurrentUser.mockResolvedValue(parentUser() as any);
-    mockPrisma.user.findFirst.mockResolvedValue(childUser({ id: "child-1" }) as any);
+    mockGetCurrentUser.mockResolvedValue(parentUserWithFamily());
+    mockPrisma.user.findFirst.mockResolvedValue(childUser({ id: "child-1" }));
     mockOpen.mockResolvedValue({
       logId: "log-3",
       item: { id: "i1", title: "本", rarity: "RARE" },
@@ -143,8 +142,8 @@ describe("POST /api/parent/child-view/treasures/open", () => {
   });
 
   it("開封後に子の id で checkAndUnlockBadges を呼ぶ（親代理でも子のバッジ判定）", async () => {
-    mockGetCurrentUser.mockResolvedValue(parentUser() as any);
-    mockPrisma.user.findFirst.mockResolvedValue(childUser({ id: "child-1" }) as any);
+    mockGetCurrentUser.mockResolvedValue(parentUserWithFamily());
+    mockPrisma.user.findFirst.mockResolvedValue(childUser({ id: "child-1" }));
     mockOpen.mockResolvedValue({
       logId: "log-4",
       item: null,
@@ -162,8 +161,8 @@ describe("POST /api/parent/child-view/treasures/open", () => {
   });
 
   it("新規解錠バッジを子の名前で掲示板に流す", async () => {
-    mockGetCurrentUser.mockResolvedValue(parentUser() as any);
-    mockPrisma.user.findFirst.mockResolvedValue(childUser({ id: "child-1" }) as any);
+    mockGetCurrentUser.mockResolvedValue(parentUserWithFamily());
+    mockPrisma.user.findFirst.mockResolvedValue(childUser({ id: "child-1" }));
     mockOpen.mockResolvedValue({
       logId: "log-5",
       item: null,

--- a/src/__tests__/api/parent/child-view/treasures-status.test.ts
+++ b/src/__tests__/api/parent/child-view/treasures-status.test.ts
@@ -1,11 +1,15 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import type { Prisma } from "@/generated/prisma/client";
 import { GET } from "@/app/api/parent/child-view/treasures/status/route";
-import { prisma } from "@/lib/prisma";
 import { getCurrentUser } from "@/lib/auth";
-import { parentUser, childUser } from "../../../helpers/fixtures";
+import { prismaMock as mockPrisma } from "../../../helpers/prisma-mock";
+import { parentUserWithFamily, childUserWithFamily, childUser, treasureLog } from "../../../helpers/fixtures";
 
-const mockPrisma = vi.mocked(prisma);
 const mockGetCurrentUser = vi.mocked(getCurrentUser);
+
+type OpenedTreasureLog = Prisma.TreasureLogGetPayload<{
+  include: { item: { select: { id: true; title: true; rarity: true } } };
+}>;
 
 const FIXED_NOW = new Date("2026-05-29T10:00:00Z");
 
@@ -34,27 +38,27 @@ describe("GET /api/parent/child-view/treasures/status", () => {
   });
 
   it("CHILD ロールの場合、403 を返す", async () => {
-    mockGetCurrentUser.mockResolvedValue(childUser() as any);
+    mockGetCurrentUser.mockResolvedValue(childUserWithFamily());
     const res = await GET(makeReq("child-1"));
     expect(res.status).toBe(403);
   });
 
   it("childId 未指定の場合、400 を返す", async () => {
-    mockGetCurrentUser.mockResolvedValue(parentUser() as any);
+    mockGetCurrentUser.mockResolvedValue(parentUserWithFamily());
     const res = await GET(makeReq(""));
     expect(res.status).toBe(400);
   });
 
   it("別 family の子を指定された場合、404 を返す", async () => {
-    mockGetCurrentUser.mockResolvedValue(parentUser() as any);
+    mockGetCurrentUser.mockResolvedValue(parentUserWithFamily());
     mockPrisma.user.findFirst.mockResolvedValue(null);
     const res = await GET(makeReq("child-other"));
     expect(res.status).toBe(404);
   });
 
   it("opened 履歴は openedAt が直近7日以内のみを問い合わせる", async () => {
-    mockGetCurrentUser.mockResolvedValue(parentUser() as any);
-    mockPrisma.user.findFirst.mockResolvedValue(childUser({ id: "child-1" }) as any);
+    mockGetCurrentUser.mockResolvedValue(parentUserWithFamily());
+    mockPrisma.user.findFirst.mockResolvedValue(childUser({ id: "child-1" }));
     mockPrisma.treasureLog.count
       .mockResolvedValueOnce(0)
       .mockResolvedValueOnce(0);
@@ -64,28 +68,34 @@ describe("GET /api/parent/child-view/treasures/status", () => {
     const res = await GET(makeReq("child-1"));
     expect(res.status).toBe(200);
 
-    const findManyCall = (mockPrisma.treasureLog.findMany as any).mock.calls[0][0];
-    expect(findManyCall.where.status).toBe("OPENED");
-    expect(findManyCall.where.openedAt.gte).toBeInstanceOf(Date);
-    const cutoff = findManyCall.where.openedAt.gte as Date;
+    const findManyCall = mockPrisma.treasureLog.findMany.mock.calls[0][0];
+    const where = findManyCall?.where as { status?: unknown; childId?: unknown; openedAt?: { gte?: Date } };
+    expect(where.status).toBe("OPENED");
+    expect(where.openedAt?.gte).toBeInstanceOf(Date);
+    const cutoff = where.openedAt?.gte as Date;
     expect(cutoff.getTime()).toBe(new Date("2026-05-22T10:00:00Z").getTime());
-    expect(findManyCall.where.childId).toBe("child-1");
+    expect(where.childId).toBe("child-1");
   });
 
   it("locked / unlocked カウントと opened を子供の childId で問い合わせて返す", async () => {
-    mockGetCurrentUser.mockResolvedValue(parentUser() as any);
-    mockPrisma.user.findFirst.mockResolvedValue(childUser({ id: "child-1" }) as any);
+    mockGetCurrentUser.mockResolvedValue(parentUserWithFamily());
+    mockPrisma.user.findFirst.mockResolvedValue(childUser({ id: "child-1" }));
     mockPrisma.treasureLog.count
       .mockResolvedValueOnce(2)
       .mockResolvedValueOnce(1);
-    mockPrisma.treasureLog.findMany.mockResolvedValue([
+    const opened: OpenedTreasureLog[] = [
       {
-        id: "log1",
-        openedAt: new Date("2026-05-29T09:30:00Z"),
-        boosted: false,
+        ...treasureLog({
+          id: "log1",
+          openedAt: new Date("2026-05-29T09:30:00Z"),
+          boosted: false,
+          status: "OPENED",
+          itemId: "i1",
+        }),
         item: { id: "i1", title: "おやつ", rarity: "COMMON" },
       },
-    ] as any);
+    ];
+    mockPrisma.treasureLog.findMany.mockResolvedValue(opened);
     mockPrisma.treasureItem.count.mockResolvedValue(3);
 
     const res = await GET(makeReq("child-1"));
@@ -98,17 +108,17 @@ describe("GET /api/parent/child-view/treasures/status", () => {
     expect(json.hasPool).toBe(true);
 
     // 全ての count / findMany 呼び出しが childId="child-1" で行われていることを確認
-    const countCalls = (mockPrisma.treasureLog.count as any).mock.calls;
-    countCalls.forEach((args: any[]) => {
-      expect(args[0].where.childId).toBe("child-1");
+    const countCalls = mockPrisma.treasureLog.count.mock.calls;
+    countCalls.forEach((args) => {
+      expect((args[0]?.where as { childId?: unknown } | undefined)?.childId).toBe("child-1");
     });
-    const itemCountCall = (mockPrisma.treasureItem.count as any).mock.calls[0][0];
-    expect(itemCountCall.where.childId).toBe("child-1");
+    const itemCountCall = mockPrisma.treasureItem.count.mock.calls[0][0];
+    expect((itemCountCall?.where as { childId?: unknown } | undefined)?.childId).toBe("child-1");
   });
 
   it("treasureItem が 0件なら hasPool=false", async () => {
-    mockGetCurrentUser.mockResolvedValue(parentUser() as any);
-    mockPrisma.user.findFirst.mockResolvedValue(childUser({ id: "child-1" }) as any);
+    mockGetCurrentUser.mockResolvedValue(parentUserWithFamily());
+    mockPrisma.user.findFirst.mockResolvedValue(childUser({ id: "child-1" }));
     mockPrisma.treasureLog.count.mockResolvedValue(0);
     mockPrisma.treasureLog.findMany.mockResolvedValue([]);
     mockPrisma.treasureItem.count.mockResolvedValue(0);


### PR DESCRIPTION
## Summary
- `as any` 計102件を全廃し、`prismaMock` を用いた型付きモックへ移行（対象8ファイル）。`fixtures.ts` は無変更
- **転生ロジックについて**: `rebirth.test.ts` のTOCTOU回避チェック（`updateMany` の `where: { rebirthPending: true }`）を含む転生規約の検証内容は、code-reviewerがアサーション内容の不変を個別に確認済み
- **家族ID権限チェックについて**: 8ファイル全てで403/404の権限チェックテストのステータスコード・文言に変更がないことをcode-reviewerが確認済み
- カバレッジの罠（モック差し替えによる暗黙のテスト範囲縮小）は今回発生せず、8ルート全てで検証内容が完全一致
- テスト件数の変化なし、`expect` の出現数も減少なし（合計125→125）

## Test plan
- [x] `npm test` パス（58/58対象ファイル、フルスイート2512件、変化なし）
- [x] `npm run typecheck`（`prisma generate` 後）: 68件→0件
- [x] code-reviewer によるレビュー: APPROVED（転生ロジック・家族ID権限チェックを個別に検証済み）

Closes #45

🤖 Generated with [Claude Code](https://claude.com/claude-code)
