### PR TITLE
test(streak): quests/streak/loginStreak/taskStreakテストのas anyを型付きモックに移行

### DIFF
--- a/src/__tests__/lib/loginStreak.test.ts
+++ b/src/__tests__/lib/loginStreak.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { prisma } from "@/lib/prisma";
 import { recordLoginActivity } from "@/lib/loginStreak";
 import { triggerMonsterEvolvedLog } from "@/lib/bulletinLog";
+import { prismaMock as mockPrisma } from "../helpers/prisma-mock";
 import { childUser, streak } from "../helpers/fixtures";
 
 vi.mock("@/lib/bulletinLog", () => ({
@@ -10,7 +10,6 @@ vi.mock("@/lib/bulletinLog", () => ({
   triggerStreakTitleLog: vi.fn().mockResolvedValue(undefined),
 }));
 
-const mockPrisma = vi.mocked(prisma);
 const mockTriggerMonsterEvolvedLog = vi.mocked(triggerMonsterEvolvedLog);
 
 beforeEach(() => {
@@ -22,9 +21,9 @@ describe("recordLoginActivity", () => {
 
   it("初回ログインで loginCurrentStreak=1 になる", async () => {
     mockPrisma.streak.upsert.mockResolvedValue(
-      streak({ loginCurrentStreak: 0, loginBestStreak: 0, lastLoginDate: null }) as any,
+      streak({ loginCurrentStreak: 0, loginBestStreak: 0, lastLoginDate: null }),
     );
-    mockPrisma.streak.update.mockResolvedValue({} as any);
+    mockPrisma.streak.update.mockResolvedValue(streak());
 
     const result = await recordLoginActivity("child-1", today);
 
@@ -42,7 +41,7 @@ describe("recordLoginActivity", () => {
 
   it("同日2回目のログインでは変化なし", async () => {
     mockPrisma.streak.upsert.mockResolvedValue(
-      streak({ loginCurrentStreak: 3, loginBestStreak: 5, lastLoginDate: today }) as any,
+      streak({ loginCurrentStreak: 3, loginBestStreak: 5, lastLoginDate: today }),
     );
 
     const result = await recordLoginActivity("child-1", today);
@@ -55,9 +54,9 @@ describe("recordLoginActivity", () => {
   it("昨日もログインしていれば連続日数が +1 になる", async () => {
     const yesterday = new Date("2026-03-28");
     mockPrisma.streak.upsert.mockResolvedValue(
-      streak({ loginCurrentStreak: 5, loginBestStreak: 10, lastLoginDate: yesterday }) as any,
+      streak({ loginCurrentStreak: 5, loginBestStreak: 10, lastLoginDate: yesterday }),
     );
-    mockPrisma.streak.update.mockResolvedValue({} as any);
+    mockPrisma.streak.update.mockResolvedValue(streak());
 
     const result = await recordLoginActivity("child-1", today);
 
@@ -75,9 +74,9 @@ describe("recordLoginActivity", () => {
   it("途切れた場合は loginCurrentStreak=1 にリセット、bestStreak は保持", async () => {
     const threeDaysAgo = new Date("2026-03-26");
     mockPrisma.streak.upsert.mockResolvedValue(
-      streak({ loginCurrentStreak: 10, loginBestStreak: 20, lastLoginDate: threeDaysAgo }) as any,
+      streak({ loginCurrentStreak: 10, loginBestStreak: 20, lastLoginDate: threeDaysAgo }),
     );
-    mockPrisma.streak.update.mockResolvedValue({} as any);
+    mockPrisma.streak.update.mockResolvedValue(streak());
 
     const result = await recordLoginActivity("child-1", today);
 
@@ -96,13 +95,13 @@ describe("recordLoginActivity", () => {
   it("10日連続ログインで +1pt が最少カテゴリ（全同値→STUDY）に付与される", async () => {
     const yesterday = new Date("2026-03-28");
     mockPrisma.streak.upsert.mockResolvedValue(
-      streak({ loginCurrentStreak: 9, loginBestStreak: 9, lastLoginDate: yesterday }) as any,
+      streak({ loginCurrentStreak: 9, loginBestStreak: 9, lastLoginDate: yesterday }),
     );
-    mockPrisma.streak.update.mockResolvedValue({} as any);
+    mockPrisma.streak.update.mockResolvedValue(streak());
     mockPrisma.user.findUnique.mockResolvedValue(
-      childUser({ evolutionStage: 1, evolutionPath: "STUDY", studyPt: 2, staminaPt: 2, lifePt: 2 }) as any,
+      childUser({ evolutionStage: 1, evolutionPath: "STUDY", studyPt: 2, staminaPt: 2, lifePt: 2 }),
     );
-    mockPrisma.user.update.mockResolvedValue({} as any);
+    mockPrisma.user.update.mockResolvedValue(childUser());
 
     const result = await recordLoginActivity("child-1", today);
 
@@ -118,13 +117,13 @@ describe("recordLoginActivity", () => {
   it("20日連続で +1pt が最少カテゴリ（LIFE=1）に付与される", async () => {
     const yesterday = new Date("2026-03-28");
     mockPrisma.streak.upsert.mockResolvedValue(
-      streak({ loginCurrentStreak: 19, loginBestStreak: 19, lastLoginDate: yesterday }) as any,
+      streak({ loginCurrentStreak: 19, loginBestStreak: 19, lastLoginDate: yesterday }),
     );
-    mockPrisma.streak.update.mockResolvedValue({} as any);
+    mockPrisma.streak.update.mockResolvedValue(streak());
     mockPrisma.user.findUnique.mockResolvedValue(
-      childUser({ evolutionStage: 1, evolutionPath: "STUDY", studyPt: 3, staminaPt: 2, lifePt: 1 }) as any,
+      childUser({ evolutionStage: 1, evolutionPath: "STUDY", studyPt: 3, staminaPt: 2, lifePt: 1 }),
     );
-    mockPrisma.user.update.mockResolvedValue({} as any);
+    mockPrisma.user.update.mockResolvedValue(childUser());
 
     const result = await recordLoginActivity("child-1", today);
 
@@ -140,13 +139,13 @@ describe("recordLoginActivity", () => {
   it("+1pt が最少カテゴリ（STAMINA=1）に付与される", async () => {
     const yesterday = new Date("2026-03-28");
     mockPrisma.streak.upsert.mockResolvedValue(
-      streak({ loginCurrentStreak: 29, loginBestStreak: 29, lastLoginDate: yesterday }) as any,
+      streak({ loginCurrentStreak: 29, loginBestStreak: 29, lastLoginDate: yesterday }),
     );
-    mockPrisma.streak.update.mockResolvedValue({} as any);
+    mockPrisma.streak.update.mockResolvedValue(streak());
     mockPrisma.user.findUnique.mockResolvedValue(
-      childUser({ evolutionStage: 1, evolutionPath: "STUDY", studyPt: 3, staminaPt: 1, lifePt: 2 }) as any,
+      childUser({ evolutionStage: 1, evolutionPath: "STUDY", studyPt: 3, staminaPt: 1, lifePt: 2 }),
     );
-    mockPrisma.user.update.mockResolvedValue({} as any);
+    mockPrisma.user.update.mockResolvedValue(childUser());
 
     const result = await recordLoginActivity("child-1", today);
 
@@ -161,9 +160,9 @@ describe("recordLoginActivity", () => {
   it("9日連続ではボーナスなし", async () => {
     const yesterday = new Date("2026-03-28");
     mockPrisma.streak.upsert.mockResolvedValue(
-      streak({ loginCurrentStreak: 8, loginBestStreak: 8, lastLoginDate: yesterday }) as any,
+      streak({ loginCurrentStreak: 8, loginBestStreak: 8, lastLoginDate: yesterday }),
     );
-    mockPrisma.streak.update.mockResolvedValue({} as any);
+    mockPrisma.streak.update.mockResolvedValue(streak());
 
     const result = await recordLoginActivity("child-1", today);
 
@@ -174,9 +173,9 @@ describe("recordLoginActivity", () => {
   it("rebirthPending中はボーナスでXPのみ加算し進化チェックをスキップ", async () => {
     const yesterday = new Date("2026-03-28");
     mockPrisma.streak.upsert.mockResolvedValue(
-      streak({ loginCurrentStreak: 9, loginBestStreak: 9, lastLoginDate: yesterday }) as any,
+      streak({ loginCurrentStreak: 9, loginBestStreak: 9, lastLoginDate: yesterday }),
     );
-    mockPrisma.streak.update.mockResolvedValue({} as any);
+    mockPrisma.streak.update.mockResolvedValue(streak());
     mockPrisma.user.findUnique.mockResolvedValue(
       childUser({
         evolutionStage: 3,
@@ -184,14 +183,15 @@ describe("recordLoginActivity", () => {
         studyPt: 15, staminaPt: 2, lifePt: 2,
         rebirthPending: true,
         collectedPaths: '["STUDY","STUDY_STAMINA","STUDY_STAMINA_LIFE"]',
-      }) as any,
+      }),
     );
-    mockPrisma.user.update.mockResolvedValue({} as any);
+    mockPrisma.user.update.mockResolvedValue(childUser());
 
     const result = await recordLoginActivity("child-1", today);
 
     expect(result.bonusGranted).toBe(1);
-    // XPのみ加算、進化関連フィールドなし
+    // XPのみ加算、進化関連フィールドなし（= rebirthPendingチェックが先に行われ
+    // isReborn/rebirthEggBonus を使う進化チェック分岐がスキップされたことの確認）
     const updateData = mockPrisma.user.update.mock.calls[0][0].data;
     // addBonusToMinCategory: min=2(STAMINA=LIFE) → STAMINA に+1
     expect(updateData.staminaPt).toBe(3);
@@ -203,9 +203,9 @@ describe("recordLoginActivity", () => {
     vi.spyOn(Math, "random").mockReturnValue(0); // STUDY が選ばれる
     const yesterday = new Date("2026-03-28");
     mockPrisma.streak.upsert.mockResolvedValue(
-      streak({ loginCurrentStreak: 9, loginBestStreak: 9, lastLoginDate: yesterday }) as any,
+      streak({ loginCurrentStreak: 9, loginBestStreak: 9, lastLoginDate: yesterday }),
     );
-    mockPrisma.streak.update.mockResolvedValue({} as any);
+    mockPrisma.streak.update.mockResolvedValue(streak());
     // stage1、9pt蓄積中。ボーナス1ptで total=10 → 10以上なので進化する
     mockPrisma.user.findUnique.mockResolvedValue(
       childUser({
@@ -214,12 +214,13 @@ describe("recordLoginActivity", () => {
         studyPt: 4, staminaPt: 3, lifePt: 2,
         collectedPaths: '["STUDY"]',
         monsterLevels: "{}",
-      }) as any,
+      }),
     );
-    mockPrisma.user.update.mockResolvedValue({} as any);
+    mockPrisma.user.update.mockResolvedValue(childUser());
 
     await recordLoginActivity("child-1", today);
 
+    // isReborn（collectedPaths.length > 0）で進化した結果、collectedPaths/monsterLevels が更新されること
     const updateData = mockPrisma.user.update.mock.calls[0][0].data;
     expect(updateData).toHaveProperty("collectedPaths");
     expect(updateData).toHaveProperty("monsterLevels");
@@ -232,9 +233,9 @@ describe("recordLoginActivity", () => {
     vi.spyOn(Math, "random").mockReturnValue(0); // STUDY が選ばれる
     const yesterday = new Date("2026-03-28");
     mockPrisma.streak.upsert.mockResolvedValue(
-      streak({ loginCurrentStreak: 9, loginBestStreak: 9, lastLoginDate: yesterday }) as any,
+      streak({ loginCurrentStreak: 9, loginBestStreak: 9, lastLoginDate: yesterday }),
     );
-    mockPrisma.streak.update.mockResolvedValue({} as any);
+    mockPrisma.streak.update.mockResolvedValue(streak());
     mockPrisma.user.findUnique.mockResolvedValue(
       childUser({
         evolutionStage: 1,
@@ -242,9 +243,9 @@ describe("recordLoginActivity", () => {
         studyPt: 4, staminaPt: 3, lifePt: 2,
         collectedPaths: '["STUDY"]',
         monsterLevels: "{}",
-      }) as any,
+      }),
     );
-    mockPrisma.user.update.mockResolvedValue({} as any);
+    mockPrisma.user.update.mockResolvedValue(childUser());
 
     await recordLoginActivity("child-1", today);
     await new Promise((r) => setImmediate(r));
@@ -260,14 +261,14 @@ describe("recordLoginActivity", () => {
   it("ボーナスで進化しなかった場合、triggerMonsterEvolvedLog は呼ばれない", async () => {
     const yesterday = new Date("2026-03-28");
     mockPrisma.streak.upsert.mockResolvedValue(
-      streak({ loginCurrentStreak: 9, loginBestStreak: 9, lastLoginDate: yesterday }) as any,
+      streak({ loginCurrentStreak: 9, loginBestStreak: 9, lastLoginDate: yesterday }),
     );
-    mockPrisma.streak.update.mockResolvedValue({} as any);
+    mockPrisma.streak.update.mockResolvedValue(streak());
     // 進化が発動しない範囲: stage1, 合計2+1=3pt < 10
     mockPrisma.user.findUnique.mockResolvedValue(
-      childUser({ evolutionStage: 1, evolutionPath: "STUDY", studyPt: 0, staminaPt: 1, lifePt: 1 }) as any,
+      childUser({ evolutionStage: 1, evolutionPath: "STUDY", studyPt: 0, staminaPt: 1, lifePt: 1 }),
     );
-    mockPrisma.user.update.mockResolvedValue({} as any);
+    mockPrisma.user.update.mockResolvedValue(childUser());
 
     await recordLoginActivity("child-1", today);
     await new Promise((r) => setImmediate(r));
@@ -278,9 +279,9 @@ describe("recordLoginActivity", () => {
   it("rebirthPending中のボーナスでは進化しないので triggerMonsterEvolvedLog は呼ばれない", async () => {
     const yesterday = new Date("2026-03-28");
     mockPrisma.streak.upsert.mockResolvedValue(
-      streak({ loginCurrentStreak: 9, loginBestStreak: 9, lastLoginDate: yesterday }) as any,
+      streak({ loginCurrentStreak: 9, loginBestStreak: 9, lastLoginDate: yesterday }),
     );
-    mockPrisma.streak.update.mockResolvedValue({} as any);
+    mockPrisma.streak.update.mockResolvedValue(streak());
     mockPrisma.user.findUnique.mockResolvedValue(
       childUser({
         evolutionStage: 3,
@@ -288,9 +289,9 @@ describe("recordLoginActivity", () => {
         studyPt: 15, staminaPt: 2, lifePt: 2,
         rebirthPending: true,
         collectedPaths: '["STUDY","STUDY_STAMINA","STUDY_STAMINA_LIFE"]',
-      }) as any,
+      }),
     );
-    mockPrisma.user.update.mockResolvedValue({} as any);
+    mockPrisma.user.update.mockResolvedValue(childUser());
 
     await recordLoginActivity("child-1", today);
     await new Promise((r) => setImmediate(r));

--- a/src/__tests__/lib/quests.test.ts
+++ b/src/__tests__/lib/quests.test.ts
@@ -3,9 +3,30 @@ import {
   ensureTodayQuests,
   cleanupStaleCarryOverInstances,
 } from "@/lib/quests";
-import { prisma } from "@/lib/prisma";
+import type { Prisma } from "@/generated/prisma/client";
+import { prismaMock as mockPrisma } from "../helpers/prisma-mock";
+import { taskTemplate, questInstance } from "../helpers/fixtures";
 
-const mockPrisma = vi.mocked(prisma);
+/**
+ * `mockImplementation` の戻り値は実際の Prisma メソッドと同じ `PrismaPromise<T>` 型が
+ * 要求されるが、`vitest-mock-extended` の DeepMockProxy はジェネリックオーバーロードを
+ * 保持しないためテストコード側では通常の `Promise` しか作れない。
+ * `PrismaPromise` は実行時には通常の thenable として振る舞うため、型だけ合わせる。
+ */
+function asPrismaPromise<T>(value: T): Prisma.PrismaPromise<T> {
+  return Promise.resolve(value) as unknown as Prisma.PrismaPromise<T>;
+}
+
+/**
+ * `findFirst` の実際の戻り値型は `Prisma__QuestInstanceClient`（リレーション用の
+ * フィールドアクセサが付与された Promise 派生型）だが、テストコード側では構築できない
+ * ため `PrismaPromise` ベースの実装を `mockImplementation` が要求する関数型にキャストする。
+ */
+function asFindFirstImpl(
+  fn: (args?: Prisma.QuestInstanceFindFirstArgs) => Prisma.PrismaPromise<Prisma.QuestInstanceGetPayload<object> | null>,
+): Parameters<typeof mockPrisma.questInstance.findFirst.mockImplementation>[0] {
+  return fn as unknown as Parameters<typeof mockPrisma.questInstance.findFirst.mockImplementation>[0];
+}
 
 beforeEach(() => {
   vi.clearAllMocks();
@@ -21,10 +42,10 @@ describe("ensureTodayQuests", () => {
     vi.setSystemTime(new Date("2026-03-12T09:00:00")); // 木曜(4)
 
     const templates = [
-      { id: "tpl-1", title: "宿題", emoji: "📚", category: "STUDY", repeatDays: [4], isTemporary: false, carryOver: false },
+      taskTemplate({ id: "tpl-1", title: "宿題", emoji: "📚", category: "STUDY", repeatDays: [4], isTemporary: false, carryOver: false }),
     ];
-    mockPrisma.taskTemplate.findMany.mockResolvedValue(templates as any);
-    mockPrisma.questInstance.upsert.mockResolvedValue({} as any);
+    mockPrisma.taskTemplate.findMany.mockResolvedValue(templates);
+    mockPrisma.questInstance.upsert.mockResolvedValue(questInstance());
 
     await ensureTodayQuests({ childId: "child-1", familyId: "fam-1" });
 
@@ -52,12 +73,12 @@ describe("ensureTodayQuests", () => {
     vi.setSystemTime(new Date("2026-03-13T09:00:00")); // 金曜(5)
 
     const templates = [
-      { id: "tpl-1", title: "宿題", emoji: "📚", category: "STUDY", repeatDays: [5], isTemporary: false, carryOver: true },
+      taskTemplate({ id: "tpl-1", title: "宿題", emoji: "📚", category: "STUDY", repeatDays: [5], isTemporary: false, carryOver: true }),
     ];
-    mockPrisma.taskTemplate.findMany.mockResolvedValue(templates as any);
+    mockPrisma.taskTemplate.findMany.mockResolvedValue(templates);
     // 直近 settled クエリ用のデフォルト
-    mockPrisma.questInstance.findMany.mockResolvedValue([] as any);
-    mockPrisma.questInstance.findFirst.mockResolvedValue({ id: "q-old", status: "PENDING" } as any);
+    mockPrisma.questInstance.findMany.mockResolvedValue([]);
+    mockPrisma.questInstance.findFirst.mockResolvedValue(questInstance({ id: "q-old", status: "PENDING" }));
 
     await ensureTodayQuests({ childId: "child-1", familyId: "fam-1" });
 
@@ -68,12 +89,12 @@ describe("ensureTodayQuests", () => {
     vi.setSystemTime(new Date("2026-03-13T09:00:00")); // 金曜(5)
 
     const templates = [
-      { id: "tpl-1", title: "宿題", emoji: "📚", category: "STUDY", repeatDays: [5], isTemporary: false, carryOver: true },
+      taskTemplate({ id: "tpl-1", title: "宿題", emoji: "📚", category: "STUDY", repeatDays: [5], isTemporary: false, carryOver: true }),
     ];
-    mockPrisma.taskTemplate.findMany.mockResolvedValue(templates as any);
-    mockPrisma.questInstance.findMany.mockResolvedValue([] as any);
+    mockPrisma.taskTemplate.findMany.mockResolvedValue(templates);
+    mockPrisma.questInstance.findMany.mockResolvedValue([]);
     mockPrisma.questInstance.findFirst.mockResolvedValue(null);
-    mockPrisma.questInstance.upsert.mockResolvedValue({} as any);
+    mockPrisma.questInstance.upsert.mockResolvedValue(questInstance());
 
     await ensureTodayQuests({ childId: "child-1", familyId: "fam-1" });
 
@@ -92,21 +113,21 @@ describe("ensureTodayQuests", () => {
     vi.setSystemTime(new Date("2026-03-13T09:00:00")); // 金曜(5)
 
     const templates = [
-      { id: "tpl-1", title: "宿題", emoji: "📚", category: "STUDY", repeatDays: [5], isTemporary: false, carryOver: true },
+      taskTemplate({ id: "tpl-1", title: "宿題", emoji: "📚", category: "STUDY", repeatDays: [5], isTemporary: false, carryOver: true }),
     ];
-    mockPrisma.taskTemplate.findMany.mockResolvedValue(templates as any);
-    mockPrisma.questInstance.findMany.mockResolvedValue([] as any);
+    mockPrisma.taskTemplate.findMany.mockResolvedValue(templates);
+    mockPrisma.questInstance.findMany.mockResolvedValue([]);
     // DB の where 条件を簡易シミュレート: status: PENDING 単一指定では REPORTED は引っかからない
-    mockPrisma.questInstance.findFirst.mockImplementation((args: any) => {
+    mockPrisma.questInstance.findFirst.mockImplementation(asFindFirstImpl((args) => {
       const status = args?.where?.status;
-      const existing = { id: "q-yesterday", status: "REPORTED" };
+      const existing = questInstance({ id: "q-yesterday", status: "REPORTED" });
       if (status && typeof status === "object" && Array.isArray(status.in) && status.in.includes("REPORTED")) {
-        return Promise.resolve(existing as any);
+        return asPrismaPromise(existing);
       }
       // status: "PENDING" 単一指定など、REPORTED を含まないクエリでは見つからない
-      return Promise.resolve(null);
-    });
-    mockPrisma.questInstance.upsert.mockResolvedValue({} as any);
+      return asPrismaPromise(null);
+    }));
+    mockPrisma.questInstance.upsert.mockResolvedValue(questInstance());
 
     await ensureTodayQuests({ childId: "child-1", familyId: "fam-1" });
 
@@ -117,19 +138,19 @@ describe("ensureTodayQuests", () => {
     vi.setSystemTime(new Date("2026-03-13T09:00:00"));
 
     const templates = [
-      { id: "tpl-1", title: "宿題", emoji: "📚", category: "STUDY", repeatDays: [5], isTemporary: false, carryOver: true },
+      taskTemplate({ id: "tpl-1", title: "宿題", emoji: "📚", category: "STUDY", repeatDays: [5], isTemporary: false, carryOver: true }),
     ];
-    mockPrisma.taskTemplate.findMany.mockResolvedValue(templates as any);
-    mockPrisma.questInstance.findMany.mockResolvedValue([] as any);
-    mockPrisma.questInstance.findFirst.mockImplementation((args: any) => {
+    mockPrisma.taskTemplate.findMany.mockResolvedValue(templates);
+    mockPrisma.questInstance.findMany.mockResolvedValue([]);
+    mockPrisma.questInstance.findFirst.mockImplementation(asFindFirstImpl((args) => {
       const status = args?.where?.status;
-      const existing = { id: "q-yesterday", status: "SKIP_REPORTED" };
+      const existing = questInstance({ id: "q-yesterday", status: "SKIP_REPORTED" });
       if (status && typeof status === "object" && Array.isArray(status.in) && status.in.includes("SKIP_REPORTED")) {
-        return Promise.resolve(existing as any);
+        return asPrismaPromise(existing);
       }
-      return Promise.resolve(null);
-    });
-    mockPrisma.questInstance.upsert.mockResolvedValue({} as any);
+      return asPrismaPromise(null);
+    }));
+    mockPrisma.questInstance.upsert.mockResolvedValue(questInstance());
 
     await ensureTodayQuests({ childId: "child-1", familyId: "fam-1" });
 
@@ -140,12 +161,12 @@ describe("ensureTodayQuests", () => {
     vi.setSystemTime(new Date("2026-03-13T09:00:00"));
 
     const templates = [
-      { id: "tpl-1", title: "宿題", emoji: "📚", category: "STUDY", repeatDays: [5], isTemporary: false, carryOver: true },
+      taskTemplate({ id: "tpl-1", title: "宿題", emoji: "📚", category: "STUDY", repeatDays: [5], isTemporary: false, carryOver: true }),
     ];
-    mockPrisma.taskTemplate.findMany.mockResolvedValue(templates as any);
-    mockPrisma.questInstance.findMany.mockResolvedValue([] as any);
+    mockPrisma.taskTemplate.findMany.mockResolvedValue(templates);
+    mockPrisma.questInstance.findMany.mockResolvedValue([]);
     mockPrisma.questInstance.findFirst.mockResolvedValue(null);
-    mockPrisma.questInstance.upsert.mockResolvedValue({} as any);
+    mockPrisma.questInstance.upsert.mockResolvedValue(questInstance());
 
     await ensureTodayQuests({ childId: "child-1", familyId: "fam-1" });
 
@@ -156,10 +177,10 @@ describe("ensureTodayQuests", () => {
     vi.setSystemTime(new Date("2026-03-13T09:00:00"));
 
     const templates = [
-      { id: "tpl-1", title: "宿題", emoji: "📚", category: "STUDY", repeatDays: [5], isTemporary: false, carryOver: false },
+      taskTemplate({ id: "tpl-1", title: "宿題", emoji: "📚", category: "STUDY", repeatDays: [5], isTemporary: false, carryOver: false }),
     ];
-    mockPrisma.taskTemplate.findMany.mockResolvedValue(templates as any);
-    mockPrisma.questInstance.upsert.mockResolvedValue({} as any);
+    mockPrisma.taskTemplate.findMany.mockResolvedValue(templates);
+    mockPrisma.questInstance.upsert.mockResolvedValue(questInstance());
 
     await ensureTodayQuests({ childId: "child-1", familyId: "fam-1" });
 
@@ -170,7 +191,7 @@ describe("ensureTodayQuests", () => {
   it("テンプレートが空なら何も書き込まないこと", async () => {
     vi.setSystemTime(new Date("2026-03-13T09:00:00"));
 
-    mockPrisma.taskTemplate.findMany.mockResolvedValue([] as any);
+    mockPrisma.taskTemplate.findMany.mockResolvedValue([]);
 
     await ensureTodayQuests({ childId: "child-1", familyId: "fam-1" });
 
@@ -181,7 +202,7 @@ describe("ensureTodayQuests", () => {
   it("findMany の where 条件に pausedAt: null が含まれること（一時停止中のテンプレートを対象外）", async () => {
     vi.setSystemTime(new Date("2026-03-12T09:00:00")); // 木曜(4)
 
-    mockPrisma.taskTemplate.findMany.mockResolvedValue([] as any);
+    mockPrisma.taskTemplate.findMany.mockResolvedValue([]);
 
     await ensureTodayQuests({ childId: "child-1", familyId: "fam-1" });
 
@@ -199,16 +220,16 @@ describe("ensureTodayQuests", () => {
     vi.setSystemTime(new Date("2026-03-13T09:00:00")); // 金曜(5)
 
     const templates = [
-      { id: "tpl-1", title: "宿題", emoji: "📚", category: "STUDY", repeatDays: [5], isTemporary: false, carryOver: true },
+      taskTemplate({ id: "tpl-1", title: "宿題", emoji: "📚", category: "STUDY", repeatDays: [5], isTemporary: false, carryOver: true }),
     ];
-    mockPrisma.taskTemplate.findMany.mockResolvedValue(templates as any);
+    mockPrisma.taskTemplate.findMany.mockResolvedValue(templates);
     // 直近 APPROVED が存在する想定（クリーンアップが発火する前提）
     mockPrisma.questInstance.findMany.mockResolvedValue([
-      { templateId: "tpl-1", date: new Date("2026-03-06T00:00:00Z") },
-    ] as any);
+      questInstance({ templateId: "tpl-1", date: new Date("2026-03-06T00:00:00Z") }),
+    ]);
     mockPrisma.questInstance.findFirst.mockResolvedValue(null);
-    mockPrisma.questInstance.upsert.mockResolvedValue({} as any);
-    mockPrisma.questInstance.updateMany.mockResolvedValue({ count: 1 } as any);
+    mockPrisma.questInstance.upsert.mockResolvedValue(questInstance());
+    mockPrisma.questInstance.updateMany.mockResolvedValue({ count: 1 });
 
     await ensureTodayQuests({ childId: "child-1", familyId: "fam-1" });
 
@@ -238,9 +259,9 @@ describe("cleanupStaleCarryOverInstances", () => {
   it("直近 APPROVED より古い PENDING / REPORTED / SKIP_REPORTED を REJECTED に変換すること", async () => {
     const settledDate = new Date("2026-03-13T00:00:00Z");
     mockPrisma.questInstance.findMany.mockResolvedValue([
-      { templateId: "tpl-1", date: settledDate },
-    ] as any);
-    mockPrisma.questInstance.updateMany.mockResolvedValue({ count: 3 } as any);
+      questInstance({ templateId: "tpl-1", date: settledDate }),
+    ]);
+    mockPrisma.questInstance.updateMany.mockResolvedValue({ count: 3 });
 
     await cleanupStaleCarryOverInstances({
       childId: "child-1",
@@ -264,7 +285,7 @@ describe("cleanupStaleCarryOverInstances", () => {
   });
 
   it("APPROVED/SKIPPED 履歴がないテンプレートには updateMany を呼ばないこと", async () => {
-    mockPrisma.questInstance.findMany.mockResolvedValue([] as any);
+    mockPrisma.questInstance.findMany.mockResolvedValue([]);
 
     await cleanupStaleCarryOverInstances({
       childId: "child-1",
@@ -276,19 +297,20 @@ describe("cleanupStaleCarryOverInstances", () => {
 
   it("APPROVED 履歴がなくても複数 PENDING があれば最新を残して古いものを REJECTED に縮約すること", async () => {
     // settled は空（APPROVED/SKIPPED なし）
-    mockPrisma.questInstance.findMany.mockImplementation((args: any) => {
+    mockPrisma.questInstance.findMany.mockImplementation((args?: Prisma.QuestInstanceFindManyArgs) => {
       // settled クエリ
-      if (args?.where?.status?.in?.includes("APPROVED")) {
-        return Promise.resolve([] as any);
+      const status = args?.where?.status;
+      if (status && typeof status === "object" && Array.isArray(status.in) && status.in.includes("APPROVED")) {
+        return asPrismaPromise([]);
       }
       // duplicate collapse 用 active 取得（PENDING/REPORTED/SKIP_REPORTED）
-      return Promise.resolve([
-        { id: "q-old", templateId: "tpl-1", date: new Date("2026-03-10T00:00:00Z"), status: "PENDING" },
-        { id: "q-mid", templateId: "tpl-1", date: new Date("2026-03-11T00:00:00Z"), status: "PENDING" },
-        { id: "q-new", templateId: "tpl-1", date: new Date("2026-03-12T00:00:00Z"), status: "PENDING" },
-      ] as any);
+      return asPrismaPromise([
+        questInstance({ id: "q-old", templateId: "tpl-1", date: new Date("2026-03-10T00:00:00Z"), status: "PENDING" }),
+        questInstance({ id: "q-mid", templateId: "tpl-1", date: new Date("2026-03-11T00:00:00Z"), status: "PENDING" }),
+        questInstance({ id: "q-new", templateId: "tpl-1", date: new Date("2026-03-12T00:00:00Z"), status: "PENDING" }),
+      ]);
     });
-    mockPrisma.questInstance.updateMany.mockResolvedValue({ count: 2 } as any);
+    mockPrisma.questInstance.updateMany.mockResolvedValue({ count: 2 });
 
     await cleanupStaleCarryOverInstances({
       childId: "child-1",
@@ -310,17 +332,18 @@ describe("cleanupStaleCarryOverInstances", () => {
   });
 
   it("REPORTED と複数 PENDING が混在する場合は REPORTED を残して PENDING を REJECTED にすること", async () => {
-    mockPrisma.questInstance.findMany.mockImplementation((args: any) => {
-      if (args?.where?.status?.in?.includes("APPROVED")) {
-        return Promise.resolve([] as any);
+    mockPrisma.questInstance.findMany.mockImplementation((args?: Prisma.QuestInstanceFindManyArgs) => {
+      const status = args?.where?.status;
+      if (status && typeof status === "object" && Array.isArray(status.in) && status.in.includes("APPROVED")) {
+        return asPrismaPromise([]);
       }
-      return Promise.resolve([
-        { id: "q-pend-old", templateId: "tpl-1", date: new Date("2026-03-10T00:00:00Z"), status: "PENDING" },
-        { id: "q-reported", templateId: "tpl-1", date: new Date("2026-03-11T00:00:00Z"), status: "REPORTED" },
-        { id: "q-pend-new", templateId: "tpl-1", date: new Date("2026-03-12T00:00:00Z"), status: "PENDING" },
-      ] as any);
+      return asPrismaPromise([
+        questInstance({ id: "q-pend-old", templateId: "tpl-1", date: new Date("2026-03-10T00:00:00Z"), status: "PENDING" }),
+        questInstance({ id: "q-reported", templateId: "tpl-1", date: new Date("2026-03-11T00:00:00Z"), status: "REPORTED" }),
+        questInstance({ id: "q-pend-new", templateId: "tpl-1", date: new Date("2026-03-12T00:00:00Z"), status: "PENDING" }),
+      ]);
     });
-    mockPrisma.questInstance.updateMany.mockResolvedValue({ count: 2 } as any);
+    mockPrisma.questInstance.updateMany.mockResolvedValue({ count: 2 });
 
     await cleanupStaleCarryOverInstances({
       childId: "child-1",
@@ -341,13 +364,14 @@ describe("cleanupStaleCarryOverInstances", () => {
   });
 
   it("アクティブインスタンスが 1 件だけなら縮約は走らないこと", async () => {
-    mockPrisma.questInstance.findMany.mockImplementation((args: any) => {
-      if (args?.where?.status?.in?.includes("APPROVED")) {
-        return Promise.resolve([] as any);
+    mockPrisma.questInstance.findMany.mockImplementation((args?: Prisma.QuestInstanceFindManyArgs) => {
+      const status = args?.where?.status;
+      if (status && typeof status === "object" && Array.isArray(status.in) && status.in.includes("APPROVED")) {
+        return asPrismaPromise([]);
       }
-      return Promise.resolve([
-        { id: "q-only", templateId: "tpl-1", date: new Date("2026-03-10T00:00:00Z"), status: "PENDING" },
-      ] as any);
+      return asPrismaPromise([
+        questInstance({ id: "q-only", templateId: "tpl-1", date: new Date("2026-03-10T00:00:00Z"), status: "PENDING" }),
+      ]);
     });
 
     await cleanupStaleCarryOverInstances({
@@ -362,9 +386,9 @@ describe("cleanupStaleCarryOverInstances", () => {
     const settledDate = new Date("2026-03-13T00:00:00Z");
     // 直近 settled クエリは carryOver=true の templateId だけ問い合わせる想定
     mockPrisma.questInstance.findMany.mockResolvedValue([
-      { templateId: "tpl-1", date: settledDate },
-    ] as any);
-    mockPrisma.questInstance.updateMany.mockResolvedValue({ count: 1 } as any);
+      questInstance({ templateId: "tpl-1", date: settledDate }),
+    ]);
+    mockPrisma.questInstance.updateMany.mockResolvedValue({ count: 1 });
 
     await cleanupStaleCarryOverInstances({
       childId: "child-1",

--- a/src/__tests__/lib/streak.test.ts
+++ b/src/__tests__/lib/streak.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { prisma } from "@/lib/prisma";
 import { recordDailyAchievement } from "@/lib/streak";
 import { triggerMonsterEvolvedLog } from "@/lib/bulletinLog";
+import { prismaMock as mockPrisma } from "../helpers/prisma-mock";
 import { childUser, streak } from "../helpers/fixtures";
 
 vi.mock("@/lib/bulletinLog", () => ({
@@ -10,7 +10,6 @@ vi.mock("@/lib/bulletinLog", () => ({
   triggerStreakTitleLog: vi.fn().mockResolvedValue(undefined),
 }));
 
-const mockPrisma = vi.mocked(prisma);
 const mockTriggerMonsterEvolvedLog = vi.mocked(triggerMonsterEvolvedLog);
 
 beforeEach(() => {
@@ -29,7 +28,7 @@ describe("recordDailyAchievement", () => {
 
   it("必要数に達していなければ何もしない（minTasks=3, achieved=1）", async () => {
     mockPrisma.user.findUnique.mockResolvedValue(
-      childUser({ minTasksForStreak: 3 }) as any,
+      childUser({ minTasksForStreak: 3 }),
     );
     mockCounts(1, 5);
 
@@ -40,7 +39,7 @@ describe("recordDailyAchievement", () => {
 
   it("既に超過していれば何もしない（minTasks=1, achieved=2）", async () => {
     mockPrisma.user.findUnique.mockResolvedValue(
-      childUser({ minTasksForStreak: 1 }) as any,
+      childUser({ minTasksForStreak: 1 }),
     );
     mockCounts(2, 3);
 
@@ -51,13 +50,13 @@ describe("recordDailyAchievement", () => {
 
   it("初回達成でcurrentStreak=1にする（minTasks=1）", async () => {
     mockPrisma.user.findUnique.mockResolvedValue(
-      childUser({ minTasksForStreak: 1 }) as any,
+      childUser({ minTasksForStreak: 1 }),
     );
     mockCounts(1, 3);
     mockPrisma.streak.upsert.mockResolvedValue(
-      streak({ currentStreak: 0, bestStreak: 0, lastAchievedDate: null }) as any,
+      streak({ currentStreak: 0, bestStreak: 0, lastAchievedDate: null }),
     );
-    mockPrisma.streak.update.mockResolvedValue({} as any);
+    mockPrisma.streak.update.mockResolvedValue(streak());
 
     await recordDailyAchievement("child-1", today);
 
@@ -74,13 +73,13 @@ describe("recordDailyAchievement", () => {
   it("昨日も達成済みなら連続日数を+1する", async () => {
     const yesterday = new Date("2026-03-12");
     mockPrisma.user.findUnique.mockResolvedValue(
-      childUser({ minTasksForStreak: 1 }) as any,
+      childUser({ minTasksForStreak: 1 }),
     );
     mockCounts(1, 3);
     mockPrisma.streak.upsert.mockResolvedValue(
-      streak({ currentStreak: 5, bestStreak: 10, lastAchievedDate: yesterday }) as any,
+      streak({ currentStreak: 5, bestStreak: 10, lastAchievedDate: yesterday }),
     );
-    mockPrisma.streak.update.mockResolvedValue({} as any);
+    mockPrisma.streak.update.mockResolvedValue(streak());
 
     await recordDailyAchievement("child-1", today);
 
@@ -97,13 +96,13 @@ describe("recordDailyAchievement", () => {
   it("途切れた場合はcurrentStreak=1にリセットし、bestStreakは保持", async () => {
     const threeDaysAgo = new Date("2026-03-10");
     mockPrisma.user.findUnique.mockResolvedValue(
-      childUser({ minTasksForStreak: 1 }) as any,
+      childUser({ minTasksForStreak: 1 }),
     );
     mockCounts(1, 3);
     mockPrisma.streak.upsert.mockResolvedValue(
-      streak({ currentStreak: 5, bestStreak: 10, lastAchievedDate: threeDaysAgo }) as any,
+      streak({ currentStreak: 5, bestStreak: 10, lastAchievedDate: threeDaysAgo }),
     );
-    mockPrisma.streak.update.mockResolvedValue({} as any);
+    mockPrisma.streak.update.mockResolvedValue(streak());
 
     await recordDailyAchievement("child-1", today);
 
@@ -119,11 +118,11 @@ describe("recordDailyAchievement", () => {
 
   it("同日2回目の承認では変化なし（lastAchievedDate=今日）", async () => {
     mockPrisma.user.findUnique.mockResolvedValue(
-      childUser({ minTasksForStreak: 1 }) as any,
+      childUser({ minTasksForStreak: 1 }),
     );
     mockCounts(1, 3);
     mockPrisma.streak.upsert.mockResolvedValue(
-      streak({ currentStreak: 3, bestStreak: 5, lastAchievedDate: today }) as any,
+      streak({ currentStreak: 3, bestStreak: 5, lastAchievedDate: today }),
     );
 
     await recordDailyAchievement("child-1", today);
@@ -134,13 +133,13 @@ describe("recordDailyAchievement", () => {
   it("minTasks=3で3件目の達成（APPROVED+SKIPPED）でストリーク達成", async () => {
     const yesterday = new Date("2026-03-12");
     mockPrisma.user.findUnique.mockResolvedValue(
-      childUser({ minTasksForStreak: 3 }) as any,
+      childUser({ minTasksForStreak: 3 }),
     );
     mockCounts(3, 5); // ちょうど3件 = 達成
     mockPrisma.streak.upsert.mockResolvedValue(
-      streak({ currentStreak: 2, bestStreak: 2, lastAchievedDate: yesterday }) as any,
+      streak({ currentStreak: 2, bestStreak: 2, lastAchievedDate: yesterday }),
     );
-    mockPrisma.streak.update.mockResolvedValue({} as any);
+    mockPrisma.streak.update.mockResolvedValue(streak());
 
     await recordDailyAchievement("child-1", today);
 
@@ -157,13 +156,13 @@ describe("recordDailyAchievement", () => {
   it("タスク総数が最低数未満なら全完了で達成（total=2, min=3 → required=2）", async () => {
     const yesterday = new Date("2026-03-12");
     mockPrisma.user.findUnique.mockResolvedValue(
-      childUser({ minTasksForStreak: 3 }) as any,
+      childUser({ minTasksForStreak: 3 }),
     );
     mockCounts(2, 2); // total=2 < min=3 → required=2, achieved=2 → 達成
     mockPrisma.streak.upsert.mockResolvedValue(
-      streak({ currentStreak: 1, bestStreak: 5, lastAchievedDate: yesterday }) as any,
+      streak({ currentStreak: 1, bestStreak: 5, lastAchievedDate: yesterday }),
     );
-    mockPrisma.streak.update.mockResolvedValue({} as any);
+    mockPrisma.streak.update.mockResolvedValue(streak());
 
     await recordDailyAchievement("child-1", today);
 
@@ -181,14 +180,14 @@ describe("recordDailyAchievement", () => {
     const yesterday = new Date("2026-03-12");
     // 最初の findUnique は minTasksForStreak 取得用
     mockPrisma.user.findUnique
-      .mockResolvedValueOnce(childUser({ minTasksForStreak: 1 }) as any)
-      .mockResolvedValueOnce(childUser({ studyPt: 5, staminaPt: 3, lifePt: 2 }) as any);
+      .mockResolvedValueOnce(childUser({ minTasksForStreak: 1 }))
+      .mockResolvedValueOnce(childUser({ studyPt: 5, staminaPt: 3, lifePt: 2 }));
     mockCounts(1, 3);
     mockPrisma.streak.upsert.mockResolvedValue(
-      streak({ currentStreak: 2, bestStreak: 2, lastAchievedDate: yesterday }) as any,
+      streak({ currentStreak: 2, bestStreak: 2, lastAchievedDate: yesterday }),
     );
-    mockPrisma.streak.update.mockResolvedValue({} as any);
-    mockPrisma.user.update.mockResolvedValue({} as any);
+    mockPrisma.streak.update.mockResolvedValue(streak());
+    mockPrisma.user.update.mockResolvedValue(childUser());
 
     await recordDailyAchievement("child-1", today);
 
@@ -198,24 +197,25 @@ describe("recordDailyAchievement", () => {
   it("rebirthPending中はマイルストーンボーナスでXPのみ加算し進化チェックをスキップ", async () => {
     const yesterday = new Date("2026-03-12");
     mockPrisma.user.findUnique
-      .mockResolvedValueOnce(childUser({ minTasksForStreak: 1 }) as any)
+      .mockResolvedValueOnce(childUser({ minTasksForStreak: 1 }))
       .mockResolvedValueOnce(childUser({
         studyPt: 15, staminaPt: 3, lifePt: 2,
         rebirthPending: true,
         evolutionStage: 3,
         evolutionPath: "STUDY_STAMINA_LIFE",
         collectedPaths: '["STUDY","STUDY_STAMINA","STUDY_STAMINA_LIFE"]',
-      }) as any);
+      }));
     mockCounts(1, 3);
     mockPrisma.streak.upsert.mockResolvedValue(
-      streak({ currentStreak: 2, bestStreak: 2, lastAchievedDate: yesterday }) as any,
+      streak({ currentStreak: 2, bestStreak: 2, lastAchievedDate: yesterday }),
     );
-    mockPrisma.streak.update.mockResolvedValue({} as any);
-    mockPrisma.user.update.mockResolvedValue({} as any);
+    mockPrisma.streak.update.mockResolvedValue(streak());
+    mockPrisma.user.update.mockResolvedValue(childUser());
 
     await recordDailyAchievement("child-1", today);
 
-    // XPのみ加算、進化関連フィールドは更新されないこと
+    // XPのみ加算、進化関連フィールドは更新されないこと（= rebirthPendingチェックが先に行われ
+    // isReborn/rebirthEggBonus を使う進化チェック分岐がスキップされたことの確認）
     expect(mockPrisma.user.update).toHaveBeenCalledWith(
       expect.objectContaining({
         data: expect.objectContaining({
@@ -236,24 +236,25 @@ describe("recordDailyAchievement", () => {
     // stage2、9pt蓄積中。ボーナス5ptで total=14 → 30未満なので進化しない
     // stage1、9pt蓄積中。ボーナス5ptで total=14 → 10以上なので進化する
     mockPrisma.user.findUnique
-      .mockResolvedValueOnce(childUser({ minTasksForStreak: 1 }) as any)
+      .mockResolvedValueOnce(childUser({ minTasksForStreak: 1 }))
       .mockResolvedValueOnce(childUser({
         studyPt: 4, staminaPt: 3, lifePt: 2,
         evolutionStage: 1,
         evolutionPath: "STUDY",
         collectedPaths: '["STUDY"]',
         monsterLevels: "{}",
-      }) as any);
+      }));
     mockCounts(1, 3);
     mockPrisma.streak.upsert.mockResolvedValue(
-      streak({ currentStreak: 2, bestStreak: 2, lastAchievedDate: yesterday }) as any,
+      streak({ currentStreak: 2, bestStreak: 2, lastAchievedDate: yesterday }),
     );
-    mockPrisma.streak.update.mockResolvedValue({} as any);
-    mockPrisma.user.update.mockResolvedValue({} as any);
+    mockPrisma.streak.update.mockResolvedValue(streak());
+    mockPrisma.user.update.mockResolvedValue(childUser());
 
     await recordDailyAchievement("child-1", today);
 
-    // collectedPaths に新パスが追加されること
+    // collectedPaths に新パスが追加されること（isReborn 判定に使う collectedPaths が
+    // 進化後に更新されていることの確認）
     const updateData = mockPrisma.user.update.mock.calls[0][0].data;
     expect(updateData).toHaveProperty("collectedPaths");
     expect(updateData).toHaveProperty("monsterLevels");
@@ -266,20 +267,20 @@ describe("recordDailyAchievement", () => {
     vi.spyOn(Math, "random").mockReturnValue(0); // STUDY が選ばれる
     const yesterday = new Date("2026-03-12");
     mockPrisma.user.findUnique
-      .mockResolvedValueOnce(childUser({ minTasksForStreak: 1 }) as any)
+      .mockResolvedValueOnce(childUser({ minTasksForStreak: 1 }))
       .mockResolvedValueOnce(childUser({
         studyPt: 4, staminaPt: 3, lifePt: 2,
         evolutionStage: 1,
         evolutionPath: "STUDY",
         collectedPaths: '["STUDY"]',
         monsterLevels: "{}",
-      }) as any);
+      }));
     mockCounts(1, 3);
     mockPrisma.streak.upsert.mockResolvedValue(
-      streak({ currentStreak: 2, bestStreak: 2, lastAchievedDate: yesterday }) as any,
+      streak({ currentStreak: 2, bestStreak: 2, lastAchievedDate: yesterday }),
     );
-    mockPrisma.streak.update.mockResolvedValue({} as any);
-    mockPrisma.user.update.mockResolvedValue({} as any);
+    mockPrisma.streak.update.mockResolvedValue(streak());
+    mockPrisma.user.update.mockResolvedValue(childUser());
 
     await recordDailyAchievement("child-1", today);
     await new Promise((r) => setImmediate(r));
@@ -294,19 +295,19 @@ describe("recordDailyAchievement", () => {
   it("マイルストーンボーナスで進化しなかった場合、triggerMonsterEvolvedLog は呼ばれない", async () => {
     const yesterday = new Date("2026-03-12");
     mockPrisma.user.findUnique
-      .mockResolvedValueOnce(childUser({ minTasksForStreak: 1 }) as any)
+      .mockResolvedValueOnce(childUser({ minTasksForStreak: 1 }))
       .mockResolvedValueOnce(childUser({
         studyPt: 0, staminaPt: 0, lifePt: 0,
         evolutionStage: 2,
         evolutionPath: "STUDY_STAMINA",
         collectedPaths: '["STUDY","STUDY_STAMINA"]',
-      }) as any);
+      }));
     mockCounts(1, 3);
     mockPrisma.streak.upsert.mockResolvedValue(
-      streak({ currentStreak: 2, bestStreak: 2, lastAchievedDate: yesterday }) as any,
+      streak({ currentStreak: 2, bestStreak: 2, lastAchievedDate: yesterday }),
     );
-    mockPrisma.streak.update.mockResolvedValue({} as any);
-    mockPrisma.user.update.mockResolvedValue({} as any);
+    mockPrisma.streak.update.mockResolvedValue(streak());
+    mockPrisma.user.update.mockResolvedValue(childUser());
 
     await recordDailyAchievement("child-1", today);
     await new Promise((r) => setImmediate(r));

--- a/src/__tests__/lib/taskStreak.test.ts
+++ b/src/__tests__/lib/taskStreak.test.ts
@@ -1,8 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { prisma } from "@/lib/prisma";
 import { recordTaskStreak } from "@/lib/streak";
-
-const mockPrisma = vi.mocked(prisma);
+import { prismaMock as mockPrisma } from "../helpers/prisma-mock";
+import { taskStreak } from "../helpers/fixtures";
 
 beforeEach(() => {
   vi.clearAllMocks();
@@ -16,14 +15,16 @@ describe("recordTaskStreak (repeatDays aware)", () => {
   // 2026-04-27 = Mon, 2026-04-29 = Wed, 2026-05-01 = Fri, 2026-05-04 = Mon
 
   it("初回達成: currentStreak=1 で記録", async () => {
-    mockPrisma.taskStreak.upsert.mockResolvedValue({
-      id: "s1",
-      taskId: "t1",
-      childId: "c1",
-      currentStreak: 0,
-      bestStreak: 0,
-      lastAchievedDate: null,
-    } as any);
+    mockPrisma.taskStreak.upsert.mockResolvedValue(
+      taskStreak({
+        id: "s1",
+        taskId: "t1",
+        childId: "c1",
+        currentStreak: 0,
+        bestStreak: 0,
+        lastAchievedDate: null,
+      }),
+    );
 
     await recordTaskStreak("t1", "c1", dateUTC("2026-04-29"), [1, 3, 5]);
 
@@ -38,14 +39,16 @@ describe("recordTaskStreak (repeatDays aware)", () => {
   });
 
   it("月水金: 月曜→水曜で連続として +1", async () => {
-    mockPrisma.taskStreak.upsert.mockResolvedValue({
-      id: "s1",
-      taskId: "t1",
-      childId: "c1",
-      currentStreak: 3,
-      bestStreak: 3,
-      lastAchievedDate: dateUTC("2026-04-27"), // Mon
-    } as any);
+    mockPrisma.taskStreak.upsert.mockResolvedValue(
+      taskStreak({
+        id: "s1",
+        taskId: "t1",
+        childId: "c1",
+        currentStreak: 3,
+        bestStreak: 3,
+        lastAchievedDate: dateUTC("2026-04-27"), // Mon
+      }),
+    );
 
     await recordTaskStreak("t1", "c1", dateUTC("2026-04-29"), [1, 3, 5]); // Wed
 
@@ -60,14 +63,16 @@ describe("recordTaskStreak (repeatDays aware)", () => {
   });
 
   it("月水金: 金曜→月曜で連続として +1（週末は無視）", async () => {
-    mockPrisma.taskStreak.upsert.mockResolvedValue({
-      id: "s1",
-      taskId: "t1",
-      childId: "c1",
-      currentStreak: 5,
-      bestStreak: 5,
-      lastAchievedDate: dateUTC("2026-05-01"), // Fri
-    } as any);
+    mockPrisma.taskStreak.upsert.mockResolvedValue(
+      taskStreak({
+        id: "s1",
+        taskId: "t1",
+        childId: "c1",
+        currentStreak: 5,
+        bestStreak: 5,
+        lastAchievedDate: dateUTC("2026-05-01"), // Fri
+      }),
+    );
 
     await recordTaskStreak("t1", "c1", dateUTC("2026-05-04"), [1, 3, 5]); // Mon
 
@@ -82,14 +87,16 @@ describe("recordTaskStreak (repeatDays aware)", () => {
   });
 
   it("月水金: 月曜を逃して水曜に達成 → 1にリセット", async () => {
-    mockPrisma.taskStreak.upsert.mockResolvedValue({
-      id: "s1",
-      taskId: "t1",
-      childId: "c1",
-      currentStreak: 5,
-      bestStreak: 10,
-      lastAchievedDate: dateUTC("2026-04-24"), // Fri last week (skipped Mon 04-27)
-    } as any);
+    mockPrisma.taskStreak.upsert.mockResolvedValue(
+      taskStreak({
+        id: "s1",
+        taskId: "t1",
+        childId: "c1",
+        currentStreak: 5,
+        bestStreak: 10,
+        lastAchievedDate: dateUTC("2026-04-24"), // Fri last week (skipped Mon 04-27)
+      }),
+    );
 
     await recordTaskStreak("t1", "c1", dateUTC("2026-04-29"), [1, 3, 5]); // Wed
 
@@ -104,14 +111,16 @@ describe("recordTaskStreak (repeatDays aware)", () => {
   });
 
   it("毎日: 昨日完了済み → +1（現状の挙動を維持）", async () => {
-    mockPrisma.taskStreak.upsert.mockResolvedValue({
-      id: "s1",
-      taskId: "t1",
-      childId: "c1",
-      currentStreak: 7,
-      bestStreak: 7,
-      lastAchievedDate: dateUTC("2026-04-28"),
-    } as any);
+    mockPrisma.taskStreak.upsert.mockResolvedValue(
+      taskStreak({
+        id: "s1",
+        taskId: "t1",
+        childId: "c1",
+        currentStreak: 7,
+        bestStreak: 7,
+        lastAchievedDate: dateUTC("2026-04-28"),
+      }),
+    );
 
     await recordTaskStreak("t1", "c1", dateUTC("2026-04-29"), [0, 1, 2, 3, 4, 5, 6]);
 
@@ -126,14 +135,16 @@ describe("recordTaskStreak (repeatDays aware)", () => {
   });
 
   it("同日2回目の承認では更新しない（冪等）", async () => {
-    mockPrisma.taskStreak.upsert.mockResolvedValue({
-      id: "s1",
-      taskId: "t1",
-      childId: "c1",
-      currentStreak: 3,
-      bestStreak: 5,
-      lastAchievedDate: dateUTC("2026-04-29"),
-    } as any);
+    mockPrisma.taskStreak.upsert.mockResolvedValue(
+      taskStreak({
+        id: "s1",
+        taskId: "t1",
+        childId: "c1",
+        currentStreak: 3,
+        bestStreak: 5,
+        lastAchievedDate: dateUTC("2026-04-29"),
+      }),
+    );
 
     await recordTaskStreak("t1", "c1", dateUTC("2026-04-29"), [1, 3, 5]);
 
@@ -143,14 +154,16 @@ describe("recordTaskStreak (repeatDays aware)", () => {
   it("repeatDays が空でも実行できる（途切れ扱い: 1にリセット）", async () => {
     // 通常運用では isTemporary=false かつ repeatDays=[] というケースは無いが、
     // 防御的に呼ばれた場合に例外を投げず 1 にリセットされる
-    mockPrisma.taskStreak.upsert.mockResolvedValue({
-      id: "s1",
-      taskId: "t1",
-      childId: "c1",
-      currentStreak: 5,
-      bestStreak: 8,
-      lastAchievedDate: dateUTC("2026-04-28"),
-    } as any);
+    mockPrisma.taskStreak.upsert.mockResolvedValue(
+      taskStreak({
+        id: "s1",
+        taskId: "t1",
+        childId: "c1",
+        currentStreak: 5,
+        bestStreak: 8,
+        lastAchievedDate: dateUTC("2026-04-28"),
+      }),
+    );
 
     await recordTaskStreak("t1", "c1", dateUTC("2026-04-29"), []);
 


### PR DESCRIPTION
## Summary
- `src/__tests__/lib/quests.test.ts` / `streak.test.ts` / `loginStreak.test.ts` / `taskStreak.test.ts` の `as any` を計137件全廃し、`prismaMock` を使った型付きモックへ移行（`fixtures.ts` は無変更）
- **CLAUDE.md「進化処理の規約」について明記**: `streak.ts` / `loginStreak.ts` の `checkEvolution` 呼び出しは実際のロジックを直接叩く形式（`Math.random` スパイで進化先を制御）を維持。rebirthPending優先チェック・isReborn/rebirthEggBonus・collectedPaths/monsterLevels更新を検証する expect は、code-reviewer が1行ずつ確認し変更なしであることを確認済み
- `quests.test.ts` の `asPrismaPromise` / `asFindFirstImpl` ヘルパーが実装の実際の Prisma 呼び出しパターンと整合していることを確認済み
- テスト件数・expect 出現数は全ファイルで移行前後完全一致（減少なし）

## Test plan
- [x] `npm test`（対象4ファイル）パス（51/51）
- [x] `npm test`（フルスイート）パス（2512件、変化なし）
- [x] `npm run typecheck`（prisma generate後）132→0件
- [x] code-reviewer による進化処理規約（checkEvolution呼び出し・rebirthPending優先チェック・collectedPaths/monsterLevels更新）の1行ずつの検証 APPROVED済み

Closes #46

🤖 Generated with [Claude Code](https://claude.com/claude-code)
