### PR TITLE
test(lib): lib残り8ファイルのas anyを型付きモックに移行

### DIFF
--- a/src/__tests__/helpers/fixtures.ts
+++ b/src/__tests__/helpers/fixtures.ts
@@ -30,6 +30,7 @@ import type {
   BulletinLog,
   CheckinLog,
   Family,
+  GatheringMember,
   Prisma,
   PushSubscription,
   QuestDeclaration,
@@ -375,6 +376,18 @@ export function userCollectionItem(overrides?: Partial<UserCollectionItem>): Use
     count: 1,
     firstAcquiredAt: FIXTURE_TIMESTAMP,
     lastAcquiredAt: FIXTURE_TIMESTAMP,
+    ...overrides,
+  };
+}
+
+// ─── GatheringMember ──────────────────────────────────
+
+export function gatheringMember(overrides?: Partial<GatheringMember>): GatheringMember {
+  return {
+    id: "member-1",
+    groupId: "group-1",
+    childId: "child-1",
+    joinedAt: FIXTURE_TIMESTAMP,
     ...overrides,
   };
 }

--- a/src/__tests__/lib/auth.test.ts
+++ b/src/__tests__/lib/auth.test.ts
@@ -26,10 +26,16 @@ vi.mock("@/lib/categories", () => ({
 import { getCurrentUser } from "@/lib/auth";
 import { createClient } from "@/lib/supabase/server";
 import { prisma } from "@/lib/prisma";
+import { family, parentUserWithFamily } from "../helpers/fixtures";
 
 const mockCreateClient = vi.mocked(createClient);
 const mockUserFindUnique = vi.mocked(prisma.user.findUnique);
 const mockFamilyCreate = vi.mocked(prisma.family.create);
+
+/** `createClient()` の戻り値は Supabase の `SupabaseClient` 型（巨大なジェネリック型）。
+ * テストで使うのは `auth.getSession` だけなので、必要な形だけを持つオブジェクトを
+ * `Awaited<ReturnType<typeof createClient>>` に `as unknown as` でキャストする。 */
+type SupabaseClientLike = Awaited<ReturnType<typeof createClient>>;
 
 function mockSupabaseUser(user: { id: string; email?: string } | null) {
   mockCreateClient.mockResolvedValue({
@@ -38,7 +44,7 @@ function mockSupabaseUser(user: { id: string; email?: string } | null) {
         data: { session: user ? { user } : null },
       }),
     },
-  } as any);
+  } as unknown as SupabaseClientLike);
 }
 
 beforeEach(() => {
@@ -54,14 +60,11 @@ describe("getCurrentUser", () => {
 
   it("DBユーザーが存在する場合、family付きで返すこと", async () => {
     mockSupabaseUser({ id: "sup-123", email: "test@example.com" });
-    const dbUser = {
-      id: "db-1",
-      supabaseId: "sup-123",
-      role: "PARENT",
-      familyId: "fam-1",
-      family: { id: "fam-1", code: "ABC123" },
-    };
-    mockUserFindUnique.mockResolvedValue(dbUser as any);
+    const dbUser = parentUserWithFamily(
+      { id: "db-1", supabaseId: "sup-123", familyId: "fam-1" },
+      { id: "fam-1", code: "ABC123" },
+    );
+    mockUserFindUnique.mockResolvedValue(dbUser);
 
     const result = await getCurrentUser();
     expect(result).toEqual(dbUser);
@@ -76,10 +79,13 @@ describe("getCurrentUser", () => {
     // 1回目のfindUnique → null
     mockUserFindUnique.mockResolvedValueOnce(null);
     // familyCreate成功
-    mockFamilyCreate.mockResolvedValue({ id: "fam-new", code: "ABC123" } as any);
+    mockFamilyCreate.mockResolvedValue(family({ id: "fam-new", code: "ABC123" }));
     // 2回目のfindUnique → 作成されたユーザー
-    const newUser = { id: "db-new", supabaseId: "sup-new", role: "PARENT" };
-    mockUserFindUnique.mockResolvedValueOnce(newUser as any);
+    const newUser = parentUserWithFamily(
+      { id: "db-new", supabaseId: "sup-new" },
+      { id: "fam-new", code: "ABC123" },
+    );
+    mockUserFindUnique.mockResolvedValueOnce(newUser);
 
     const result = await getCurrentUser();
     expect(result).toEqual(newUser);
@@ -109,8 +115,8 @@ describe("getCurrentUser", () => {
   it("emailからユーザー名を@前で抽出すること", async () => {
     mockSupabaseUser({ id: "sup-x", email: "tanaka.taro@company.co.jp" });
     mockUserFindUnique.mockResolvedValueOnce(null);
-    mockFamilyCreate.mockResolvedValue({} as any);
-    mockUserFindUnique.mockResolvedValueOnce({} as any);
+    mockFamilyCreate.mockResolvedValue(family());
+    mockUserFindUnique.mockResolvedValueOnce(parentUserWithFamily());
 
     await getCurrentUser();
     expect(mockFamilyCreate).toHaveBeenCalledWith(

--- a/src/__tests__/lib/badgesLoadContext.test.ts
+++ b/src/__tests__/lib/badgesLoadContext.test.ts
@@ -9,27 +9,28 @@
 
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { loadBadgeContext } from "@/lib/badges";
-import { prisma } from "@/lib/prisma";
 import { ALL_COLLECTION_ITEMS } from "@/lib/collectionItems";
-
-const mockPrisma = vi.mocked(prisma);
+import { prismaMock as mockPrisma } from "../helpers/prisma-mock";
+import { childUser, userCollectionItem } from "../helpers/fixtures";
 
 function mockPrismaBaseline() {
-  mockPrisma.user.findUnique.mockResolvedValue({
-    evolutionStage: 1,
-    collectedPaths: "[]",
-    studyPt: 0,
-    staminaPt: 0,
-    lifePt: 0,
-    usedEggBonuses: "[]",
-  } as any);
+  mockPrisma.user.findUnique.mockResolvedValue(
+    childUser({
+      evolutionStage: 1,
+      collectedPaths: "[]",
+      studyPt: 0,
+      staminaPt: 0,
+      lifePt: 0,
+      usedEggBonuses: "[]",
+    }),
+  );
   mockPrisma.streak.findUnique.mockResolvedValue(null);
-  mockPrisma.questInstance.findMany.mockResolvedValue([] as any);
-  // taskStreak.findMany はグローバル setup ではモック定義がないので、その場で追加する
-  (mockPrisma as any).taskStreak.findMany = vi.fn().mockResolvedValue([]);
+  mockPrisma.questInstance.findMany.mockResolvedValue([]);
+  // taskStreak.findMany はグローバル setup ではデフォルト値が設定されていないので、その場で追加する
+  mockPrisma.taskStreak.findMany.mockResolvedValue([]);
   mockPrisma.taskTemplate.count.mockResolvedValue(0);
   mockPrisma.userBadge.count.mockResolvedValue(0);
-  mockPrisma.treasureLog.findMany.mockResolvedValue([] as any);
+  mockPrisma.treasureLog.findMany.mockResolvedValue([]);
 }
 
 beforeEach(() => {
@@ -45,7 +46,7 @@ describe("loadBadgeContext: 通常アイテム 80 種で判定する", () => {
     expect(regularSummer).toHaveLength(20);
 
     mockPrisma.userCollectionItem.findMany.mockResolvedValue(
-      regularSummer.map((i) => ({ itemId: i.id, season: "summer" })) as any,
+      regularSummer.map((i) => userCollectionItem({ itemId: i.id, season: "summer" })),
     );
 
     const ctx = await loadBadgeContext("c1");
@@ -61,7 +62,7 @@ describe("loadBadgeContext: 通常アイテム 80 種で判定する", () => {
     const monthly7 = ALL_COLLECTION_ITEMS.filter((i) => i.month === 7);
 
     mockPrisma.userCollectionItem.findMany.mockResolvedValue(
-      [...owned, ...monthly7].map((i) => ({ itemId: i.id, season: i.season })) as any,
+      [...owned, ...monthly7].map((i) => userCollectionItem({ itemId: i.id, season: i.season })),
     );
 
     const ctx = await loadBadgeContext("c1");
@@ -73,7 +74,7 @@ describe("loadBadgeContext: 通常アイテム 80 種で判定する", () => {
     expect(regularAll).toHaveLength(80);
 
     mockPrisma.userCollectionItem.findMany.mockResolvedValue(
-      regularAll.map((i) => ({ itemId: i.id, season: i.season })) as any,
+      regularAll.map((i) => userCollectionItem({ itemId: i.id, season: i.season })),
     );
 
     const ctx = await loadBadgeContext("c1");
@@ -87,7 +88,7 @@ describe("loadBadgeContext: 通常アイテム 80 種で判定する", () => {
     const monthlyAll = ALL_COLLECTION_ITEMS.filter((i) => i.month !== undefined);
 
     mockPrisma.userCollectionItem.findMany.mockResolvedValue(
-      [...owned, ...monthlyAll].map((i) => ({ itemId: i.id, season: i.season })) as any,
+      [...owned, ...monthlyAll].map((i) => userCollectionItem({ itemId: i.id, season: i.season })),
     );
 
     const ctx = await loadBadgeContext("c1");
@@ -100,7 +101,7 @@ describe("loadBadgeContext: 通常アイテム 80 種で判定する", () => {
     const owned = [...regularAll, ...monthlyAll];
 
     mockPrisma.userCollectionItem.findMany.mockResolvedValue(
-      owned.map((i) => ({ itemId: i.id, season: i.season })) as any,
+      owned.map((i) => userCollectionItem({ itemId: i.id, season: i.season })),
     );
 
     const ctx = await loadBadgeContext("c1");

--- a/src/__tests__/lib/bulletinLog.test.ts
+++ b/src/__tests__/lib/bulletinLog.test.ts
@@ -8,9 +8,24 @@ import {
   triggerStampSentLog,
   triggerCollectionItemLog,
 } from "@/lib/bulletinLog";
-import { prisma } from "@/lib/prisma";
+import { prismaMock as mockPrisma } from "../helpers/prisma-mock";
+import {
+  bulletinLog as bulletinLogFixture,
+  childUser,
+  gatheringMember,
+} from "../helpers/fixtures";
 
-const mockPrisma = vi.mocked(prisma);
+/** `gatheringMember.findUnique` の select は `{ groupId: true }` だが、DeepMockProxy の
+ * `mockResolvedValue` は select 付き部分型を受け付けないため完全なフィクスチャで代替する。 */
+function groupIdOnly(groupId: string) {
+  return gatheringMember({ groupId });
+}
+
+/** `user.findUnique` の select は `{ name: true, monsterName: true }` だが、同様の理由で
+ * 完全な User フィクスチャで代替する（実装は name/monsterName のみ参照する）。 */
+function nameOnly(name: string | null, monsterName: string | null) {
+  return childUser({ name, monsterName });
+}
 
 beforeEach(() => {
   vi.clearAllMocks();
@@ -24,12 +39,12 @@ describe("triggerTaskProgressLog", () => {
   });
 
   it("name が null でも monsterName があれば monsterName で書き込む", async () => {
-    mockPrisma.gatheringMember.findUnique.mockResolvedValue({ groupId: "g-1" } as never);
-    mockPrisma.user.findUnique.mockResolvedValue({ name: null, monsterName: "ドラゴン" } as never);
+    mockPrisma.gatheringMember.findUnique.mockResolvedValue(groupIdOnly("g-1"));
+    mockPrisma.user.findUnique.mockResolvedValue(nameOnly(null, "ドラゴン"));
     mockPrisma.questInstance.count
-      .mockResolvedValueOnce(2 as never) // total
-      .mockResolvedValueOnce(2 as never); // done
-    mockPrisma.bulletinLog.create.mockResolvedValue({} as never);
+      .mockResolvedValueOnce(2) // total
+      .mockResolvedValueOnce(2); // done
+    mockPrisma.bulletinLog.create.mockResolvedValue(bulletinLogFixture());
 
     await triggerTaskProgressLog("child-1");
 
@@ -39,8 +54,8 @@ describe("triggerTaskProgressLog", () => {
   });
 
   it("name も monsterName も両方 null なら書き込まない", async () => {
-    mockPrisma.gatheringMember.findUnique.mockResolvedValue({ groupId: "g-1" } as never);
-    mockPrisma.user.findUnique.mockResolvedValue({ name: null, monsterName: null } as never);
+    mockPrisma.gatheringMember.findUnique.mockResolvedValue(groupIdOnly("g-1"));
+    mockPrisma.user.findUnique.mockResolvedValue(nameOnly(null, null));
 
     await triggerTaskProgressLog("child-1");
 
@@ -48,12 +63,12 @@ describe("triggerTaskProgressLog", () => {
   });
 
   it("monsterName が優先される（プライバシー: 本名はグループ内に晒さない）", async () => {
-    mockPrisma.gatheringMember.findUnique.mockResolvedValue({ groupId: "g-1" } as never);
-    mockPrisma.user.findUnique.mockResolvedValue({ name: "鈴木太郎", monsterName: "ドラゴン" } as never);
+    mockPrisma.gatheringMember.findUnique.mockResolvedValue(groupIdOnly("g-1"));
+    mockPrisma.user.findUnique.mockResolvedValue(nameOnly("鈴木太郎", "ドラゴン"));
     mockPrisma.questInstance.count
-      .mockResolvedValueOnce(1 as never)
-      .mockResolvedValueOnce(1 as never);
-    mockPrisma.bulletinLog.create.mockResolvedValue({} as never);
+      .mockResolvedValueOnce(1)
+      .mockResolvedValueOnce(1);
+    mockPrisma.bulletinLog.create.mockResolvedValue(bulletinLogFixture());
 
     await triggerTaskProgressLog("child-1");
 
@@ -63,9 +78,9 @@ describe("triggerTaskProgressLog", () => {
   });
 
   it("当日タスク0件なら書き込まない", async () => {
-    mockPrisma.gatheringMember.findUnique.mockResolvedValue({ groupId: "g-1" } as never);
-    mockPrisma.user.findUnique.mockResolvedValue({ name: "太郎", monsterName: null } as never);
-    mockPrisma.questInstance.count.mockResolvedValueOnce(0 as never); // total = 0
+    mockPrisma.gatheringMember.findUnique.mockResolvedValue(groupIdOnly("g-1"));
+    mockPrisma.user.findUnique.mockResolvedValue(nameOnly("太郎", null));
+    mockPrisma.questInstance.count.mockResolvedValueOnce(0); // total = 0
 
     await triggerTaskProgressLog("child-1");
 
@@ -73,12 +88,12 @@ describe("triggerTaskProgressLog", () => {
   });
 
   it("達成率に応じて複数のマイルストーンを書き込む", async () => {
-    mockPrisma.gatheringMember.findUnique.mockResolvedValue({ groupId: "g-1" } as never);
-    mockPrisma.user.findUnique.mockResolvedValue({ name: null, monsterName: "モンスタロウ" } as never);
+    mockPrisma.gatheringMember.findUnique.mockResolvedValue(groupIdOnly("g-1"));
+    mockPrisma.user.findUnique.mockResolvedValue(nameOnly(null, "モンスタロウ"));
     mockPrisma.questInstance.count
-      .mockResolvedValueOnce(4 as never) // total
-      .mockResolvedValueOnce(4 as never); // done = 100%
-    mockPrisma.bulletinLog.create.mockResolvedValue({} as never);
+      .mockResolvedValueOnce(4) // total
+      .mockResolvedValueOnce(4); // done = 100%
+    mockPrisma.bulletinLog.create.mockResolvedValue(bulletinLogFixture());
 
     await triggerTaskProgressLog("child-1");
 
@@ -89,12 +104,12 @@ describe("triggerTaskProgressLog", () => {
 
 describe("triggerBadgeLog / triggerStreakTitleLog / triggerMonsterEvolvedLog / triggerMonsterRebornLog", () => {
   beforeEach(() => {
-    mockPrisma.gatheringMember.findUnique.mockResolvedValue({ groupId: "g-1" } as never);
-    mockPrisma.bulletinLog.create.mockResolvedValue({} as never);
+    mockPrisma.gatheringMember.findUnique.mockResolvedValue(groupIdOnly("g-1"));
+    mockPrisma.bulletinLog.create.mockResolvedValue(bulletinLogFixture());
   });
 
   it("triggerBadgeLog: monsterName fallback で書き込む", async () => {
-    mockPrisma.user.findUnique.mockResolvedValue({ name: null, monsterName: "ドラゴン" } as never);
+    mockPrisma.user.findUnique.mockResolvedValue(nameOnly(null, "ドラゴン"));
     await triggerBadgeLog("child-1", "はじめの一歩");
 
     const call = mockPrisma.bulletinLog.create.mock.calls[0][0] as { data: { message: string } };
@@ -103,7 +118,7 @@ describe("triggerBadgeLog / triggerStreakTitleLog / triggerMonsterEvolvedLog / t
   });
 
   it("triggerStreakTitleLog: monsterName fallback で書き込む", async () => {
-    mockPrisma.user.findUnique.mockResolvedValue({ name: null, monsterName: "ドラゴン" } as never);
+    mockPrisma.user.findUnique.mockResolvedValue(nameOnly(null, "ドラゴン"));
     await triggerStreakTitleLog("child-1", "一週間の戦士");
 
     const call = mockPrisma.bulletinLog.create.mock.calls[0][0] as { data: { message: string } };
@@ -112,7 +127,7 @@ describe("triggerBadgeLog / triggerStreakTitleLog / triggerMonsterEvolvedLog / t
   });
 
   it("triggerMonsterEvolvedLog: monsterName fallback で書き込む", async () => {
-    mockPrisma.user.findUnique.mockResolvedValue({ name: null, monsterName: "ドラゴン" } as never);
+    mockPrisma.user.findUnique.mockResolvedValue(nameOnly(null, "ドラゴン"));
     await triggerMonsterEvolvedLog("child-1", "フレアドラゴン");
 
     const call = mockPrisma.bulletinLog.create.mock.calls[0][0] as { data: { message: string } };
@@ -121,7 +136,7 @@ describe("triggerBadgeLog / triggerStreakTitleLog / triggerMonsterEvolvedLog / t
   });
 
   it("triggerMonsterRebornLog: monsterName fallback で書き込む", async () => {
-    mockPrisma.user.findUnique.mockResolvedValue({ name: null, monsterName: "ドラゴン" } as never);
+    mockPrisma.user.findUnique.mockResolvedValue(nameOnly(null, "ドラゴン"));
     await triggerMonsterRebornLog("child-1", "べんきょう");
 
     const call = mockPrisma.bulletinLog.create.mock.calls[0][0] as { data: { message: string } };
@@ -130,7 +145,7 @@ describe("triggerBadgeLog / triggerStreakTitleLog / triggerMonsterEvolvedLog / t
   });
 
   it("どのトリガーも name と monsterName が両方 null なら書き込まない", async () => {
-    mockPrisma.user.findUnique.mockResolvedValue({ name: null, monsterName: null } as never);
+    mockPrisma.user.findUnique.mockResolvedValue(nameOnly(null, null));
     await triggerBadgeLog("child-1", "はじめの一歩");
     await triggerStreakTitleLog("child-1", "一週間");
     await triggerMonsterEvolvedLog("child-1", "ドラゴン");
@@ -140,28 +155,28 @@ describe("triggerBadgeLog / triggerStreakTitleLog / triggerMonsterEvolvedLog / t
   });
 
   it("triggerBadgeLog: data.key にバッジ名をセット（同日に別バッジ複数件を許可するため）", async () => {
-    mockPrisma.user.findUnique.mockResolvedValue({ name: null, monsterName: "ドラゴン" } as never);
+    mockPrisma.user.findUnique.mockResolvedValue(nameOnly(null, "ドラゴン"));
     await triggerBadgeLog("child-1", "はじめの一歩");
     const call = mockPrisma.bulletinLog.create.mock.calls[0][0] as { data: { key: string } };
     expect(call.data.key).toBe("はじめの一歩");
   });
 
   it("triggerStreakTitleLog: data.key に称号名をセット", async () => {
-    mockPrisma.user.findUnique.mockResolvedValue({ name: null, monsterName: "ドラゴン" } as never);
+    mockPrisma.user.findUnique.mockResolvedValue(nameOnly(null, "ドラゴン"));
     await triggerStreakTitleLog("child-1", "一週間の戦士");
     const call = mockPrisma.bulletinLog.create.mock.calls[0][0] as { data: { key: string } };
     expect(call.data.key).toBe("一週間の戦士");
   });
 
   it("triggerMonsterEvolvedLog: data.key に進化先モンスター名をセット", async () => {
-    mockPrisma.user.findUnique.mockResolvedValue({ name: null, monsterName: "ドラゴン" } as never);
+    mockPrisma.user.findUnique.mockResolvedValue(nameOnly(null, "ドラゴン"));
     await triggerMonsterEvolvedLog("child-1", "フレアドラゴン");
     const call = mockPrisma.bulletinLog.create.mock.calls[0][0] as { data: { key: string } };
     expect(call.data.key).toBe("フレアドラゴン");
   });
 
   it("triggerMonsterRebornLog: data.key に卵タイプをセット", async () => {
-    mockPrisma.user.findUnique.mockResolvedValue({ name: null, monsterName: "ドラゴン" } as never);
+    mockPrisma.user.findUnique.mockResolvedValue(nameOnly(null, "ドラゴン"));
     await triggerMonsterRebornLog("child-1", "べんきょう");
     const call = mockPrisma.bulletinLog.create.mock.calls[0][0] as { data: { key: string } };
     expect(call.data.key).toBe("べんきょう");
@@ -170,8 +185,8 @@ describe("triggerBadgeLog / triggerStreakTitleLog / triggerMonsterEvolvedLog / t
 
 describe("triggerStampSentLog", () => {
   beforeEach(() => {
-    mockPrisma.gatheringMember.findUnique.mockResolvedValue({ groupId: "g-1" } as never);
-    mockPrisma.bulletinLog.create.mockResolvedValue({} as never);
+    mockPrisma.gatheringMember.findUnique.mockResolvedValue(groupIdOnly("g-1"));
+    mockPrisma.bulletinLog.create.mockResolvedValue(bulletinLogFixture());
   });
 
   it("グループ未参加なら何も書き込まない", async () => {
@@ -181,13 +196,13 @@ describe("triggerStampSentLog", () => {
   });
 
   it("name と monsterName が両方 null なら書き込まない", async () => {
-    mockPrisma.user.findUnique.mockResolvedValue({ name: null, monsterName: null } as never);
+    mockPrisma.user.findUnique.mockResolvedValue(nameOnly(null, null));
     await triggerStampSentLog("child-1");
     expect(mockPrisma.bulletinLog.create).not.toHaveBeenCalled();
   });
 
   it("monsterName を優先して STAMP_SENT を書き込む", async () => {
-    mockPrisma.user.findUnique.mockResolvedValue({ name: "鈴木太郎", monsterName: "ドラゴン" } as never);
+    mockPrisma.user.findUnique.mockResolvedValue(nameOnly("鈴木太郎", "ドラゴン"));
     await triggerStampSentLog("child-1");
     expect(mockPrisma.bulletinLog.create).toHaveBeenCalledTimes(1);
     const call = mockPrisma.bulletinLog.create.mock.calls[0][0] as {
@@ -200,14 +215,14 @@ describe("triggerStampSentLog", () => {
   });
 
   it("data.key は \"エール\" 固定（同日1回制約は Stamp 側で担保済みなので key で衝突は起きない）", async () => {
-    mockPrisma.user.findUnique.mockResolvedValue({ name: null, monsterName: "ドラゴン" } as never);
+    mockPrisma.user.findUnique.mockResolvedValue(nameOnly(null, "ドラゴン"));
     await triggerStampSentLog("child-1");
     const call = mockPrisma.bulletinLog.create.mock.calls[0][0] as { data: { key: string } };
     expect(call.data.key).toBe("エール");
   });
 
   it("unique 違反は握りつぶす（同日に2回 trigger されても例外を投げない）", async () => {
-    mockPrisma.user.findUnique.mockResolvedValue({ name: null, monsterName: "ドラゴン" } as never);
+    mockPrisma.user.findUnique.mockResolvedValue(nameOnly(null, "ドラゴン"));
     mockPrisma.bulletinLog.create.mockRejectedValueOnce(
       Object.assign(new Error("Unique constraint failed"), { code: "P2002" }),
     );
@@ -217,12 +232,12 @@ describe("triggerStampSentLog", () => {
 
 describe("triggerTaskProgressLog: key", () => {
   it("data.key は空文字（同日マイルストーン重複は引き続き禁止）", async () => {
-    mockPrisma.gatheringMember.findUnique.mockResolvedValue({ groupId: "g-1" } as never);
-    mockPrisma.user.findUnique.mockResolvedValue({ name: null, monsterName: "ドラゴン" } as never);
+    mockPrisma.gatheringMember.findUnique.mockResolvedValue(groupIdOnly("g-1"));
+    mockPrisma.user.findUnique.mockResolvedValue(nameOnly(null, "ドラゴン"));
     mockPrisma.questInstance.count
-      .mockResolvedValueOnce(4 as never) // total
-      .mockResolvedValueOnce(1 as never); // done (TASK_STARTED only)
-    mockPrisma.bulletinLog.create.mockResolvedValue({} as never);
+      .mockResolvedValueOnce(4) // total
+      .mockResolvedValueOnce(1); // done (TASK_STARTED only)
+    mockPrisma.bulletinLog.create.mockResolvedValue(bulletinLogFixture());
 
     await triggerTaskProgressLog("child-1");
 
@@ -236,8 +251,8 @@ describe("triggerTaskProgressLog: key", () => {
 
 describe("triggerCollectionItemLog", () => {
   beforeEach(() => {
-    mockPrisma.gatheringMember.findUnique.mockResolvedValue({ groupId: "g-1" } as never);
-    mockPrisma.bulletinLog.create.mockResolvedValue({} as never);
+    mockPrisma.gatheringMember.findUnique.mockResolvedValue(groupIdOnly("g-1"));
+    mockPrisma.bulletinLog.create.mockResolvedValue(bulletinLogFixture());
   });
 
   it("グループ未参加なら何も書き込まない", async () => {
@@ -247,13 +262,13 @@ describe("triggerCollectionItemLog", () => {
   });
 
   it("name も monsterName も null なら書き込まない", async () => {
-    mockPrisma.user.findUnique.mockResolvedValue({ name: null, monsterName: null } as never);
+    mockPrisma.user.findUnique.mockResolvedValue(nameOnly(null, null));
     await triggerCollectionItemLog("child-1", "summer-01", 1);
     expect(mockPrisma.bulletinLog.create).not.toHaveBeenCalled();
   });
 
   it("monsterName 優先で type=COLLECTION_ITEM_OBTAINED + アイテム名+季節+★ を含むメッセージを書き込む", async () => {
-    mockPrisma.user.findUnique.mockResolvedValue({ name: "鈴木太郎", monsterName: "ドラゴン" } as never);
+    mockPrisma.user.findUnique.mockResolvedValue(nameOnly("鈴木太郎", "ドラゴン"));
     await triggerCollectionItemLog("child-1", "summer-04", 1); // リュウグウノツカイ (RARE)
     expect(mockPrisma.bulletinLog.create).toHaveBeenCalledTimes(1);
     const call = mockPrisma.bulletinLog.create.mock.calls[0][0] as {
@@ -268,7 +283,7 @@ describe("triggerCollectionItemLog", () => {
   });
 
   it("data.key に id+count をセット (同日に同じアイテムをダブり獲得しても uniq 制約と衝突しない)", async () => {
-    mockPrisma.user.findUnique.mockResolvedValue({ name: null, monsterName: "ドラゴン" } as never);
+    mockPrisma.user.findUnique.mockResolvedValue(nameOnly(null, "ドラゴン"));
     await triggerCollectionItemLog("child-1", "fall-04", 1);
     await triggerCollectionItemLog("child-1", "fall-04", 2);
     await triggerCollectionItemLog("child-1", "fall-04", 3);
@@ -279,7 +294,7 @@ describe("triggerCollectionItemLog", () => {
   });
 
   it("未知の id は書き込みスキップ (message が空文字列なので writeBulletinLog が早期 return)", async () => {
-    mockPrisma.user.findUnique.mockResolvedValue({ name: null, monsterName: "ドラゴン" } as never);
+    mockPrisma.user.findUnique.mockResolvedValue(nameOnly(null, "ドラゴン"));
     await triggerCollectionItemLog("child-1", "bogus-99", 1);
     expect(mockPrisma.bulletinLog.create).not.toHaveBeenCalled();
   });

--- a/src/__tests__/lib/checkin.test.ts
+++ b/src/__tests__/lib/checkin.test.ts
@@ -1,14 +1,12 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { prisma } from "@/lib/prisma";
 import { recordCheckin, type CheckinResult } from "@/lib/checkin";
 import {
   isBeforeCheckinDeadline,
   computeNextCheckinStreak,
   isValidCheckinDeadlineTime,
 } from "@/lib/checkin.logic";
-import { childUser, streak } from "../helpers/fixtures";
-
-const mockPrisma = vi.mocked(prisma);
+import { prismaMock as mockPrisma } from "../helpers/prisma-mock";
+import { checkinLog, childUser, streak } from "../helpers/fixtures";
 
 beforeEach(() => {
   vi.clearAllMocks();
@@ -93,7 +91,7 @@ describe("recordCheckin", () => {
 
   it("checkinDeadlineTime が未設定なら enabled=false", async () => {
     mockPrisma.user.findUnique.mockResolvedValue(
-      childUser({ checkinDeadlineTime: null }) as any,
+      childUser({ checkinDeadlineTime: null }),
     );
 
     const result = await recordCheckin("child-1", new Date("2026-06-23T06:30:00Z"));
@@ -104,17 +102,18 @@ describe("recordCheckin", () => {
 
   it("当日の CheckinLog が既にあれば justNow=false かつ DB 操作なし", async () => {
     mockPrisma.user.findUnique.mockResolvedValue(
-      childUser({ checkinDeadlineTime: "16:00" }) as any,
+      childUser({ checkinDeadlineTime: "16:00" }),
     );
-    mockPrisma.checkinLog.findUnique.mockResolvedValue({
-      id: "log-1",
-      childId: "child-1",
-      date: today,
-      success: true,
-      checkedInAt: new Date("2026-06-23T06:00:00Z"),
-    } as any);
+    mockPrisma.checkinLog.findUnique.mockResolvedValue(
+      checkinLog({
+        id: "log-1",
+        date: today,
+        success: true,
+        checkedInAt: new Date("2026-06-23T06:00:00Z"),
+      }),
+    );
     mockPrisma.streak.findUnique.mockResolvedValue(
-      streak({ checkinCurrentStreak: 5, checkinBestStreak: 10, lastCheckinDate: today }) as any,
+      streak({ checkinCurrentStreak: 5, checkinBestStreak: 10, lastCheckinDate: today }),
     );
 
     const result = await recordCheckin("child-1", new Date("2026-06-23T06:30:00Z"));
@@ -128,14 +127,14 @@ describe("recordCheckin", () => {
 
   it("締切前の初回チェックインで success=true・streak=1 が記録される", async () => {
     mockPrisma.user.findUnique.mockResolvedValue(
-      childUser({ checkinDeadlineTime: "16:00" }) as any,
+      childUser({ checkinDeadlineTime: "16:00" }),
     );
     mockPrisma.checkinLog.findUnique.mockResolvedValue(null);
     mockPrisma.streak.upsert.mockResolvedValue(
-      streak({ checkinCurrentStreak: 0, checkinBestStreak: 0, lastCheckinDate: null }) as any,
+      streak({ checkinCurrentStreak: 0, checkinBestStreak: 0, lastCheckinDate: null }),
     );
-    mockPrisma.checkinLog.create.mockResolvedValue({} as any);
-    mockPrisma.streak.update.mockResolvedValue({} as any);
+    mockPrisma.checkinLog.create.mockResolvedValue(checkinLog());
+    mockPrisma.streak.update.mockResolvedValue(streak());
 
     const result = await recordCheckin("child-1", new Date("2026-06-23T06:30:00Z")); // JST 15:30
 
@@ -166,14 +165,14 @@ describe("recordCheckin", () => {
 
   it("締切後のチェックインで success=false・streak がリセット", async () => {
     mockPrisma.user.findUnique.mockResolvedValue(
-      childUser({ checkinDeadlineTime: "16:00" }) as any,
+      childUser({ checkinDeadlineTime: "16:00" }),
     );
     mockPrisma.checkinLog.findUnique.mockResolvedValue(null);
     mockPrisma.streak.upsert.mockResolvedValue(
-      streak({ checkinCurrentStreak: 5, checkinBestStreak: 10, lastCheckinDate: yesterday }) as any,
+      streak({ checkinCurrentStreak: 5, checkinBestStreak: 10, lastCheckinDate: yesterday }),
     );
-    mockPrisma.checkinLog.create.mockResolvedValue({} as any);
-    mockPrisma.streak.update.mockResolvedValue({} as any);
+    mockPrisma.checkinLog.create.mockResolvedValue(checkinLog());
+    mockPrisma.streak.update.mockResolvedValue(streak());
 
     const result = await recordCheckin("child-1", new Date("2026-06-23T08:00:00Z")); // JST 17:00
 
@@ -202,14 +201,14 @@ describe("recordCheckin", () => {
 
   it("昨日もチェックイン済みなら streak が +1 になる", async () => {
     mockPrisma.user.findUnique.mockResolvedValue(
-      childUser({ checkinDeadlineTime: "16:00" }) as any,
+      childUser({ checkinDeadlineTime: "16:00" }),
     );
     mockPrisma.checkinLog.findUnique.mockResolvedValue(null);
     mockPrisma.streak.upsert.mockResolvedValue(
-      streak({ checkinCurrentStreak: 5, checkinBestStreak: 5, lastCheckinDate: yesterday }) as any,
+      streak({ checkinCurrentStreak: 5, checkinBestStreak: 5, lastCheckinDate: yesterday }),
     );
-    mockPrisma.checkinLog.create.mockResolvedValue({} as any);
-    mockPrisma.streak.update.mockResolvedValue({} as any);
+    mockPrisma.checkinLog.create.mockResolvedValue(checkinLog());
+    mockPrisma.streak.update.mockResolvedValue(streak());
 
     const result: CheckinResult = await recordCheckin(
       "child-1",
@@ -223,14 +222,14 @@ describe("recordCheckin", () => {
 
   it("締切ちょうどは失敗扱い（境界値）", async () => {
     mockPrisma.user.findUnique.mockResolvedValue(
-      childUser({ checkinDeadlineTime: "16:00" }) as any,
+      childUser({ checkinDeadlineTime: "16:00" }),
     );
     mockPrisma.checkinLog.findUnique.mockResolvedValue(null);
     mockPrisma.streak.upsert.mockResolvedValue(
-      streak({ checkinCurrentStreak: 0, checkinBestStreak: 0, lastCheckinDate: null }) as any,
+      streak({ checkinCurrentStreak: 0, checkinBestStreak: 0, lastCheckinDate: null }),
     );
-    mockPrisma.checkinLog.create.mockResolvedValue({} as any);
-    mockPrisma.streak.update.mockResolvedValue({} as any);
+    mockPrisma.checkinLog.create.mockResolvedValue(checkinLog());
+    mockPrisma.streak.update.mockResolvedValue(streak());
 
     const result = await recordCheckin("child-1", new Date("2026-06-23T07:00:00Z")); // JST 16:00 ちょうど
 

--- a/src/__tests__/lib/collectionService.test.ts
+++ b/src/__tests__/lib/collectionService.test.ts
@@ -1,11 +1,10 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { prisma } from "@/lib/prisma";
 import {
   awardCollectionItem,
   getOwnedCollection,
 } from "@/lib/collectionService";
-
-const mockPrisma = vi.mocked(prisma);
+import { prismaMock as mockPrisma } from "../helpers/prisma-mock";
+import { userCollectionItem } from "../helpers/fixtures";
 
 beforeEach(() => {
   vi.clearAllMocks();
@@ -15,15 +14,17 @@ const FIXED_NOW = new Date("2026-06-15T03:00:00Z");
 
 describe("awardCollectionItem", () => {
   it("初獲得 → upsert で count=1 / firstAcquiredAt=now / lastAcquiredAt=now", async () => {
-    mockPrisma.userCollectionItem.upsert.mockResolvedValue({
-      id: "rec-1",
-      childId: "c1",
-      itemId: "summer-01",
-      season: "summer",
-      count: 1,
-      firstAcquiredAt: FIXED_NOW,
-      lastAcquiredAt: FIXED_NOW,
-    } as any);
+    mockPrisma.userCollectionItem.upsert.mockResolvedValue(
+      userCollectionItem({
+        id: "rec-1",
+        childId: "c1",
+        itemId: "summer-01",
+        season: "summer",
+        count: 1,
+        firstAcquiredAt: FIXED_NOW,
+        lastAcquiredAt: FIXED_NOW,
+      }),
+    );
 
     const rec = await awardCollectionItem("c1", "summer-01", "summer", FIXED_NOW);
 
@@ -46,15 +47,17 @@ describe("awardCollectionItem", () => {
   });
 
   it("ダブり獲得 → update で count increment と lastAcquiredAt 更新", async () => {
-    mockPrisma.userCollectionItem.upsert.mockResolvedValue({
-      id: "rec-1",
-      childId: "c1",
-      itemId: "summer-01",
-      season: "summer",
-      count: 2,
-      firstAcquiredAt: new Date("2026-06-01T00:00:00Z"),
-      lastAcquiredAt: FIXED_NOW,
-    } as any);
+    mockPrisma.userCollectionItem.upsert.mockResolvedValue(
+      userCollectionItem({
+        id: "rec-1",
+        childId: "c1",
+        itemId: "summer-01",
+        season: "summer",
+        count: 2,
+        firstAcquiredAt: new Date("2026-06-01T00:00:00Z"),
+        lastAcquiredAt: FIXED_NOW,
+      }),
+    );
 
     const rec = await awardCollectionItem("c1", "summer-01", "summer", FIXED_NOW);
     expect(rec.count).toBe(2);
@@ -64,8 +67,8 @@ describe("awardCollectionItem", () => {
 describe("getOwnedCollection", () => {
   it("子供の所持コレクションを取得 (childId フィルタ)", async () => {
     mockPrisma.userCollectionItem.findMany.mockResolvedValue([
-      { id: "r1", childId: "c1", itemId: "summer-01", season: "summer", count: 2, firstAcquiredAt: FIXED_NOW, lastAcquiredAt: FIXED_NOW } as any,
-      { id: "r2", childId: "c1", itemId: "summer-05", season: "summer", count: 1, firstAcquiredAt: FIXED_NOW, lastAcquiredAt: FIXED_NOW } as any,
+      userCollectionItem({ id: "r1", childId: "c1", itemId: "summer-01", season: "summer", count: 2, firstAcquiredAt: FIXED_NOW, lastAcquiredAt: FIXED_NOW }),
+      userCollectionItem({ id: "r2", childId: "c1", itemId: "summer-05", season: "summer", count: 1, firstAcquiredAt: FIXED_NOW, lastAcquiredAt: FIXED_NOW }),
     ]);
 
     const list = await getOwnedCollection("c1");

--- a/src/__tests__/lib/parentChildView.test.ts
+++ b/src/__tests__/lib/parentChildView.test.ts
@@ -1,9 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { resolveTargetChild } from "@/lib/parentChildView";
-import { prisma } from "@/lib/prisma";
-import { parentUser, childUser } from "../helpers/fixtures";
-
-const mockPrisma = vi.mocked(prisma);
+import { prismaMock as mockPrisma } from "../helpers/prisma-mock";
+import { parentUserWithFamily, childUser, childUserWithFamily } from "../helpers/fixtures";
 
 beforeEach(() => {
   vi.clearAllMocks();
@@ -11,8 +9,8 @@ beforeEach(() => {
 
 describe("resolveTargetChild", () => {
   it("PARENT ロールでない場合は 403 エラーを返す", async () => {
-    const child = childUser();
-    const result = await resolveTargetChild(child as any, "child-1");
+    const child = childUserWithFamily();
+    const result = await resolveTargetChild(child, "child-1");
     expect(result.ok).toBe(false);
     if (!result.ok) {
       expect(result.status).toBe(403);
@@ -20,8 +18,8 @@ describe("resolveTargetChild", () => {
   });
 
   it("familyId が無い場合は 403 エラーを返す", async () => {
-    const parent = parentUser({ familyId: null });
-    const result = await resolveTargetChild(parent as any, "child-1");
+    const parent = parentUserWithFamily({ familyId: null }, null);
+    const result = await resolveTargetChild(parent, "child-1");
     expect(result.ok).toBe(false);
     if (!result.ok) {
       expect(result.status).toBe(403);
@@ -29,8 +27,8 @@ describe("resolveTargetChild", () => {
   });
 
   it("childId が空文字 / undefined の場合は 400 を返す", async () => {
-    const parent = parentUser();
-    const result = await resolveTargetChild(parent as any, "");
+    const parent = parentUserWithFamily();
+    const result = await resolveTargetChild(parent, "");
     expect(result.ok).toBe(false);
     if (!result.ok) {
       expect(result.status).toBe(400);
@@ -38,9 +36,9 @@ describe("resolveTargetChild", () => {
   });
 
   it("同一 family の CHILD が見つからない場合は 404 を返す", async () => {
-    const parent = parentUser();
+    const parent = parentUserWithFamily();
     mockPrisma.user.findFirst.mockResolvedValue(null);
-    const result = await resolveTargetChild(parent as any, "child-9");
+    const result = await resolveTargetChild(parent, "child-9");
     expect(result.ok).toBe(false);
     if (!result.ok) {
       expect(result.status).toBe(404);
@@ -51,10 +49,10 @@ describe("resolveTargetChild", () => {
   });
 
   it("正しい子供が見つかった場合は ok:true で child を返す", async () => {
-    const parent = parentUser();
+    const parent = parentUserWithFamily();
     const child = childUser({ id: "child-3" });
-    mockPrisma.user.findFirst.mockResolvedValue(child as any);
-    const result = await resolveTargetChild(parent as any, "child-3");
+    mockPrisma.user.findFirst.mockResolvedValue(child);
+    const result = await resolveTargetChild(parent, "child-3");
     expect(result.ok).toBe(true);
     if (result.ok) {
       expect(result.child.id).toBe("child-3");
@@ -62,10 +60,10 @@ describe("resolveTargetChild", () => {
   });
 
   it("別 family の childId を指定された場合は 404 を返す（family クロス検証）", async () => {
-    const parent = parentUser({ familyId: "fam-1" });
+    const parent = parentUserWithFamily({ familyId: "fam-1" });
     // 別ファミリーの子は findFirst の where 条件で除外され null が返る
     mockPrisma.user.findFirst.mockResolvedValue(null);
-    const result = await resolveTargetChild(parent as any, "child-other-family");
+    const result = await resolveTargetChild(parent, "child-other-family");
     expect(result.ok).toBe(false);
     if (!result.ok) {
       expect(result.status).toBe(404);

--- a/src/__tests__/lib/push.test.ts
+++ b/src/__tests__/lib/push.test.ts
@@ -4,7 +4,8 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 vi.unmock("@/lib/push");
 
 import { sendPushToChild } from "@/lib/push";
-import { prisma } from "@/lib/prisma";
+import { prismaMock as mockPrisma } from "../helpers/prisma-mock";
+import { pushSubscription } from "../helpers/fixtures";
 
 vi.mock("web-push", () => ({
   default: {
@@ -12,8 +13,6 @@ vi.mock("web-push", () => ({
     sendNotification: vi.fn().mockResolvedValue({}),
   },
 }));
-
-const mockPrisma = vi.mocked(prisma);
 
 beforeEach(() => {
   vi.clearAllMocks();
@@ -24,9 +23,9 @@ beforeEach(() => {
 describe("sendPushToChild", () => {
   it("子供のsubscriptionが存在する場合、通知を送信すること", async () => {
     const subs = [
-      { id: "sub-1", endpoint: "https://push.example.com/1", p256dh: "key1", auth: "auth1" },
+      pushSubscription({ id: "sub-1", endpoint: "https://push.example.com/1", p256dh: "key1", auth: "auth1" }),
     ];
-    mockPrisma.pushSubscription.findMany.mockResolvedValue(subs as any);
+    mockPrisma.pushSubscription.findMany.mockResolvedValue(subs);
 
     const webpush = (await import("web-push")).default;
 
@@ -53,10 +52,10 @@ describe("sendPushToChild", () => {
 
   it("410 Gone エラーが返ったとき、subscriptionを削除すること", async () => {
     const subs = [
-      { id: "sub-1", endpoint: "https://push.example.com/1", p256dh: "key1", auth: "auth1" },
+      pushSubscription({ id: "sub-1", endpoint: "https://push.example.com/1", p256dh: "key1", auth: "auth1" }),
     ];
-    mockPrisma.pushSubscription.findMany.mockResolvedValue(subs as any);
-    mockPrisma.pushSubscription.delete.mockResolvedValue({} as any);
+    mockPrisma.pushSubscription.findMany.mockResolvedValue(subs);
+    mockPrisma.pushSubscription.delete.mockResolvedValue(pushSubscription({ id: "sub-1" }));
 
     const webpush = (await import("web-push")).default;
     vi.mocked(webpush.sendNotification).mockRejectedValueOnce({ statusCode: 410 });

--- a/src/__tests__/lib/subscriptionService.test.ts
+++ b/src/__tests__/lib/subscriptionService.test.ts
@@ -1,13 +1,12 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { prisma } from "@/lib/prisma";
 import {
   getSubscription,
   getUserPlan,
   getFamilyPlan,
   countActiveTasksForChild,
 } from "@/lib/subscriptionService";
-
-const mockPrisma = vi.mocked(prisma);
+import { prismaMock as mockPrisma } from "../helpers/prisma-mock";
+import { parentUser, subscription } from "../helpers/fixtures";
 
 beforeEach(() => {
   vi.clearAllMocks();
@@ -26,18 +25,15 @@ describe("getSubscription", () => {
   });
 
   it("レコードがあればそのまま返す", async () => {
-    const row = {
+    const row = subscription({
       id: "sub-1",
       userId: "user-1",
-      plan: "PREMIUM" as const,
+      plan: "PREMIUM",
       platform: "web",
       externalId: "cus_xxx",
       currentPeriodEnd: new Date("2026-09-06"),
-      canceledAt: null,
-      createdAt: new Date(),
-      updatedAt: new Date(),
-    };
-    mockPrisma.subscription.findUnique.mockResolvedValue(row as never);
+    });
+    mockPrisma.subscription.findUnique.mockResolvedValue(row);
 
     const sub = await getSubscription("user-1");
     expect(sub).toEqual(row);
@@ -56,40 +52,36 @@ describe("getUserPlan", () => {
   });
 
   it("plan=FREE のレコード → FREE", async () => {
-    mockPrisma.subscription.findUnique.mockResolvedValue({
-      plan: "FREE",
-      currentPeriodEnd: null,
-    } as never);
+    mockPrisma.subscription.findUnique.mockResolvedValue(
+      subscription({ plan: "FREE", currentPeriodEnd: null }),
+    );
 
     const plan = await getUserPlan("user-1", now);
     expect(plan).toBe("FREE");
   });
 
   it("plan=PREMIUM で期間有効 → PREMIUM", async () => {
-    mockPrisma.subscription.findUnique.mockResolvedValue({
-      plan: "PREMIUM",
-      currentPeriodEnd: new Date("2026-09-06"),
-    } as never);
+    mockPrisma.subscription.findUnique.mockResolvedValue(
+      subscription({ plan: "PREMIUM", currentPeriodEnd: new Date("2026-09-06") }),
+    );
 
     const plan = await getUserPlan("user-1", now);
     expect(plan).toBe("PREMIUM");
   });
 
   it("plan=PREMIUM で期間切れ → FREE (grace period なし)", async () => {
-    mockPrisma.subscription.findUnique.mockResolvedValue({
-      plan: "PREMIUM",
-      currentPeriodEnd: new Date("2026-07-01"),
-    } as never);
+    mockPrisma.subscription.findUnique.mockResolvedValue(
+      subscription({ plan: "PREMIUM", currentPeriodEnd: new Date("2026-07-01") }),
+    );
 
     const plan = await getUserPlan("user-1", now);
     expect(plan).toBe("FREE");
   });
 
   it("plan=PREMIUM で currentPeriodEnd=null は PREMIUM (無期限扱い、手動付与など)", async () => {
-    mockPrisma.subscription.findUnique.mockResolvedValue({
-      plan: "PREMIUM",
-      currentPeriodEnd: null,
-    } as never);
+    mockPrisma.subscription.findUnique.mockResolvedValue(
+      subscription({ plan: "PREMIUM", currentPeriodEnd: null }),
+    );
 
     const plan = await getUserPlan("user-1", now);
     expect(plan).toBe("PREMIUM");
@@ -112,7 +104,7 @@ describe("getFamilyPlan", () => {
   });
 
   it("PARENT の Subscription が無ければ FREE", async () => {
-    mockPrisma.user.findFirst.mockResolvedValue({ id: "parent-1" } as never);
+    mockPrisma.user.findFirst.mockResolvedValue(parentUser({ id: "parent-1" }));
     mockPrisma.subscription.findUnique.mockResolvedValue(null);
 
     const plan = await getFamilyPlan("fam-1", now);
@@ -121,22 +113,20 @@ describe("getFamilyPlan", () => {
   });
 
   it("PARENT が PREMIUM 有効期間中なら PREMIUM", async () => {
-    mockPrisma.user.findFirst.mockResolvedValue({ id: "parent-1" } as never);
-    mockPrisma.subscription.findUnique.mockResolvedValue({
-      plan: "PREMIUM",
-      currentPeriodEnd: new Date("2026-09-06"),
-    } as never);
+    mockPrisma.user.findFirst.mockResolvedValue(parentUser({ id: "parent-1" }));
+    mockPrisma.subscription.findUnique.mockResolvedValue(
+      subscription({ plan: "PREMIUM", currentPeriodEnd: new Date("2026-09-06") }),
+    );
 
     const plan = await getFamilyPlan("fam-1", now);
     expect(plan).toBe("PREMIUM");
   });
 
   it("PARENT の Subscription が期限切れなら FREE", async () => {
-    mockPrisma.user.findFirst.mockResolvedValue({ id: "parent-1" } as never);
-    mockPrisma.subscription.findUnique.mockResolvedValue({
-      plan: "PREMIUM",
-      currentPeriodEnd: new Date("2026-07-01"),
-    } as never);
+    mockPrisma.user.findFirst.mockResolvedValue(parentUser({ id: "parent-1" }));
+    mockPrisma.subscription.findUnique.mockResolvedValue(
+      subscription({ plan: "PREMIUM", currentPeriodEnd: new Date("2026-07-01") }),
+    );
 
     const plan = await getFamilyPlan("fam-1", now);
     expect(plan).toBe("FREE");


### PR DESCRIPTION
## Summary
- `as any`/`as never` 計49件と型エラーを全廃し、`prismaMock` を使った型付きモックへ移行（対象: lib残り8ファイル）。`fixtures.ts` に `gatheringMember()` を純追加
- `push.test.ts` の `vi.unmock("@/lib/push")` 特殊パターンが維持されていることを code-reviewer が確認済み
- `auth.test.ts` に Supabase クライアント部分の `as unknown as` が1箇所理由コメント付きで残存（Prisma以外の別系統のため許容範囲）
- `badgesLoadContext.test.ts` の手動モック差し替えハックを `prismaMock` の標準パターンに置換
- テスト件数変化なし、`expect` 出現数139→139で減少なし

## Test plan
- [x] `npm test` パス（87/87対象ファイル、フルスイート2512件、変化なし）
- [x] `npm run typecheck`（prisma generate後）: 127→0件
- [ ] `npm run lint` パス

Closes #47

🤖 Generated with [Claude Code](https://claude.com/claude-code)
