### PR TITLE
test(treasures): treasures/badges/collection-items系10ファイルのas anyを型付きモックに移行

### DIFF
--- a/src/__tests__/api/badges/route.test.ts
+++ b/src/__tests__/api/badges/route.test.ts
@@ -1,10 +1,11 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { prisma } from "@/lib/prisma";
 import { getCurrentUser } from "@/lib/auth";
 import { checkAndUnlockBadges } from "@/lib/badges";
+import type { Badge, BadgeProgress } from "@/lib/badges";
 import { triggerBadgeLog } from "@/lib/bulletinLog";
 import { GET } from "@/app/api/badges/route";
-import { childUser, parentUser } from "../../helpers/fixtures";
+import { prismaMock as mockPrisma } from "../../helpers/prisma-mock";
+import { childUserWithFamily, parentUserWithFamily, userBadge } from "../../helpers/fixtures";
 
 vi.mock("@/lib/badges", async () => {
   const actual = await vi.importActual<typeof import("@/lib/badges")>("@/lib/badges");
@@ -38,10 +39,23 @@ vi.mock("@/lib/bulletinLog", () => ({
   triggerBadgeLog: vi.fn().mockResolvedValue(undefined),
 }));
 
-const mockPrisma = vi.mocked(prisma);
 const mockGetCurrentUser = vi.mocked(getCurrentUser);
 const mockCheckAndUnlockBadges = vi.mocked(checkAndUnlockBadges);
 const mockTriggerBadgeLog = vi.mocked(triggerBadgeLog);
+
+type BadgeResponseItem = Badge & {
+  unlocked: boolean;
+  unlockedAt: Date | null;
+  isNew: boolean;
+  progress: BadgeProgress | null;
+};
+
+type BadgesResponse = {
+  badges: BadgeResponseItem[];
+  unlockedCount: number;
+  totalCount: number;
+  newlyUnlocked: string[];
+};
 
 beforeEach(() => {
   vi.clearAllMocks();
@@ -50,7 +64,7 @@ beforeEach(() => {
 
 describe("GET /api/badges", () => {
   it("子供以外（親 or 未認証）は 403", async () => {
-    mockGetCurrentUser.mockResolvedValue(parentUser() as any);
+    mockGetCurrentUser.mockResolvedValue(parentUserWithFamily());
     const res = await GET();
     expect(res.status).toBe(403);
 
@@ -60,7 +74,7 @@ describe("GET /api/badges", () => {
   });
 
   it("新規解除されたバッジを掲示板に流す（triggerBadgeLog 呼び出し）", async () => {
-    mockGetCurrentUser.mockResolvedValue(childUser() as any);
+    mockGetCurrentUser.mockResolvedValue(childUserWithFamily());
     mockCheckAndUnlockBadges.mockResolvedValue([
       { id: "first_step", name: "はじめの一歩", emoji: "🌱", description: "..." },
       { id: "login_14", name: "2週間ログイン", emoji: "🌿", description: "..." },
@@ -76,7 +90,7 @@ describe("GET /api/badges", () => {
   });
 
   it("新規解除がなければ triggerBadgeLog は呼ばれない", async () => {
-    mockGetCurrentUser.mockResolvedValue(childUser() as any);
+    mockGetCurrentUser.mockResolvedValue(childUserWithFamily());
     mockCheckAndUnlockBadges.mockResolvedValue([]);
 
     const res = await GET();
@@ -87,40 +101,40 @@ describe("GET /api/badges", () => {
   });
 
   it("UserBadge に廃止された旧ID が残っていても unlockedCount は ALL_BADGES の ID のみ数える", async () => {
-    mockGetCurrentUser.mockResolvedValue(childUser() as any);
+    mockGetCurrentUser.mockResolvedValue(childUserWithFamily());
     mockCheckAndUnlockBadges.mockResolvedValue([]);
     mockPrisma.userBadge.findMany.mockResolvedValue([
-      { badgeId: "first_quest", unlockedAt: new Date("2026-06-01") },
-      { badgeId: "first_approval", unlockedAt: new Date("2026-04-10") }, // 廃止ID
-      { badgeId: "streak_3", unlockedAt: new Date("2026-04-11") },       // 廃止ID
-      { badgeId: "xp_10", unlockedAt: new Date("2026-04-12") },          // 廃止ID
-    ] as any);
+      userBadge({ id: "ub-1", badgeId: "first_quest", unlockedAt: new Date("2026-06-01") }),
+      userBadge({ id: "ub-2", badgeId: "first_approval", unlockedAt: new Date("2026-04-10") }), // 廃止ID
+      userBadge({ id: "ub-3", badgeId: "streak_3", unlockedAt: new Date("2026-04-11") }),       // 廃止ID
+      userBadge({ id: "ub-4", badgeId: "xp_10", unlockedAt: new Date("2026-04-12") }),          // 廃止ID
+    ]);
 
     const res = await GET();
-    const json = await res.json();
+    const json = (await res.json()) as BadgesResponse;
     expect(res.status).toBe(200);
     expect(json.unlockedCount).toBe(1);
     expect(json.totalCount).toBe(100);
     // 旧IDのバッジは badges 配列に含まれない（ALL_BADGES ベース描画）
-    const ids = json.badges.map((b: any) => b.id);
+    const ids = json.badges.map((b) => b.id);
     expect(ids).not.toContain("first_approval");
     expect(ids).not.toContain("streak_3");
     expect(ids).not.toContain("xp_10");
   });
 
   it("レスポンスの各バッジに progress フィールドを含む（数値系は {current,target}、ブール系は null）", async () => {
-    mockGetCurrentUser.mockResolvedValue(childUser() as any);
+    mockGetCurrentUser.mockResolvedValue(childUserWithFamily());
     const res = await GET();
-    const json = await res.json();
+    const json = (await res.json()) as BadgesResponse;
     expect(res.status).toBe(200);
     expect(Array.isArray(json.badges)).toBe(true);
 
-    const questBadge = json.badges.find((b: any) => b.id === "quest_10");
+    const questBadge = json.badges.find((b) => b.id === "quest_10");
     expect(questBadge).toBeDefined();
-    expect(questBadge.progress).toEqual({ current: 0, target: 10 });
+    expect(questBadge?.progress).toEqual({ current: 0, target: 10 });
 
-    const collectionAll = json.badges.find((b: any) => b.id === "collection_all");
+    const collectionAll = json.badges.find((b) => b.id === "collection_all");
     expect(collectionAll).toBeDefined();
-    expect(collectionAll.progress).toBeNull();
+    expect(collectionAll?.progress).toBeNull();
   });
 });

--- a/src/__tests__/api/badges/unseen-count.test.ts
+++ b/src/__tests__/api/badges/unseen-count.test.ts
@@ -1,10 +1,9 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { prisma } from "@/lib/prisma";
 import { getCurrentUser } from "@/lib/auth";
 import { GET } from "@/app/api/badges/unseen-count/route";
-import { childUser, parentUser } from "../../helpers/fixtures";
+import { prismaMock as mockPrisma } from "../../helpers/prisma-mock";
+import { childUserWithFamily, parentUserWithFamily } from "../../helpers/fixtures";
 
-const mockPrisma = vi.mocked(prisma);
 const mockGetCurrentUser = vi.mocked(getCurrentUser);
 
 beforeEach(() => {
@@ -17,13 +16,13 @@ describe("GET /api/badges/unseen-count", () => {
     const res1 = await GET();
     expect(res1.status).toBe(403);
 
-    mockGetCurrentUser.mockResolvedValue(parentUser() as any);
+    mockGetCurrentUser.mockResolvedValue(parentUserWithFamily());
     const res2 = await GET();
     expect(res2.status).toBe(403);
   });
 
   it("count は ALL_BADGES の ID 集合に絞ったクエリで実行する（旧IDを含まない）", async () => {
-    mockGetCurrentUser.mockResolvedValue(childUser() as any);
+    mockGetCurrentUser.mockResolvedValue(childUserWithFamily());
     mockPrisma.userBadge.count.mockResolvedValue(3);
 
     const res = await GET();
@@ -31,16 +30,17 @@ describe("GET /api/badges/unseen-count", () => {
     const json = await res.json();
     expect(json.unlockedCount).toBe(3);
 
-    const countCall = (mockPrisma.userBadge.count as any).mock.calls[0][0];
-    expect(countCall.where.userId).toBe("child-1");
+    const countCall = mockPrisma.userBadge.count.mock.calls[0][0];
+    const where = countCall?.where as { userId?: unknown; badgeId?: { in?: unknown[] } };
+    expect(where.userId).toBe("child-1");
     // ALL_BADGES の ID 集合で絞る where 句が指定されていること
-    expect(countCall.where.badgeId).toBeDefined();
-    expect(countCall.where.badgeId.in).toBeInstanceOf(Array);
-    expect(countCall.where.badgeId.in.length).toBe(100);
+    expect(where.badgeId).toBeDefined();
+    expect(where.badgeId?.in).toBeInstanceOf(Array);
+    expect(where.badgeId?.in?.length).toBe(100);
     // 旧IDは含まれない
-    expect(countCall.where.badgeId.in).not.toContain("first_approval");
-    expect(countCall.where.badgeId.in).not.toContain("streak_3");
+    expect(where.badgeId?.in).not.toContain("first_approval");
+    expect(where.badgeId?.in).not.toContain("streak_3");
     // 現行IDのサンプルは含まれる
-    expect(countCall.where.badgeId.in).toContain("first_quest");
+    expect(where.badgeId?.in).toContain("first_quest");
   });
 });

--- a/src/__tests__/api/collection-items/route.test.ts
+++ b/src/__tests__/api/collection-items/route.test.ts
@@ -1,11 +1,10 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { GET as getChild } from "@/app/api/collection-items/route";
 import { GET as getParentProxy } from "@/app/api/parent/child-view/collection-items/route";
-import { prisma } from "@/lib/prisma";
 import { getCurrentUser } from "@/lib/auth";
-import { childUser, parentUser } from "../../helpers/fixtures";
+import { prismaMock as mockPrisma } from "../../helpers/prisma-mock";
+import { childUserWithFamily, parentUserWithFamily, childUser, userCollectionItem } from "../../helpers/fixtures";
 
-const mockPrisma = vi.mocked(prisma);
 const mockGetCurrentUser = vi.mocked(getCurrentUser);
 
 beforeEach(() => {
@@ -14,7 +13,7 @@ beforeEach(() => {
 
 describe("GET /api/collection-items (子供)", () => {
   it("PARENT で 403", async () => {
-    mockGetCurrentUser.mockResolvedValue(parentUser() as any);
+    mockGetCurrentUser.mockResolvedValue(parentUserWithFamily());
     const res = await getChild();
     expect(res.status).toBe(403);
   });
@@ -26,9 +25,9 @@ describe("GET /api/collection-items (子供)", () => {
   });
 
   it("子供 → 全 140 件 (通常 80 + 月限定 60) + 所持アイテムは owned=true + currentMonth を返す", async () => {
-    mockGetCurrentUser.mockResolvedValue(childUser({ id: "c1" }) as any);
+    mockGetCurrentUser.mockResolvedValue(childUserWithFamily({ id: "c1" }));
     mockPrisma.userCollectionItem.findMany.mockResolvedValue([
-      {
+      userCollectionItem({
         id: "r1",
         childId: "c1",
         itemId: "summer-01",
@@ -36,8 +35,8 @@ describe("GET /api/collection-items (子供)", () => {
         count: 2,
         firstAcquiredAt: new Date("2026-06-01T00:00:00Z"),
         lastAcquiredAt: new Date("2026-06-05T00:00:00Z"),
-      },
-    ] as any);
+      }),
+    ]);
 
     const res = await getChild();
     const json = await res.json();
@@ -75,28 +74,28 @@ describe("GET /api/parent/child-view/collection-items (親代理)", () => {
   });
 
   it("CHILD で 403 (PARENT のみ許可)", async () => {
-    mockGetCurrentUser.mockResolvedValue(childUser() as any);
+    mockGetCurrentUser.mockResolvedValue(childUserWithFamily());
     const res = await getParentProxy(makeReq("childId=c1"));
     expect(res.status).toBe(403);
   });
 
   it("childId 未指定で 400", async () => {
-    mockGetCurrentUser.mockResolvedValue(parentUser() as any);
+    mockGetCurrentUser.mockResolvedValue(parentUserWithFamily());
     const res = await getParentProxy(makeReq(""));
     expect(res.status).toBe(400);
   });
 
   it("別 family の子で 404", async () => {
-    mockGetCurrentUser.mockResolvedValue(parentUser() as any);
+    mockGetCurrentUser.mockResolvedValue(parentUserWithFamily());
     mockPrisma.user.findFirst.mockResolvedValue(null);
     const res = await getParentProxy(makeReq("childId=c-other"));
     expect(res.status).toBe(404);
   });
 
   it("親代理 → 子供と同形式のレスポンス", async () => {
-    mockGetCurrentUser.mockResolvedValue(parentUser() as any);
-    mockPrisma.user.findFirst.mockResolvedValue(childUser({ id: "c1" }) as any);
-    mockPrisma.userCollectionItem.findMany.mockResolvedValue([] as any);
+    mockGetCurrentUser.mockResolvedValue(parentUserWithFamily());
+    mockPrisma.user.findFirst.mockResolvedValue(childUser({ id: "c1" }));
+    mockPrisma.userCollectionItem.findMany.mockResolvedValue([]);
 
     const res = await getParentProxy(makeReq("childId=c1"));
     const json = await res.json();

--- a/src/__tests__/api/treasures/fulfill-pending.test.ts
+++ b/src/__tests__/api/treasures/fulfill-pending.test.ts
@@ -1,11 +1,18 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { Prisma } from "@/generated/prisma/client";
 import { GET as pendingGET } from "@/app/api/treasures/pending/route";
-import { prisma } from "@/lib/prisma";
 import { getCurrentUser } from "@/lib/auth";
-import { parentUser, childUser } from "../../helpers/fixtures";
+import { prismaMock as mockPrisma } from "../../helpers/prisma-mock";
+import { parentUserWithFamily, childUserWithFamily, treasureLog } from "../../helpers/fixtures";
 
-const mockPrisma = vi.mocked(prisma);
 const mockGetCurrentUser = vi.mocked(getCurrentUser);
+
+type PendingTreasureLog = Prisma.TreasureLogGetPayload<{
+  include: {
+    item: { select: { id: true; title: true; rarity: true } };
+    child: { select: { id: true; name: true; monsterName: true } };
+  };
+}>;
 
 beforeEach(() => {
   vi.clearAllMocks();
@@ -16,54 +23,59 @@ beforeEach(() => {
 // fulfilled フィルタは外して時系列順で返す。
 describe("GET /api/treasures/pending (もらったごほうび履歴)", () => {
   it("CHILDで403", async () => {
-    mockGetCurrentUser.mockResolvedValue(childUser() as any);
+    mockGetCurrentUser.mockResolvedValue(childUserWithFamily());
     const res = await pendingGET();
     expect(res.status).toBe(403);
   });
 
   it("familyId なしで空配列", async () => {
-    mockGetCurrentUser.mockResolvedValue(parentUser({ familyId: null }) as any);
+    mockGetCurrentUser.mockResolvedValue(parentUserWithFamily({ familyId: null }, null));
     const res = await pendingGET();
     const json = await res.json();
     expect(json.items).toEqual([]);
   });
 
   it("OPENED + itemId 有 を fulfilled の値に関係なく取得", async () => {
-    mockGetCurrentUser.mockResolvedValue(parentUser() as any);
-    mockPrisma.treasureLog.findMany.mockResolvedValue([
+    mockGetCurrentUser.mockResolvedValue(parentUserWithFamily());
+    const items: PendingTreasureLog[] = [
       {
-        id: "log-1",
-        openedAt: new Date("2026-03-21"),
+        ...treasureLog({
+          id: "log-1",
+          openedAt: new Date("2026-03-21"),
+          status: "OPENED",
+          itemId: "i1",
+        }),
         item: { id: "i1", title: "おやつ", rarity: "COMMON" },
         child: { id: "child-1", name: "太郎", monsterName: "ドラゴン" },
-      } as any,
-    ]);
+      },
+    ];
+    mockPrisma.treasureLog.findMany.mockResolvedValue(items);
     const res = await pendingGET();
     const json = await res.json();
     expect(json.items).toHaveLength(1);
-    const arg = (mockPrisma.treasureLog.findMany as any).mock.calls[0][0];
+    const arg = mockPrisma.treasureLog.findMany.mock.calls[0][0];
     // 「渡したよ」廃止: fulfilled フィルタは入らない
-    expect(arg.where).not.toHaveProperty("fulfilled");
+    expect(arg?.where).not.toHaveProperty("fulfilled");
     // 当たりのみ取得（ハズレは履歴に出さない）
-    expect(arg.where).toMatchObject({
+    expect(arg?.where).toMatchObject({
       status: "OPENED",
       itemId: { not: null },
     });
   });
 
   it("openedAt の新しい順で並ぶ", async () => {
-    mockGetCurrentUser.mockResolvedValue(parentUser() as any);
+    mockGetCurrentUser.mockResolvedValue(parentUserWithFamily());
     mockPrisma.treasureLog.findMany.mockResolvedValue([]);
     await pendingGET();
-    const arg = (mockPrisma.treasureLog.findMany as any).mock.calls[0][0];
-    expect(arg.orderBy).toMatchObject({ openedAt: "desc" });
+    const arg = mockPrisma.treasureLog.findMany.mock.calls[0][0];
+    expect(arg?.orderBy).toMatchObject({ openedAt: "desc" });
   });
 
   it("最大100件まで取得（履歴は無制限に出さない）", async () => {
-    mockGetCurrentUser.mockResolvedValue(parentUser() as any);
+    mockGetCurrentUser.mockResolvedValue(parentUserWithFamily());
     mockPrisma.treasureLog.findMany.mockResolvedValue([]);
     await pendingGET();
-    const arg = (mockPrisma.treasureLog.findMany as any).mock.calls[0][0];
-    expect(arg.take).toBe(100);
+    const arg = mockPrisma.treasureLog.findMany.mock.calls[0][0];
+    expect(arg?.take).toBe(100);
   });
 });

--- a/src/__tests__/api/treasures/fulfill.test.ts
+++ b/src/__tests__/api/treasures/fulfill.test.ts
@@ -1,11 +1,10 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { POST } from "@/app/api/treasures/fulfill/[id]/route";
-import { prisma } from "@/lib/prisma";
 import { getCurrentUser } from "@/lib/auth";
-import { childUser, parentUser } from "../../helpers/fixtures";
+import { prismaMock as mockPrisma } from "../../helpers/prisma-mock";
+import { childUserWithFamily, parentUserWithFamily, treasureLog } from "../../helpers/fixtures";
 import { makeParams, makeRequest } from "../../helpers/request";
 
-const mockPrisma = vi.mocked(prisma);
 const mockGetCurrentUser = vi.mocked(getCurrentUser);
 
 beforeEach(() => {
@@ -23,7 +22,7 @@ describe("POST /api/treasures/fulfill/[id]", () => {
   });
 
   it("CHILD ロールで 403 (親のみ操作可)", async () => {
-    mockGetCurrentUser.mockResolvedValue(childUser() as any);
+    mockGetCurrentUser.mockResolvedValue(childUserWithFamily());
     const res = await POST(
       makeRequest("/api/treasures/fulfill/t1", { fulfilled: true }),
       makeParams("t1"),
@@ -32,7 +31,7 @@ describe("POST /api/treasures/fulfill/[id]", () => {
   });
 
   it("対象 TreasureLog が無ければ 404", async () => {
-    mockGetCurrentUser.mockResolvedValue(parentUser() as any);
+    mockGetCurrentUser.mockResolvedValue(parentUserWithFamily());
     mockPrisma.treasureLog.findFirst.mockResolvedValue(null);
     const res = await POST(
       makeRequest("/api/treasures/fulfill/t-missing", { fulfilled: true }),
@@ -42,7 +41,7 @@ describe("POST /api/treasures/fulfill/[id]", () => {
   });
 
   it("別 family の TreasureLog で 404 (familyId スコープ)", async () => {
-    mockGetCurrentUser.mockResolvedValue(parentUser({ familyId: "fam-1" }) as any);
+    mockGetCurrentUser.mockResolvedValue(parentUserWithFamily({ familyId: "fam-1" }));
     mockPrisma.treasureLog.findFirst.mockResolvedValue(null);
     const res = await POST(
       makeRequest("/api/treasures/fulfill/t1", { fulfilled: true }),
@@ -50,18 +49,19 @@ describe("POST /api/treasures/fulfill/[id]", () => {
     );
     expect(res.status).toBe(404);
     // findFirst の where に familyId スコープが入っていることを確認
-    const callArg = (mockPrisma.treasureLog.findFirst as any).mock.calls[0][0];
-    expect(callArg.where.child.familyId).toBe("fam-1");
+    const callArg = mockPrisma.treasureLog.findFirst.mock.calls[0][0];
+    const where = callArg?.where as { child?: { familyId?: unknown } };
+    expect(where.child?.familyId).toBe("fam-1");
   });
 
   it("親ごほうび当選 (item not null) を fulfilled=true で更新", async () => {
-    mockGetCurrentUser.mockResolvedValue(parentUser({ familyId: "fam-1" }) as any);
-    mockPrisma.treasureLog.findFirst.mockResolvedValue({
-      id: "t1",
-      itemId: "item-1",
-      fulfilled: false,
-    } as any);
-    mockPrisma.treasureLog.update.mockResolvedValue({ id: "t1", fulfilled: true } as any);
+    mockGetCurrentUser.mockResolvedValue(parentUserWithFamily({ familyId: "fam-1" }));
+    mockPrisma.treasureLog.findFirst.mockResolvedValue(
+      treasureLog({ id: "t1", itemId: "item-1", fulfilled: false }),
+    );
+    mockPrisma.treasureLog.update.mockResolvedValue(
+      treasureLog({ id: "t1", itemId: "item-1", fulfilled: true }),
+    );
 
     const res = await POST(
       makeRequest("/api/treasures/fulfill/t1", { fulfilled: true }),
@@ -79,13 +79,13 @@ describe("POST /api/treasures/fulfill/[id]", () => {
   });
 
   it("fulfilled=false で取り消し可能 (誤チェック復旧用)", async () => {
-    mockGetCurrentUser.mockResolvedValue(parentUser({ familyId: "fam-1" }) as any);
-    mockPrisma.treasureLog.findFirst.mockResolvedValue({
-      id: "t1",
-      itemId: "item-1",
-      fulfilled: true,
-    } as any);
-    mockPrisma.treasureLog.update.mockResolvedValue({ id: "t1", fulfilled: false } as any);
+    mockGetCurrentUser.mockResolvedValue(parentUserWithFamily({ familyId: "fam-1" }));
+    mockPrisma.treasureLog.findFirst.mockResolvedValue(
+      treasureLog({ id: "t1", itemId: "item-1", fulfilled: true }),
+    );
+    mockPrisma.treasureLog.update.mockResolvedValue(
+      treasureLog({ id: "t1", itemId: "item-1", fulfilled: false }),
+    );
 
     const res = await POST(
       makeRequest("/api/treasures/fulfill/t1", { fulfilled: false }),
@@ -101,13 +101,15 @@ describe("POST /api/treasures/fulfill/[id]", () => {
   });
 
   it("コレクション獲得 (itemId=null) は 400 (実物受け渡しが無いので fulfilled の意味なし)", async () => {
-    mockGetCurrentUser.mockResolvedValue(parentUser({ familyId: "fam-1" }) as any);
-    mockPrisma.treasureLog.findFirst.mockResolvedValue({
-      id: "t-col",
-      itemId: null,
-      collectionItemId: "summer-01",
-      fulfilled: false,
-    } as any);
+    mockGetCurrentUser.mockResolvedValue(parentUserWithFamily({ familyId: "fam-1" }));
+    mockPrisma.treasureLog.findFirst.mockResolvedValue(
+      treasureLog({
+        id: "t-col",
+        itemId: null,
+        collectionItemId: "summer-01",
+        fulfilled: false,
+      }),
+    );
 
     const res = await POST(
       makeRequest("/api/treasures/fulfill/t-col", { fulfilled: true }),
@@ -118,9 +120,9 @@ describe("POST /api/treasures/fulfill/[id]", () => {
   });
 
   it("body.fulfilled が boolean でなければ 400", async () => {
-    mockGetCurrentUser.mockResolvedValue(parentUser({ familyId: "fam-1" }) as any);
+    mockGetCurrentUser.mockResolvedValue(parentUserWithFamily({ familyId: "fam-1" }));
     const res = await POST(
-      makeRequest("/api/treasures/fulfill/t1", { fulfilled: "yes" } as any),
+      makeRequest("/api/treasures/fulfill/t1", { fulfilled: "yes" }),
       makeParams("t1"),
     );
     expect(res.status).toBe(400);

--- a/src/__tests__/api/treasures/open.test.ts
+++ b/src/__tests__/api/treasures/open.test.ts
@@ -1,12 +1,12 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { POST } from "@/app/api/treasures/open/route";
-import { prisma } from "@/lib/prisma";
 import { getCurrentUser } from "@/lib/auth";
 import { openOldestTreasure } from "@/lib/treasureService";
 import { sendPushToParent } from "@/lib/push";
 import { checkAndUnlockBadges } from "@/lib/badges";
 import { triggerBadgeLog } from "@/lib/bulletinLog";
-import { childUser, parentUser } from "../../helpers/fixtures";
+import { prismaMock as mockPrisma } from "../../helpers/prisma-mock";
+import { childUserWithFamily, parentUser, parentUserWithFamily } from "../../helpers/fixtures";
 
 vi.mock("@/lib/treasureService", () => ({
   openOldestTreasure: vi.fn(),
@@ -24,7 +24,6 @@ vi.mock("@/lib/bulletinLog", () => ({
   triggerBadgeLog: vi.fn().mockResolvedValue(undefined),
 }));
 
-const mockPrisma = vi.mocked(prisma);
 const mockGetCurrentUser = vi.mocked(getCurrentUser);
 const mockOpen = vi.mocked(openOldestTreasure);
 const mockSendPushToParent = vi.mocked(sendPushToParent);
@@ -38,7 +37,7 @@ beforeEach(() => {
 
 describe("POST /api/treasures/open", () => {
   it("PARENTで403", async () => {
-    mockGetCurrentUser.mockResolvedValue(parentUser() as any);
+    mockGetCurrentUser.mockResolvedValue(parentUserWithFamily());
     const res = await POST();
     expect(res.status).toBe(403);
   });
@@ -50,20 +49,20 @@ describe("POST /api/treasures/open", () => {
   });
 
   it("UNLOCKED 宝箱が無いと 400", async () => {
-    mockGetCurrentUser.mockResolvedValue(childUser() as any);
+    mockGetCurrentUser.mockResolvedValue(childUserWithFamily());
     mockOpen.mockResolvedValue(null);
     const res = await POST();
     expect(res.status).toBe(400);
   });
 
   it("親ごほうび当選時: 親に Push を送る", async () => {
-    mockGetCurrentUser.mockResolvedValue(childUser({ name: "太郎" }) as any);
+    mockGetCurrentUser.mockResolvedValue(childUserWithFamily({ name: "太郎" }));
     mockOpen.mockResolvedValue({
       logId: "log-1",
       item: { id: "i1", title: "おやつ", rarity: "COMMON" },
       collectionItem: null,
     });
-    mockPrisma.user.findFirst.mockResolvedValue({ id: "parent-1" } as any);
+    mockPrisma.user.findFirst.mockResolvedValue(parentUser({ id: "parent-1" }));
     mockPrisma.treasureLog.count.mockResolvedValue(2);
 
     const res = await POST();
@@ -83,7 +82,7 @@ describe("POST /api/treasures/open", () => {
   });
 
   it("コレクション獲得時: Push は送らない / collectionItem をレスポンスに含める", async () => {
-    mockGetCurrentUser.mockResolvedValue(childUser() as any);
+    mockGetCurrentUser.mockResolvedValue(childUserWithFamily());
     mockOpen.mockResolvedValue({
       logId: "log-2",
       item: null,
@@ -111,7 +110,7 @@ describe("POST /api/treasures/open", () => {
   });
 
   it("レスポンスに pityTriggered フィールドは含まない (pity 廃止)", async () => {
-    mockGetCurrentUser.mockResolvedValue(childUser() as any);
+    mockGetCurrentUser.mockResolvedValue(childUserWithFamily());
     mockOpen.mockResolvedValue({
       logId: "log-3",
       item: { id: "i1", title: "本", rarity: "RARE" },
@@ -125,7 +124,7 @@ describe("POST /api/treasures/open", () => {
   });
 
   it("開封後に checkAndUnlockBadges を呼ぶ（宝箱・コレクション系バッジを即時解錠）", async () => {
-    mockGetCurrentUser.mockResolvedValue(childUser({ id: "child-1" }) as any);
+    mockGetCurrentUser.mockResolvedValue(childUserWithFamily({ id: "child-1" }));
     mockOpen.mockResolvedValue({
       logId: "log-4",
       item: null,
@@ -143,7 +142,7 @@ describe("POST /api/treasures/open", () => {
   });
 
   it("新規解錠バッジを掲示板に流す（triggerBadgeLog 呼び出し）", async () => {
-    mockGetCurrentUser.mockResolvedValue(childUser({ id: "child-1" }) as any);
+    mockGetCurrentUser.mockResolvedValue(childUserWithFamily({ id: "child-1" }));
     mockOpen.mockResolvedValue({
       logId: "log-5",
       item: null,

--- a/src/__tests__/api/treasures/status.test.ts
+++ b/src/__tests__/api/treasures/status.test.ts
@@ -1,11 +1,15 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { Prisma } from "@/generated/prisma/client";
 import { GET } from "@/app/api/treasures/status/route";
-import { prisma } from "@/lib/prisma";
 import { getCurrentUser } from "@/lib/auth";
-import { childUser, parentUser } from "../../helpers/fixtures";
+import { prismaMock as mockPrisma } from "../../helpers/prisma-mock";
+import { childUserWithFamily, parentUserWithFamily, treasureLog } from "../../helpers/fixtures";
 
-const mockPrisma = vi.mocked(prisma);
 const mockGetCurrentUser = vi.mocked(getCurrentUser);
+
+type OpenedTreasureLog = Prisma.TreasureLogGetPayload<{
+  include: { item: { select: { id: true; title: true; rarity: true } } };
+}>;
 
 beforeEach(() => {
   vi.clearAllMocks();
@@ -13,30 +17,40 @@ beforeEach(() => {
 
 describe("GET /api/treasures/status", () => {
   it("PARENTで403", async () => {
-    mockGetCurrentUser.mockResolvedValue(parentUser() as any);
+    mockGetCurrentUser.mockResolvedValue(parentUserWithFamily());
     const res = await GET();
     expect(res.status).toBe(403);
   });
 
   it("LOCKED/UNLOCKED 件数と OPENED 履歴を返す", async () => {
-    mockGetCurrentUser.mockResolvedValue(childUser() as any);
+    mockGetCurrentUser.mockResolvedValue(childUserWithFamily());
     mockPrisma.treasureLog.count
       .mockResolvedValueOnce(2) // LOCKED
       .mockResolvedValueOnce(3); // UNLOCKED
-    mockPrisma.treasureLog.findMany.mockResolvedValue([
+    const opened: OpenedTreasureLog[] = [
       {
-        id: "log-1",
-        openedAt: new Date("2026-03-21"),
-        boosted: false,
+        ...treasureLog({
+          id: "log-1",
+          openedAt: new Date("2026-03-21"),
+          boosted: false,
+          status: "OPENED",
+          itemId: "i1",
+        }),
         item: { id: "i1", title: "おやつ", rarity: "COMMON" },
-      } as any,
+      },
       {
-        id: "log-2",
-        openedAt: new Date("2026-03-20"),
-        boosted: true,
+        ...treasureLog({
+          id: "log-2",
+          openedAt: new Date("2026-03-20"),
+          boosted: true,
+          status: "OPENED",
+          itemId: null,
+        }),
         item: null, // 親ごほうび不当選 (コレクションアイテム獲得)
-      } as any,
-    ]);
+      },
+    ];
+    mockPrisma.treasureLog.findMany.mockResolvedValue(opened);
+    mockPrisma.treasureItem.count.mockResolvedValue(0);
 
     const res = await GET();
     const json = await res.json();

--- a/src/__tests__/api/treasures/treasure-status.test.ts
+++ b/src/__tests__/api/treasures/treasure-status.test.ts
@@ -1,11 +1,15 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import type { Prisma } from "@/generated/prisma/client";
 import { GET } from "@/app/api/treasures/status/route";
-import { prisma } from "@/lib/prisma";
 import { getCurrentUser } from "@/lib/auth";
-import { childUser, parentUser } from "../../helpers/fixtures";
+import { prismaMock as mockPrisma } from "../../helpers/prisma-mock";
+import { childUserWithFamily, parentUserWithFamily, treasureLog } from "../../helpers/fixtures";
 
-const mockPrisma = vi.mocked(prisma);
 const mockGetCurrentUser = vi.mocked(getCurrentUser);
+
+type OpenedTreasureLog = Prisma.TreasureLogGetPayload<{
+  include: { item: { select: { id: true; title: true; rarity: true } } };
+}>;
 
 const FIXED_NOW = new Date("2026-05-29T10:00:00Z");
 
@@ -27,27 +31,29 @@ describe("GET /api/treasures/status", () => {
   });
 
   it("PARENT で403（CHILD 専用 API）", async () => {
-    mockGetCurrentUser.mockResolvedValue(parentUser() as any);
+    mockGetCurrentUser.mockResolvedValue(parentUserWithFamily());
     const res = await GET();
     expect(res.status).toBe(403);
   });
 
   it("opened 履歴は openedAt が直近7日以内のみを問い合わせる", async () => {
-    mockGetCurrentUser.mockResolvedValue(childUser() as any);
+    mockGetCurrentUser.mockResolvedValue(childUserWithFamily());
     mockPrisma.treasureLog.count
       .mockResolvedValueOnce(0) // locked
       .mockResolvedValueOnce(0); // unlocked
     mockPrisma.treasureLog.findMany.mockResolvedValue([]);
+    mockPrisma.treasureItem.count.mockResolvedValue(0);
 
     const res = await GET();
     expect(res.status).toBe(200);
 
-    const findManyCall = (mockPrisma.treasureLog.findMany as any).mock.calls[0][0];
+    const findManyCall = mockPrisma.treasureLog.findMany.mock.calls[0][0];
+    const where = findManyCall?.where as { status?: unknown; openedAt?: { gte?: Date } };
     // OPENED 状態 + 7日以内のフィルタ
-    expect(findManyCall.where.status).toBe("OPENED");
-    expect(findManyCall.where.openedAt).toBeDefined();
-    expect(findManyCall.where.openedAt.gte).toBeInstanceOf(Date);
-    const cutoff = findManyCall.where.openedAt.gte as Date;
+    expect(where.status).toBe("OPENED");
+    expect(where.openedAt).toBeDefined();
+    expect(where.openedAt?.gte).toBeInstanceOf(Date);
+    const cutoff = where.openedAt?.gte as Date;
     // 7日前
     expect(cutoff.getTime()).toBe(
       new Date("2026-05-22T10:00:00Z").getTime(),
@@ -55,18 +61,24 @@ describe("GET /api/treasures/status", () => {
   });
 
   it("locked / unlocked カウントと opened を返す", async () => {
-    mockGetCurrentUser.mockResolvedValue(childUser() as any);
+    mockGetCurrentUser.mockResolvedValue(childUserWithFamily());
     mockPrisma.treasureLog.count
       .mockResolvedValueOnce(2) // locked
       .mockResolvedValueOnce(1); // unlocked
-    mockPrisma.treasureLog.findMany.mockResolvedValue([
+    const opened: OpenedTreasureLog[] = [
       {
-        id: "log1",
-        openedAt: new Date("2026-05-29T09:30:00Z"),
-        boosted: false,
+        ...treasureLog({
+          id: "log1",
+          openedAt: new Date("2026-05-29T09:30:00Z"),
+          boosted: false,
+          status: "OPENED",
+          itemId: "i1",
+        }),
         item: { id: "i1", title: "おやつ", rarity: "COMMON" },
       },
-    ] as any);
+    ];
+    mockPrisma.treasureLog.findMany.mockResolvedValue(opened);
+    mockPrisma.treasureItem.count.mockResolvedValue(0);
 
     const res = await GET();
     const json = await res.json();
@@ -78,7 +90,7 @@ describe("GET /api/treasures/status", () => {
   });
 
   it("treasureItem (有効プール) が 1件以上あれば hasPool=true", async () => {
-    mockGetCurrentUser.mockResolvedValue(childUser() as any);
+    mockGetCurrentUser.mockResolvedValue(childUserWithFamily());
     mockPrisma.treasureLog.count.mockResolvedValue(0);
     mockPrisma.treasureLog.findMany.mockResolvedValue([]);
     mockPrisma.treasureItem.count.mockResolvedValue(3);
@@ -90,7 +102,7 @@ describe("GET /api/treasures/status", () => {
   });
 
   it("treasureItem が 0件なら hasPool=false (フッタータブ非表示判定に使う)", async () => {
-    mockGetCurrentUser.mockResolvedValue(childUser() as any);
+    mockGetCurrentUser.mockResolvedValue(childUserWithFamily());
     mockPrisma.treasureLog.count.mockResolvedValue(0);
     mockPrisma.treasureLog.findMany.mockResolvedValue([]);
     mockPrisma.treasureItem.count.mockResolvedValue(0);

--- a/src/__tests__/api/treasures/treasures-limit.test.ts
+++ b/src/__tests__/api/treasures/treasures-limit.test.ts
@@ -2,17 +2,16 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 import { POST as listPOST } from "@/app/api/treasures/route";
 import { PUT as itemPUT } from "@/app/api/treasures/[id]/route";
 import { POST as importPOST } from "@/app/api/treasures/import/route";
-import { prisma } from "@/lib/prisma";
 import { getCurrentUser } from "@/lib/auth";
-import { parentUser } from "../../helpers/fixtures";
+import { prismaMock as mockPrisma } from "../../helpers/prisma-mock";
+import { parentUserWithFamily, childUser, parentUser, treasureItem, subscription } from "../../helpers/fixtures";
 import { makeParams, makeRequest } from "../../helpers/request";
 
-const mockPrisma = vi.mocked(prisma);
 const mockGetCurrentUser = vi.mocked(getCurrentUser);
 
 beforeEach(() => {
   vi.clearAllMocks();
-  mockGetCurrentUser.mockResolvedValue(parentUser() as never);
+  mockGetCurrentUser.mockResolvedValue(parentUserWithFamily());
 });
 
 /// FREE プランのごほうび (TreasureItem) 上限 (5個/子) の enforce を担保。
@@ -20,23 +19,19 @@ beforeEach(() => {
 describe("POST /api/treasures — FREE プランのごほうび上限", () => {
   beforeEach(() => {
     // 家族チェック用
-    mockPrisma.user.findFirst.mockResolvedValue({ id: "child-1" } as never);
+    mockPrisma.user.findFirst.mockResolvedValue(childUser({ id: "child-1" }));
   });
 
   it("FREE で 4/5: 5 個目は追加成功", async () => {
     // getFamilyPlan 用に PARENT を返し (2 回目呼び出し), Subscription なし
     mockPrisma.user.findFirst
-      .mockResolvedValueOnce({ id: "child-1" } as never) // ensureFamilyChild
-      .mockResolvedValueOnce({ id: "parent-1" } as never); // getFamilyPlan
+      .mockResolvedValueOnce(childUser({ id: "child-1" })) // ensureFamilyChild
+      .mockResolvedValueOnce(parentUser({ id: "parent-1" })); // getFamilyPlan
     mockPrisma.subscription.findUnique.mockResolvedValue(null);
     mockPrisma.treasureItem.count.mockResolvedValue(4);
-    mockPrisma.treasureItem.create.mockResolvedValue({
-      id: "i-new",
-      title: "おやつ",
-      rarity: "COMMON",
-      sortOrder: 0,
-      isActive: true,
-    } as never);
+    mockPrisma.treasureItem.create.mockResolvedValue(
+      treasureItem({ id: "i-new", title: "おやつ", rarity: "COMMON", sortOrder: 0, isActive: true }),
+    );
 
     const res = await listPOST(
       makeRequest("/api/treasures", { childId: "child-1", title: "おやつ", rarity: "COMMON" }),
@@ -47,8 +42,8 @@ describe("POST /api/treasures — FREE プランのごほうび上限", () => {
 
   it("FREE で 5/5: 6 個目は 403 で拒否", async () => {
     mockPrisma.user.findFirst
-      .mockResolvedValueOnce({ id: "child-1" } as never)
-      .mockResolvedValueOnce({ id: "parent-1" } as never);
+      .mockResolvedValueOnce(childUser({ id: "child-1" }))
+      .mockResolvedValueOnce(parentUser({ id: "parent-1" }));
     mockPrisma.subscription.findUnique.mockResolvedValue(null);
     mockPrisma.treasureItem.count.mockResolvedValue(5);
 
@@ -66,14 +61,13 @@ describe("POST /api/treasures — FREE プランのごほうび上限", () => {
 
   it("PREMIUM 有効期間中は無制限に追加可能", async () => {
     mockPrisma.user.findFirst
-      .mockResolvedValueOnce({ id: "child-1" } as never)
-      .mockResolvedValueOnce({ id: "parent-1" } as never);
-    mockPrisma.subscription.findUnique.mockResolvedValue({
-      plan: "PREMIUM",
-      currentPeriodEnd: new Date("2099-12-31"),
-    } as never);
+      .mockResolvedValueOnce(childUser({ id: "child-1" }))
+      .mockResolvedValueOnce(parentUser({ id: "parent-1" }));
+    mockPrisma.subscription.findUnique.mockResolvedValue(
+      subscription({ plan: "PREMIUM", currentPeriodEnd: new Date("2099-12-31") }),
+    );
     mockPrisma.treasureItem.count.mockResolvedValue(999);
-    mockPrisma.treasureItem.create.mockResolvedValue({ id: "i-premium" } as never);
+    mockPrisma.treasureItem.create.mockResolvedValue(treasureItem({ id: "i-premium" }));
 
     const res = await listPOST(
       makeRequest("/api/treasures", { childId: "child-1", title: "無制限", rarity: "COMMON" }),
@@ -83,11 +77,11 @@ describe("POST /api/treasures — FREE プランのごほうび上限", () => {
 
   it("カウントは childId ごと isActive: true のみ", async () => {
     mockPrisma.user.findFirst
-      .mockResolvedValueOnce({ id: "child-1" } as never)
-      .mockResolvedValueOnce({ id: "parent-1" } as never);
+      .mockResolvedValueOnce(childUser({ id: "child-1" }))
+      .mockResolvedValueOnce(parentUser({ id: "parent-1" }));
     mockPrisma.subscription.findUnique.mockResolvedValue(null);
     mockPrisma.treasureItem.count.mockResolvedValue(0);
-    mockPrisma.treasureItem.create.mockResolvedValue({ id: "i1" } as never);
+    mockPrisma.treasureItem.create.mockResolvedValue(treasureItem({ id: "i1" }));
 
     await listPOST(
       makeRequest("/api/treasures", { childId: "child-1", title: "x", rarity: "COMMON" }),
@@ -101,12 +95,10 @@ describe("POST /api/treasures — FREE プランのごほうび上限", () => {
 
 describe("PUT /api/treasures/[id] — 再アクティブ化時の上限チェック", () => {
   it("isActive: false → true (再アクティブ化) は上限チェックが走る (FREE 5/5 で 403)", async () => {
-    mockPrisma.treasureItem.findFirst.mockResolvedValue({
-      id: "i1",
-      childId: "child-1",
-      isActive: false,
-    } as never);
-    mockPrisma.user.findFirst.mockResolvedValue({ id: "parent-1" } as never);
+    mockPrisma.treasureItem.findFirst.mockResolvedValue(
+      treasureItem({ id: "i1", childId: "child-1", isActive: false }),
+    );
+    mockPrisma.user.findFirst.mockResolvedValue(parentUser({ id: "parent-1" }));
     mockPrisma.subscription.findUnique.mockResolvedValue(null); // FREE
     mockPrisma.treasureItem.count.mockResolvedValue(5);
 
@@ -121,15 +113,13 @@ describe("PUT /api/treasures/[id] — 再アクティブ化時の上限チェッ
   });
 
   it("isActive: false → true が FREE 4/5 なら成功", async () => {
-    mockPrisma.treasureItem.findFirst.mockResolvedValue({
-      id: "i1",
-      childId: "child-1",
-      isActive: false,
-    } as never);
-    mockPrisma.user.findFirst.mockResolvedValue({ id: "parent-1" } as never);
+    mockPrisma.treasureItem.findFirst.mockResolvedValue(
+      treasureItem({ id: "i1", childId: "child-1", isActive: false }),
+    );
+    mockPrisma.user.findFirst.mockResolvedValue(parentUser({ id: "parent-1" }));
     mockPrisma.subscription.findUnique.mockResolvedValue(null);
     mockPrisma.treasureItem.count.mockResolvedValue(4);
-    mockPrisma.treasureItem.update.mockResolvedValue({ id: "i1" } as never);
+    mockPrisma.treasureItem.update.mockResolvedValue(treasureItem({ id: "i1" }));
 
     const res = await itemPUT(
       makeRequest("/api/treasures/i1", { isActive: true }),
@@ -139,12 +129,10 @@ describe("PUT /api/treasures/[id] — 再アクティブ化時の上限チェッ
   });
 
   it("isActive: true → false (非アクティブ化) は上限チェック不要 (常に成功)", async () => {
-    mockPrisma.treasureItem.findFirst.mockResolvedValue({
-      id: "i1",
-      childId: "child-1",
-      isActive: true,
-    } as never);
-    mockPrisma.treasureItem.update.mockResolvedValue({ id: "i1" } as never);
+    mockPrisma.treasureItem.findFirst.mockResolvedValue(
+      treasureItem({ id: "i1", childId: "child-1", isActive: true }),
+    );
+    mockPrisma.treasureItem.update.mockResolvedValue(treasureItem({ id: "i1" }));
 
     const res = await itemPUT(
       makeRequest("/api/treasures/i1", { isActive: false }),
@@ -156,12 +144,10 @@ describe("PUT /api/treasures/[id] — 再アクティブ化時の上限チェッ
   });
 
   it("isActive を触らない title/rarity 更新は上限チェック不要", async () => {
-    mockPrisma.treasureItem.findFirst.mockResolvedValue({
-      id: "i1",
-      childId: "child-1",
-      isActive: true,
-    } as never);
-    mockPrisma.treasureItem.update.mockResolvedValue({ id: "i1" } as never);
+    mockPrisma.treasureItem.findFirst.mockResolvedValue(
+      treasureItem({ id: "i1", childId: "child-1", isActive: true }),
+    );
+    mockPrisma.treasureItem.update.mockResolvedValue(treasureItem({ id: "i1" }));
 
     const res = await itemPUT(
       makeRequest("/api/treasures/i1", { title: "変更", rarity: "RARE" }),
@@ -172,12 +158,10 @@ describe("PUT /api/treasures/[id] — 再アクティブ化時の上限チェッ
   });
 
   it("既に isActive: true な状態で isActive: true を送信 (no-op) は上限チェック不要", async () => {
-    mockPrisma.treasureItem.findFirst.mockResolvedValue({
-      id: "i1",
-      childId: "child-1",
-      isActive: true,
-    } as never);
-    mockPrisma.treasureItem.update.mockResolvedValue({ id: "i1" } as never);
+    mockPrisma.treasureItem.findFirst.mockResolvedValue(
+      treasureItem({ id: "i1", childId: "child-1", isActive: true }),
+    );
+    mockPrisma.treasureItem.update.mockResolvedValue(treasureItem({ id: "i1" }));
 
     const res = await itemPUT(
       makeRequest("/api/treasures/i1", { isActive: true }),
@@ -191,8 +175,8 @@ describe("PUT /api/treasures/[id] — 再アクティブ化時の上限チェッ
 describe("POST /api/treasures/import — バルクインポートの上限チェック", () => {
   it("FREE + 0 個: 20 個 import は 403 (合計 20 > 上限 5)", async () => {
     mockPrisma.user.findFirst
-      .mockResolvedValueOnce({ id: "child-1" } as never) // 対象子供検証
-      .mockResolvedValueOnce({ id: "parent-1" } as never); // getFamilyPlan
+      .mockResolvedValueOnce(childUser({ id: "child-1" })) // 対象子供検証
+      .mockResolvedValueOnce(parentUser({ id: "parent-1" })); // getFamilyPlan
     mockPrisma.subscription.findUnique.mockResolvedValue(null);
     mockPrisma.treasureItem.count.mockResolvedValue(0);
 
@@ -208,14 +192,13 @@ describe("POST /api/treasures/import — バルクインポートの上限チェ
 
   it("PREMIUM は 20 個 import 成功", async () => {
     mockPrisma.user.findFirst
-      .mockResolvedValueOnce({ id: "child-1" } as never)
-      .mockResolvedValueOnce({ id: "parent-1" } as never);
-    mockPrisma.subscription.findUnique.mockResolvedValue({
-      plan: "PREMIUM",
-      currentPeriodEnd: new Date("2099-12-31"),
-    } as never);
+      .mockResolvedValueOnce(childUser({ id: "child-1" }))
+      .mockResolvedValueOnce(parentUser({ id: "parent-1" }));
+    mockPrisma.subscription.findUnique.mockResolvedValue(
+      subscription({ plan: "PREMIUM", currentPeriodEnd: new Date("2099-12-31") }),
+    );
     mockPrisma.treasureItem.count.mockResolvedValue(0);
-    mockPrisma.treasureItem.createMany.mockResolvedValue({ count: 20 } as never);
+    mockPrisma.treasureItem.createMany.mockResolvedValue({ count: 20 });
 
     const res = await importPOST(
       makeRequest("/api/treasures/import", { childId: "child-1" }),

--- a/src/__tests__/api/treasures/treasures.test.ts
+++ b/src/__tests__/api/treasures/treasures.test.ts
@@ -2,12 +2,11 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 import { GET as listGET, POST as listPOST } from "@/app/api/treasures/route";
 import { PUT as itemPUT, DELETE as itemDELETE } from "@/app/api/treasures/[id]/route";
 import { POST as importPOST } from "@/app/api/treasures/import/route";
-import { prisma } from "@/lib/prisma";
 import { getCurrentUser } from "@/lib/auth";
-import { parentUser, childUser } from "../../helpers/fixtures";
+import { prismaMock as mockPrisma } from "../../helpers/prisma-mock";
+import { parentUserWithFamily, childUserWithFamily, childUser, parentUser, treasureItem, subscription } from "../../helpers/fixtures";
 import { makeParams, makeRequest } from "../../helpers/request";
 
-const mockPrisma = vi.mocked(prisma);
 const mockGetCurrentUser = vi.mocked(getCurrentUser);
 
 beforeEach(() => {
@@ -23,29 +22,29 @@ describe("GET /api/treasures", () => {
   });
 
   it("CHILDロールで403", async () => {
-    mockGetCurrentUser.mockResolvedValue(childUser() as any);
+    mockGetCurrentUser.mockResolvedValue(childUserWithFamily());
     const res = await listGET(new Request("http://localhost/api/treasures?childId=c1"));
     expect(res.status).toBe(403);
   });
 
   it("childId 未指定で400", async () => {
-    mockGetCurrentUser.mockResolvedValue(parentUser() as any);
+    mockGetCurrentUser.mockResolvedValue(parentUserWithFamily());
     const res = await listGET(new Request("http://localhost/api/treasures"));
     expect(res.status).toBe(400);
   });
 
   it("自家族でない子供は404", async () => {
-    mockGetCurrentUser.mockResolvedValue(parentUser() as any);
+    mockGetCurrentUser.mockResolvedValue(parentUserWithFamily());
     mockPrisma.user.findFirst.mockResolvedValue(null);
     const res = await listGET(new Request("http://localhost/api/treasures?childId=c-other"));
     expect(res.status).toBe(404);
   });
 
   it("自家族の子供のプール一覧を返す", async () => {
-    mockGetCurrentUser.mockResolvedValue(parentUser() as any);
-    mockPrisma.user.findFirst.mockResolvedValue({ id: "child-1" } as any);
+    mockGetCurrentUser.mockResolvedValue(parentUserWithFamily());
+    mockPrisma.user.findFirst.mockResolvedValue(childUser({ id: "child-1" }));
     mockPrisma.treasureItem.findMany.mockResolvedValue([
-      { id: "i1", title: "おやつ", rarity: "COMMON", sortOrder: 0, isActive: true } as any,
+      treasureItem({ id: "i1", title: "おやつ", rarity: "COMMON", sortOrder: 0, isActive: true }),
     ]);
     const res = await listGET(new Request("http://localhost/api/treasures?childId=child-1"));
     const json = await res.json();
@@ -58,7 +57,7 @@ describe("GET /api/treasures", () => {
 // ─── POST /api/treasures ─────────────────────────────────────────────
 describe("POST /api/treasures", () => {
   it("CHILDで403", async () => {
-    mockGetCurrentUser.mockResolvedValue(childUser() as any);
+    mockGetCurrentUser.mockResolvedValue(childUserWithFamily());
     const res = await listPOST(
       makeRequest("/api/treasures", { childId: "c1", title: "x", rarity: "COMMON" }),
     );
@@ -66,7 +65,7 @@ describe("POST /api/treasures", () => {
   });
 
   it("title 空で400", async () => {
-    mockGetCurrentUser.mockResolvedValue(parentUser() as any);
+    mockGetCurrentUser.mockResolvedValue(parentUserWithFamily());
     const res = await listPOST(
       makeRequest("/api/treasures", { childId: "child-1", title: "", rarity: "COMMON" }),
     );
@@ -74,7 +73,7 @@ describe("POST /api/treasures", () => {
   });
 
   it("rarity 不正で400", async () => {
-    mockGetCurrentUser.mockResolvedValue(parentUser() as any);
+    mockGetCurrentUser.mockResolvedValue(parentUserWithFamily());
     const res = await listPOST(
       makeRequest("/api/treasures", { childId: "child-1", title: "x", rarity: "MYTHIC" }),
     );
@@ -82,7 +81,7 @@ describe("POST /api/treasures", () => {
   });
 
   it("自家族でない子供は404", async () => {
-    mockGetCurrentUser.mockResolvedValue(parentUser() as any);
+    mockGetCurrentUser.mockResolvedValue(parentUserWithFamily());
     mockPrisma.user.findFirst.mockResolvedValue(null);
     const res = await listPOST(
       makeRequest("/api/treasures", { childId: "x", title: "おやつ", rarity: "COMMON" }),
@@ -91,15 +90,11 @@ describe("POST /api/treasures", () => {
   });
 
   it("正常系: 作成して 200", async () => {
-    mockGetCurrentUser.mockResolvedValue(parentUser() as any);
-    mockPrisma.user.findFirst.mockResolvedValue({ id: "child-1" } as any);
-    mockPrisma.treasureItem.create.mockResolvedValue({
-      id: "i1",
-      title: "おやつ",
-      rarity: "COMMON",
-      sortOrder: 0,
-      isActive: true,
-    } as any);
+    mockGetCurrentUser.mockResolvedValue(parentUserWithFamily());
+    mockPrisma.user.findFirst.mockResolvedValue(childUser({ id: "child-1" }));
+    mockPrisma.treasureItem.create.mockResolvedValue(
+      treasureItem({ id: "i1", title: "おやつ", rarity: "COMMON", sortOrder: 0, isActive: true }),
+    );
 
     const res = await listPOST(
       makeRequest("/api/treasures", { childId: "child-1", title: "  おやつ  ", rarity: "COMMON" }),
@@ -118,29 +113,29 @@ describe("POST /api/treasures", () => {
 // ─── PUT /api/treasures/[id] ─────────────────────────────────────────
 describe("PUT /api/treasures/[id]", () => {
   it("CHILDで403", async () => {
-    mockGetCurrentUser.mockResolvedValue(childUser() as any);
+    mockGetCurrentUser.mockResolvedValue(childUserWithFamily());
     const res = await itemPUT(makeRequest("/api/treasures/i1", { title: "x" }), makeParams("i1"));
     expect(res.status).toBe(403);
   });
 
   it("自家族でないアイテムは404", async () => {
-    mockGetCurrentUser.mockResolvedValue(parentUser() as any);
+    mockGetCurrentUser.mockResolvedValue(parentUserWithFamily());
     mockPrisma.treasureItem.findFirst.mockResolvedValue(null);
     const res = await itemPUT(makeRequest("/api/treasures/i1", { title: "x" }), makeParams("i1"));
     expect(res.status).toBe(404);
   });
 
   it("更新項目がないと400", async () => {
-    mockGetCurrentUser.mockResolvedValue(parentUser() as any);
-    mockPrisma.treasureItem.findFirst.mockResolvedValue({ id: "i1" } as any);
+    mockGetCurrentUser.mockResolvedValue(parentUserWithFamily());
+    mockPrisma.treasureItem.findFirst.mockResolvedValue(treasureItem({ id: "i1" }));
     const res = await itemPUT(makeRequest("/api/treasures/i1", {}), makeParams("i1"));
     expect(res.status).toBe(400);
   });
 
   it("title/rarity を更新", async () => {
-    mockGetCurrentUser.mockResolvedValue(parentUser() as any);
-    mockPrisma.treasureItem.findFirst.mockResolvedValue({ id: "i1" } as any);
-    mockPrisma.treasureItem.update.mockResolvedValue({} as any);
+    mockGetCurrentUser.mockResolvedValue(parentUserWithFamily());
+    mockPrisma.treasureItem.findFirst.mockResolvedValue(treasureItem({ id: "i1" }));
+    mockPrisma.treasureItem.update.mockResolvedValue(treasureItem({ id: "i1" }));
 
     const res = await itemPUT(
       makeRequest("/api/treasures/i1", { title: "新タイトル", rarity: "RARE" }),
@@ -158,9 +153,9 @@ describe("PUT /api/treasures/[id]", () => {
 // ─── DELETE /api/treasures/[id] ──────────────────────────────────────
 describe("DELETE /api/treasures/[id]", () => {
   it("ソフトデリート（isActive=false に更新）", async () => {
-    mockGetCurrentUser.mockResolvedValue(parentUser() as any);
-    mockPrisma.treasureItem.findFirst.mockResolvedValue({ id: "i1" } as any);
-    mockPrisma.treasureItem.update.mockResolvedValue({} as any);
+    mockGetCurrentUser.mockResolvedValue(parentUserWithFamily());
+    mockPrisma.treasureItem.findFirst.mockResolvedValue(treasureItem({ id: "i1" }));
+    mockPrisma.treasureItem.update.mockResolvedValue(treasureItem({ id: "i1" }));
 
     const res = await itemDELETE(new Request("http://localhost/api/treasures/i1", { method: "DELETE" }), makeParams("i1"));
     expect(res.status).toBe(200);
@@ -174,17 +169,16 @@ describe("DELETE /api/treasures/[id]", () => {
 // ─── POST /api/treasures/import ──────────────────────────────────────
 describe("POST /api/treasures/import", () => {
   it("テンプレ20件を子供のプールに投入", async () => {
-    mockGetCurrentUser.mockResolvedValue(parentUser() as any);
+    mockGetCurrentUser.mockResolvedValue(parentUserWithFamily());
     // 対象子供検証 + getFamilyPlan 用の PARENT (2 回連続で findFirst が呼ばれる)
     mockPrisma.user.findFirst
-      .mockResolvedValueOnce({ id: "child-1" } as any)
-      .mockResolvedValueOnce({ id: "parent-1" } as any);
+      .mockResolvedValueOnce(childUser({ id: "child-1" }))
+      .mockResolvedValueOnce(parentUser({ id: "parent-1" }));
     // PREMIUM 相当。FREE だと 5 個上限を超過して 403 になる (別テストで検証)
-    mockPrisma.subscription.findUnique.mockResolvedValue({
-      plan: "PREMIUM",
-      currentPeriodEnd: new Date("2099-12-31"),
-    } as any);
-    mockPrisma.treasureItem.createMany.mockResolvedValue({ count: 20 } as any);
+    mockPrisma.subscription.findUnique.mockResolvedValue(
+      subscription({ plan: "PREMIUM", currentPeriodEnd: new Date("2099-12-31") }),
+    );
+    mockPrisma.treasureItem.createMany.mockResolvedValue({ count: 20 });
 
     const res = await importPOST(
       makeRequest("/api/treasures/import", { childId: "child-1" }),
@@ -193,8 +187,9 @@ describe("POST /api/treasures/import", () => {
     expect(res.status).toBe(200);
     expect(json.count).toBe(20);
     // createMany 呼び出しの内容を確認
-    const arg = (mockPrisma.treasureItem.createMany as any).mock.calls[0][0];
-    expect(arg.data.length).toBe(20);
-    expect(arg.data[0]).toMatchObject({ childId: "child-1", sortOrder: 0 });
+    const arg = mockPrisma.treasureItem.createMany.mock.calls[0][0];
+    const data = arg?.data as Array<{ childId: string; sortOrder: number }>;
+    expect(data.length).toBe(20);
+    expect(data[0]).toMatchObject({ childId: "child-1", sortOrder: 0 });
   });
 });


### PR DESCRIPTION
## Summary
- `as any`/`as never`計92件+型エラー86件を全廃し、`prismaMock`に移行（`fixtures.ts`は無変更）
- **重要な発見**: `status.test.ts`/`treasure-status.test.ts`で一部テストが`treasureItem.count`を未モックのまま（mockDeepの暗黙undefinedを`Promise.all`が許容）動作していたことを発見し、`mockResolvedValue(0)`を明示追加。code-reviewerが実装コード（`hasPool`計算）を確認し、該当テストはこの値をassertしていないため挙動・カバレッジへの影響がないことを検証済み
- `badges/route.test.ts`のレスポンスJSON型として`BadgeResponseItem`を定義
- マネタイズ上限境界値テスト（`treasures-limit.test.ts`）のexpectは一字一句変更なし
- テスト件数変化なし、expect出現数163→163で減少なし

## Test plan
- [x] `npm test` パス（71/71対象ファイル、2512フルスイート、変化なし）
- [x] `npm run typecheck`（prisma generate後）: 86→0件
- [x] code-reviewerによるレビュー: APPROVED（マネタイズ上限境界値・count未モック問題を検証済み）

## Related
- Closes #48

🤖 Generated with [Claude Code](https://claude.com/claude-code)
