### PR TITLE
test(family): family/monster/rebirthテストのas anyを型付きモックに移行

### DIFF
--- a/src/__tests__/api/family/code.test.ts
+++ b/src/__tests__/api/family/code.test.ts
@@ -1,11 +1,42 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { GET, POST } from "@/app/api/family/code/route";
-import { prisma } from "@/lib/prisma";
 import { getCurrentUser } from "@/lib/auth";
-import { parentUser, childUser, family } from "../../helpers/fixtures";
+import { prismaMock as mockPrisma } from "../../helpers/prisma-mock";
+import { parentUserWithFamily, childUserWithFamily, family } from "../../helpers/fixtures";
+import type { Prisma } from "@/generated/prisma/client";
 
-const mockPrisma = vi.mocked(prisma);
 const mockGetCurrentUser = vi.mocked(getCurrentUser);
+
+/**
+ * `prisma.family.findUnique` は `include: { users: { include: { streak: { select: ... } } } }`
+ * 付きで呼ばれるが、DeepMockProxy の `mockResolvedValue` は関係（リレーション）を含まない
+ * ベースの `Family` 型しか受け付けない（`users` プロパティ自体が型エラーになる）。
+ * `Prisma.FamilyGetPayload<{ include: ... }>` で実際のクエリ形状の値を組み立てたうえで、
+ * モック関数の戻り値型へ `as unknown as` でキャストする。
+ */
+type FamilyWithUsersAndStreak = Prisma.FamilyGetPayload<{
+  include: { users: { include: { streak: { select: { lastLoginDate: true } } } } };
+}>;
+
+function mockFamilyFindUnique(payload: FamilyWithUsersAndStreak | null) {
+  mockPrisma.family.findUnique.mockResolvedValue(
+    payload as unknown as Awaited<ReturnType<typeof mockPrisma.family.findUnique>>,
+  );
+}
+
+/**
+ * `route.ts` の members map は `u.evolutionStage ?? 0` 等、多数の防御的フォールバックを
+ * 持つ。旧テスト（`as any`）は一部フィールドを欠いたメンバー行を渡しており、これらの
+ * フォールバック分岐は「欠落データ」を前提に到達していた。フィクスチャの完全な値だけを
+ * 使うとこの分岐が到達不能になりカバレッジが下がるため、旧データ状態を意図的に再現する
+ * （`src/__tests__/api/rebirth/rebirth.test.ts` 等と同じ「フィールド欠落の再現」パターン）。
+ */
+function legacyMemberRow(
+  fields: Pick<FamilyWithUsersAndStreak["users"][number], "id" | "name" | "role" | "monsterName" | "side" | "childCode"> &
+    Partial<FamilyWithUsersAndStreak["users"][number]>,
+): FamilyWithUsersAndStreak["users"][number] {
+  return fields as unknown as FamilyWithUsersAndStreak["users"][number];
+}
 
 beforeEach(() => {
   vi.clearAllMocks();
@@ -20,23 +51,28 @@ describe("GET /api/family/code", () => {
   });
 
   it("familyIdがない場合、code=null, members=[]を返すこと", async () => {
-    mockGetCurrentUser.mockResolvedValue(parentUser({ familyId: null }) as any);
+    mockGetCurrentUser.mockResolvedValue(parentUserWithFamily({ familyId: null }, null));
     const res = await GET();
     const json = await res.json();
     expect(json).toEqual({ code: null, members: [] });
   });
 
   it("ファミリー情報とメンバー一覧を返すこと", async () => {
-    mockGetCurrentUser.mockResolvedValue(parentUser() as any);
-    mockPrisma.family.findUnique.mockResolvedValue(
-      {
-        ...family({ code: "ABCD12" }),
-        users: [
-          { id: "u1", name: "パパ", role: "PARENT", monsterName: null, side: null, childCode: null },
-          { id: "u2", name: "太郎", role: "CHILD", monsterName: "ドラゴン", side: "DARK", childCode: "1234" },
-        ],
-      } as any,
-    );
+    mockGetCurrentUser.mockResolvedValue(parentUserWithFamily());
+    mockFamilyFindUnique({
+      ...family({ code: "ABCD12" }),
+      users: [
+        legacyMemberRow({ id: "u1", name: "パパ", role: "PARENT", monsterName: null, side: null, childCode: null }),
+        legacyMemberRow({
+          id: "u2",
+          name: "太郎",
+          role: "CHILD",
+          monsterName: "ドラゴン",
+          side: "DARK",
+          childCode: "1234",
+        }),
+      ],
+    });
 
     const res = await GET();
     const json = await res.json();
@@ -67,16 +103,23 @@ describe("GET /api/family/code", () => {
   });
 
   it("子供メンバーのXPフィールドを返すこと", async () => {
-    mockGetCurrentUser.mockResolvedValue(parentUser() as any);
-    mockPrisma.family.findUnique.mockResolvedValue(
-      {
-        ...family(),
-        users: [
-          { id: "u2", name: "太郎", role: "CHILD", monsterName: "ドラゴン", side: "DARK", childCode: "1234",
-            studyPt: 5, staminaPt: 3, lifePt: 2 },
-        ],
-      } as any,
-    );
+    mockGetCurrentUser.mockResolvedValue(parentUserWithFamily());
+    mockFamilyFindUnique({
+      ...family(),
+      users: [
+        legacyMemberRow({
+          id: "u2",
+          name: "太郎",
+          role: "CHILD",
+          monsterName: "ドラゴン",
+          side: "DARK",
+          childCode: "1234",
+          studyPt: 5,
+          staminaPt: 3,
+          lifePt: 2,
+        }),
+      ],
+    });
 
     const res = await GET();
     const json = await res.json();
@@ -87,8 +130,8 @@ describe("GET /api/family/code", () => {
   });
 
   it("usersをcreatedAt昇順で取得すること", async () => {
-    mockGetCurrentUser.mockResolvedValue(parentUser() as any);
-    mockPrisma.family.findUnique.mockResolvedValue({ ...family(), users: [] } as any);
+    mockGetCurrentUser.mockResolvedValue(parentUserWithFamily());
+    mockFamilyFindUnique({ ...family(), users: [] });
 
     await GET();
 
@@ -120,14 +163,14 @@ describe("POST /api/family/code", () => {
   });
 
   it("CHILDロールの場合、403を返すこと", async () => {
-    mockGetCurrentUser.mockResolvedValue(childUser() as any);
+    mockGetCurrentUser.mockResolvedValue(childUserWithFamily());
     const res = await POST();
     expect(res.status).toBe(403);
   });
 
   it("既存ファミリーのコードを再生成すること", async () => {
-    mockGetCurrentUser.mockResolvedValue(parentUser() as any);
-    mockPrisma.family.update.mockResolvedValue(family({ code: "NEWCOD" }) as any);
+    mockGetCurrentUser.mockResolvedValue(parentUserWithFamily());
+    mockPrisma.family.update.mockResolvedValue(family({ code: "NEWCOD" }));
 
     const res = await POST();
     const json = await res.json();
@@ -140,8 +183,8 @@ describe("POST /api/family/code", () => {
   });
 
   it("ファミリーがない場合、新規作成すること", async () => {
-    mockGetCurrentUser.mockResolvedValue(parentUser({ familyId: null }) as any);
-    mockPrisma.family.create.mockResolvedValue(family({ id: "fam-new", code: "CREAT1" }) as any);
+    mockGetCurrentUser.mockResolvedValue(parentUserWithFamily({ familyId: null }, null));
+    mockPrisma.family.create.mockResolvedValue(family({ id: "fam-new", code: "CREAT1" }));
 
     const res = await POST();
     const json = await res.json();

--- a/src/__tests__/api/family/members-id.test.ts
+++ b/src/__tests__/api/family/members-id.test.ts
@@ -1,11 +1,10 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { DELETE } from "@/app/api/family/members/[id]/route";
-import { prisma } from "@/lib/prisma";
 import { getCurrentUser } from "@/lib/auth";
+import { prismaMock as mockPrisma } from "../../helpers/prisma-mock";
 import { makeParams } from "../../helpers/request";
-import { parentUser, childUser } from "../../helpers/fixtures";
+import { parentUserWithFamily, childUserWithFamily, childUser } from "../../helpers/fixtures";
 
-const mockPrisma = vi.mocked(prisma);
 const mockGetCurrentUser = vi.mocked(getCurrentUser);
 
 beforeEach(() => {
@@ -20,27 +19,27 @@ describe("DELETE /api/family/members/[id]", () => {
   });
 
   it("CHILDロールの場合、403を返すこと", async () => {
-    mockGetCurrentUser.mockResolvedValue(childUser() as any);
+    mockGetCurrentUser.mockResolvedValue(childUserWithFamily());
     const res = await DELETE(new Request("http://localhost"), makeParams("child-1"));
     expect(res.status).toBe(403);
   });
 
   it("familyIdがない場合、403を返すこと", async () => {
-    mockGetCurrentUser.mockResolvedValue(parentUser({ familyId: null }) as any);
+    mockGetCurrentUser.mockResolvedValue(parentUserWithFamily({ familyId: null }, null));
     const res = await DELETE(new Request("http://localhost"), makeParams("child-1"));
     expect(res.status).toBe(403);
   });
 
   it("対象の子供が見つからない場合、404を返すこと", async () => {
-    mockGetCurrentUser.mockResolvedValue(parentUser() as any);
+    mockGetCurrentUser.mockResolvedValue(parentUserWithFamily());
     mockPrisma.user.findFirst.mockResolvedValue(null);
     const res = await DELETE(new Request("http://localhost"), makeParams("child-999"));
     expect(res.status).toBe(404);
   });
 
   it("子供アカウントを正常に削除できること", async () => {
-    mockGetCurrentUser.mockResolvedValue(parentUser() as any);
-    mockPrisma.user.findFirst.mockResolvedValue(childUser() as any);
+    mockGetCurrentUser.mockResolvedValue(parentUserWithFamily());
+    mockPrisma.user.findFirst.mockResolvedValue(childUser());
     mockPrisma.$transaction.mockResolvedValue([]);
 
     const res = await DELETE(new Request("http://localhost"), makeParams("child-1"));
@@ -52,21 +51,29 @@ describe("DELETE /api/family/members/[id]", () => {
   });
 
   it("トランザクションに QuestInstance・Streak・TaskStreak・TaskTemplate(null化)・User の削除が含まれること", async () => {
-    mockGetCurrentUser.mockResolvedValue(parentUser() as any);
-    mockPrisma.user.findFirst.mockResolvedValue(childUser() as any);
+    mockGetCurrentUser.mockResolvedValue(parentUserWithFamily());
+    mockPrisma.user.findFirst.mockResolvedValue(childUser());
 
     let capturedOps: unknown[] = [];
-    mockPrisma.$transaction.mockImplementation(async (ops: unknown) => {
-      capturedOps = ops as unknown[];
+    // `prisma.$transaction` は配列版（`Prisma.PrismaPromise[]`）とコールバック版
+    // （`(prisma) => Promise<T>`）のオーバーロードを持つが、DeepMockProxy の
+    // `mockImplementation` はコールバック版のシグネチャしか型推論できない。
+    // 実装（route.ts）は配列版で呼んでいるため、setup.ts の $transaction デフォルト
+    // 実装と同様に `unknown[]` を受け取る関数へキャストする。
+    const transactionMock = mockPrisma.$transaction as unknown as {
+      mockImplementation: (fn: (ops: unknown[]) => Promise<unknown[]>) => void;
+    };
+    transactionMock.mockImplementation(async (ops) => {
+      capturedOps = ops;
       return [];
     });
 
     // 各 deleteMany / updateMany / delete の戻り値を設定
-    mockPrisma.questInstance.deleteMany.mockReturnValue({ childId: "child-1" } as any);
-    mockPrisma.streak.deleteMany.mockReturnValue({ childId: "child-1" } as any);
-    mockPrisma.taskStreak.deleteMany.mockReturnValue({ childId: "child-1" } as any);
-    mockPrisma.taskTemplate.updateMany.mockReturnValue({ assignedChildId: null } as any);
-    mockPrisma.user.delete.mockReturnValue({ id: "child-1" } as any);
+    mockPrisma.questInstance.deleteMany.mockResolvedValue({ count: 1 });
+    mockPrisma.streak.deleteMany.mockResolvedValue({ count: 1 });
+    mockPrisma.taskStreak.deleteMany.mockResolvedValue({ count: 1 });
+    mockPrisma.taskTemplate.updateMany.mockResolvedValue({ count: 1 });
+    mockPrisma.user.delete.mockResolvedValue(childUser({ id: "child-1" }));
 
     await DELETE(new Request("http://localhost"), makeParams("child-1"));
 

--- a/src/__tests__/api/family/members-limit.test.ts
+++ b/src/__tests__/api/family/members-limit.test.ts
@@ -1,16 +1,15 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { POST } from "@/app/api/family/members/route";
-import { prisma } from "@/lib/prisma";
 import { getCurrentUser } from "@/lib/auth";
+import { prismaMock as mockPrisma } from "../../helpers/prisma-mock";
 import { makeRequest } from "../../helpers/request";
-import { parentUser } from "../../helpers/fixtures";
+import { parentUserWithFamily, parentUser, childUser, subscription } from "../../helpers/fixtures";
 
-const mockPrisma = vi.mocked(prisma);
 const mockGetCurrentUser = vi.mocked(getCurrentUser);
 
 beforeEach(() => {
   vi.clearAllMocks();
-  mockGetCurrentUser.mockResolvedValue(parentUser() as never);
+  mockGetCurrentUser.mockResolvedValue(parentUserWithFamily());
 });
 
 /// FREE プランの子アカウント上限 (Family 内 1 人まで) は、実際の子作成経路である
@@ -19,7 +18,7 @@ beforeEach(() => {
 /// 仕様: docs/未実装仕様書/monetization-plan.md §2.1 / §4.4
 describe("POST /api/family/members — FREE プランの子アカウント上限", () => {
   it("FREE で既に 1 人子がいる: 2 人目の追加は 403", async () => {
-    mockPrisma.user.findFirst.mockResolvedValue({ id: "parent-1" } as never); // getFamilyPlan
+    mockPrisma.user.findFirst.mockResolvedValue(parentUser({ id: "parent-1" })); // getFamilyPlan
     mockPrisma.subscription.findUnique.mockResolvedValue(null);
     mockPrisma.user.count.mockResolvedValue(1); // 既に 1 人
 
@@ -36,16 +35,18 @@ describe("POST /api/family/members — FREE プランの子アカウント上限
   });
 
   it("FREE で 0 人: 1 人目は追加成功", async () => {
-    mockPrisma.user.findFirst.mockResolvedValue({ id: "parent-1" } as never);
+    mockPrisma.user.findFirst.mockResolvedValue(parentUser({ id: "parent-1" }));
     mockPrisma.subscription.findUnique.mockResolvedValue(null);
     mockPrisma.user.count.mockResolvedValue(0);
     mockPrisma.user.findUnique.mockResolvedValue(null); // childCode 重複なし
-    mockPrisma.user.create.mockResolvedValue({
-      id: "db-1",
-      monsterName: "1人目",
-      side: "LIGHT",
-      childCode: "0001",
-    } as never);
+    mockPrisma.user.create.mockResolvedValue(
+      childUser({
+        id: "db-1",
+        monsterName: "1人目",
+        side: "LIGHT",
+        childCode: "0001",
+      }),
+    );
 
     const res = await POST(
       makeRequest("/api/family/members", { monsterName: "1人目", side: "LIGHT" }),
@@ -54,19 +55,20 @@ describe("POST /api/family/members — FREE プランの子アカウント上限
   });
 
   it("PREMIUM は 5 人目でも追加成功", async () => {
-    mockPrisma.user.findFirst.mockResolvedValue({ id: "parent-1" } as never);
-    mockPrisma.subscription.findUnique.mockResolvedValue({
-      plan: "PREMIUM",
-      currentPeriodEnd: new Date("2099-12-31"),
-    } as never);
+    mockPrisma.user.findFirst.mockResolvedValue(parentUser({ id: "parent-1" }));
+    mockPrisma.subscription.findUnique.mockResolvedValue(
+      subscription({ plan: "PREMIUM", currentPeriodEnd: new Date("2099-12-31") }),
+    );
     mockPrisma.user.count.mockResolvedValue(4);
     mockPrisma.user.findUnique.mockResolvedValue(null);
-    mockPrisma.user.create.mockResolvedValue({
-      id: "db-5",
-      monsterName: "5人目",
-      side: "LIGHT",
-      childCode: "0005",
-    } as never);
+    mockPrisma.user.create.mockResolvedValue(
+      childUser({
+        id: "db-5",
+        monsterName: "5人目",
+        side: "LIGHT",
+        childCode: "0005",
+      }),
+    );
 
     const res = await POST(
       makeRequest("/api/family/members", { monsterName: "5人目", side: "LIGHT" }),
@@ -75,16 +77,18 @@ describe("POST /api/family/members — FREE プランの子アカウント上限
   });
 
   it("カウントは familyId + role: CHILD のみ", async () => {
-    mockPrisma.user.findFirst.mockResolvedValue({ id: "parent-1" } as never);
+    mockPrisma.user.findFirst.mockResolvedValue(parentUser({ id: "parent-1" }));
     mockPrisma.subscription.findUnique.mockResolvedValue(null);
     mockPrisma.user.count.mockResolvedValue(0);
     mockPrisma.user.findUnique.mockResolvedValue(null);
-    mockPrisma.user.create.mockResolvedValue({
-      id: "db-x",
-      monsterName: "x",
-      side: "LIGHT",
-      childCode: "1111",
-    } as never);
+    mockPrisma.user.create.mockResolvedValue(
+      childUser({
+        id: "db-x",
+        monsterName: "x",
+        side: "LIGHT",
+        childCode: "1111",
+      }),
+    );
 
     await POST(
       makeRequest("/api/family/members", { monsterName: "x", side: "LIGHT" }),

--- a/src/__tests__/api/family/members.test.ts
+++ b/src/__tests__/api/family/members.test.ts
@@ -1,11 +1,10 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { POST, PATCH } from "@/app/api/family/members/route";
-import { prisma } from "@/lib/prisma";
 import { getCurrentUser } from "@/lib/auth";
+import { prismaMock as mockPrisma } from "../../helpers/prisma-mock";
 import { makeRequest } from "../../helpers/request";
-import { parentUser, childUser } from "../../helpers/fixtures";
+import { parentUserWithFamily, childUserWithFamily, childUser } from "../../helpers/fixtures";
 
-const mockPrisma = vi.mocked(prisma);
 const mockGetCurrentUser = vi.mocked(getCurrentUser);
 
 beforeEach(() => {
@@ -20,38 +19,40 @@ describe("POST /api/family/members", () => {
   });
 
   it("CHILDロールの場合、403を返すこと", async () => {
-    mockGetCurrentUser.mockResolvedValue(childUser() as any);
+    mockGetCurrentUser.mockResolvedValue(childUserWithFamily());
     const res = await POST(makeRequest("/api/family/members", { monsterName: "test", side: "LIGHT" }));
     expect(res.status).toBe(403);
   });
 
   it("familyIdがない場合、403を返すこと", async () => {
-    mockGetCurrentUser.mockResolvedValue(parentUser({ familyId: null }) as any);
+    mockGetCurrentUser.mockResolvedValue(parentUserWithFamily({ familyId: null }, null));
     const res = await POST(makeRequest("/api/family/members", { monsterName: "test", side: "LIGHT" }));
     expect(res.status).toBe(403);
   });
 
   it("monsterNameがない場合、400を返すこと", async () => {
-    mockGetCurrentUser.mockResolvedValue(parentUser() as any);
+    mockGetCurrentUser.mockResolvedValue(parentUserWithFamily());
     const res = await POST(makeRequest("/api/family/members", { side: "LIGHT" }));
     expect(res.status).toBe(400);
   });
 
   it("sideがない場合、400を返すこと", async () => {
-    mockGetCurrentUser.mockResolvedValue(parentUser() as any);
+    mockGetCurrentUser.mockResolvedValue(parentUserWithFamily());
     const res = await POST(makeRequest("/api/family/members", { monsterName: "テスト" }));
     expect(res.status).toBe(400);
   });
 
   it("子どもアカウントを正常に作成できること", async () => {
-    mockGetCurrentUser.mockResolvedValue(parentUser() as any);
+    mockGetCurrentUser.mockResolvedValue(parentUserWithFamily());
     mockPrisma.user.findUnique.mockResolvedValue(null);
-    mockPrisma.user.create.mockResolvedValue({
-      id: "child-new",
-      monsterName: "リュウ",
-      side: "DARK",
-      childCode: "5678",
-    } as any);
+    mockPrisma.user.create.mockResolvedValue(
+      childUser({
+        id: "child-new",
+        monsterName: "リュウ",
+        side: "DARK",
+        childCode: "5678",
+      }),
+    );
 
     const res = await POST(makeRequest("/api/family/members", { monsterName: "リュウ", side: "DARK" }));
     const json = await res.json();
@@ -64,17 +65,19 @@ describe("POST /api/family/members", () => {
   });
 
   it("childCodeが重複する場合、リトライすること", async () => {
-    mockGetCurrentUser.mockResolvedValue(parentUser() as any);
+    mockGetCurrentUser.mockResolvedValue(parentUserWithFamily());
     // 1回目: 既存あり, 2回目: なし
     mockPrisma.user.findUnique
-      .mockResolvedValueOnce({ id: "existing" } as any)
+      .mockResolvedValueOnce(childUser({ id: "existing" }))
       .mockResolvedValueOnce(null);
-    mockPrisma.user.create.mockResolvedValue({
-      id: "child-x",
-      monsterName: "テスト",
-      side: "LIGHT",
-      childCode: "9999",
-    } as any);
+    mockPrisma.user.create.mockResolvedValue(
+      childUser({
+        id: "child-x",
+        monsterName: "テスト",
+        side: "LIGHT",
+        childCode: "9999",
+      }),
+    );
 
     const res = await POST(makeRequest("/api/family/members", { monsterName: "テスト", side: "LIGHT" }));
     expect(res.status).toBe(200);
@@ -82,9 +85,9 @@ describe("POST /api/family/members", () => {
   });
 
   it("10回リトライしてもchildCodeが生成できない場合、500を返すこと", async () => {
-    mockGetCurrentUser.mockResolvedValue(parentUser() as any);
+    mockGetCurrentUser.mockResolvedValue(parentUserWithFamily());
     // 全10回とも既存あり
-    mockPrisma.user.findUnique.mockResolvedValue({ id: "existing" } as any);
+    mockPrisma.user.findUnique.mockResolvedValue(childUser({ id: "existing" }));
 
     const res = await POST(makeRequest("/api/family/members", { monsterName: "テスト", side: "LIGHT" }));
     expect(res.status).toBe(500);
@@ -92,14 +95,16 @@ describe("POST /api/family/members", () => {
   });
 
   it("作成されるユーザーがplaceholder supabaseIdを持つこと", async () => {
-    mockGetCurrentUser.mockResolvedValue(parentUser() as any);
+    mockGetCurrentUser.mockResolvedValue(parentUserWithFamily());
     mockPrisma.user.findUnique.mockResolvedValue(null);
-    mockPrisma.user.create.mockResolvedValue({
-      id: "child-1",
-      monsterName: "テスト",
-      side: "DARK",
-      childCode: "1234",
-    } as any);
+    mockPrisma.user.create.mockResolvedValue(
+      childUser({
+        id: "child-1",
+        monsterName: "テスト",
+        side: "DARK",
+        childCode: "1234",
+      }),
+    );
 
     await POST(makeRequest("/api/family/members", { monsterName: "テスト", side: "DARK" }));
 
@@ -123,22 +128,22 @@ describe("PATCH /api/family/members", () => {
   });
 
   it("minTasksForStreakが0以下なら400を返すこと", async () => {
-    mockGetCurrentUser.mockResolvedValue(parentUser() as any);
+    mockGetCurrentUser.mockResolvedValue(parentUserWithFamily());
     const res = await PATCH(makeRequest("/api/family/members", { childId: "c1", minTasksForStreak: 0 }, "PATCH"));
     expect(res.status).toBe(400);
   });
 
   it("存在しない子供IDで404を返すこと", async () => {
-    mockGetCurrentUser.mockResolvedValue(parentUser() as any);
+    mockGetCurrentUser.mockResolvedValue(parentUserWithFamily());
     mockPrisma.user.findFirst.mockResolvedValue(null);
     const res = await PATCH(makeRequest("/api/family/members", { childId: "c-none", minTasksForStreak: 3 }, "PATCH"));
     expect(res.status).toBe(404);
   });
 
   it("minTasksForStreakを正常に更新できること", async () => {
-    mockGetCurrentUser.mockResolvedValue(parentUser() as any);
-    mockPrisma.user.findFirst.mockResolvedValue(childUser() as any);
-    mockPrisma.user.update.mockResolvedValue({} as any);
+    mockGetCurrentUser.mockResolvedValue(parentUserWithFamily());
+    mockPrisma.user.findFirst.mockResolvedValue(childUser());
+    mockPrisma.user.update.mockResolvedValue(childUser({ minTasksForStreak: 3 }));
 
     const res = await PATCH(makeRequest("/api/family/members", { childId: "child-1", minTasksForStreak: 3 }, "PATCH"));
     const json = await res.json();

--- a/src/__tests__/api/family/settings.test.ts
+++ b/src/__tests__/api/family/settings.test.ts
@@ -1,9 +1,9 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { PATCH } from "@/app/api/family/settings/route";
-import { prisma } from "@/lib/prisma";
 import { getCurrentUser } from "@/lib/auth";
+import { prismaMock as mockPrisma } from "../../helpers/prisma-mock";
+import { parentUserWithFamily, childUserWithFamily, childUser } from "../../helpers/fixtures";
 
-const mockPrisma = vi.mocked(prisma);
 const mockGetCurrentUser = vi.mocked(getCurrentUser);
 
 function makeRequest(body: unknown) {
@@ -16,17 +16,13 @@ function makeRequest(body: unknown) {
 
 beforeEach(() => {
   vi.clearAllMocks();
-  mockGetCurrentUser.mockResolvedValue({
-    id: "parent-1",
-    role: "PARENT",
-    familyId: "fam-1",
-  } as any);
+  mockGetCurrentUser.mockResolvedValue(parentUserWithFamily({ id: "parent-1" }));
 });
 
 describe("PATCH /api/family/settings — questTimeNotifyEnabled", () => {
   it("親が自分のファミリーの子供の通知フラグを true→false に更新できること", async () => {
-    mockPrisma.user.findFirst.mockResolvedValue({ id: "child-1" } as any);
-    mockPrisma.user.update.mockResolvedValue({} as any);
+    mockPrisma.user.findFirst.mockResolvedValue(childUser({ id: "child-1" }));
+    mockPrisma.user.update.mockResolvedValue(childUser({ id: "child-1", questTimeNotifyEnabled: false }));
 
     const res = await PATCH(
       makeRequest({ childId: "child-1", questTimeNotifyEnabled: false }),
@@ -40,8 +36,8 @@ describe("PATCH /api/family/settings — questTimeNotifyEnabled", () => {
   });
 
   it("true への切り替えも反映されること", async () => {
-    mockPrisma.user.findFirst.mockResolvedValue({ id: "child-1" } as any);
-    mockPrisma.user.update.mockResolvedValue({} as any);
+    mockPrisma.user.findFirst.mockResolvedValue(childUser({ id: "child-1" }));
+    mockPrisma.user.update.mockResolvedValue(childUser({ id: "child-1", questTimeNotifyEnabled: true }));
 
     const res = await PATCH(
       makeRequest({ childId: "child-1", questTimeNotifyEnabled: true }),
@@ -66,11 +62,7 @@ describe("PATCH /api/family/settings — questTimeNotifyEnabled", () => {
   });
 
   it("親以外のロールは 403 で拒否されること", async () => {
-    mockGetCurrentUser.mockResolvedValue({
-      id: "child-1",
-      role: "CHILD",
-      familyId: "fam-1",
-    } as any);
+    mockGetCurrentUser.mockResolvedValue(childUserWithFamily({ id: "child-1" }));
 
     const res = await PATCH(
       makeRequest({ childId: "child-1", questTimeNotifyEnabled: false }),
@@ -81,7 +73,7 @@ describe("PATCH /api/family/settings — questTimeNotifyEnabled", () => {
   });
 
   it("questTimeNotifyEnabled が boolean でない場合は 400 を返すこと", async () => {
-    mockPrisma.user.findFirst.mockResolvedValue({ id: "child-1" } as any);
+    mockPrisma.user.findFirst.mockResolvedValue(childUser({ id: "child-1" }));
 
     const res = await PATCH(
       makeRequest({ childId: "child-1", questTimeNotifyEnabled: "true" }),
@@ -94,8 +86,8 @@ describe("PATCH /api/family/settings — questTimeNotifyEnabled", () => {
 
 describe("PATCH /api/family/settings — checkinDeadlineTime", () => {
   it("HH:mm 形式で更新できること", async () => {
-    mockPrisma.user.findFirst.mockResolvedValue({ id: "child-1" } as any);
-    mockPrisma.user.update.mockResolvedValue({} as any);
+    mockPrisma.user.findFirst.mockResolvedValue(childUser({ id: "child-1" }));
+    mockPrisma.user.update.mockResolvedValue(childUser({ id: "child-1", checkinDeadlineTime: "16:00" }));
 
     const res = await PATCH(
       makeRequest({ childId: "child-1", checkinDeadlineTime: "16:00" }),
@@ -109,8 +101,8 @@ describe("PATCH /api/family/settings — checkinDeadlineTime", () => {
   });
 
   it("null でクリアできること", async () => {
-    mockPrisma.user.findFirst.mockResolvedValue({ id: "child-1" } as any);
-    mockPrisma.user.update.mockResolvedValue({} as any);
+    mockPrisma.user.findFirst.mockResolvedValue(childUser({ id: "child-1" }));
+    mockPrisma.user.update.mockResolvedValue(childUser({ id: "child-1", checkinDeadlineTime: null }));
 
     const res = await PATCH(
       makeRequest({ childId: "child-1", checkinDeadlineTime: null }),

--- a/src/__tests__/api/monster/monster-status.test.ts
+++ b/src/__tests__/api/monster/monster-status.test.ts
@@ -1,10 +1,15 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { GET } from "@/app/api/monster-status/route";
-import { prisma } from "@/lib/prisma";
 import { getCurrentUser } from "@/lib/auth";
-import { childUser, streak } from "../../helpers/fixtures";
+import { prismaMock as mockPrisma } from "../../helpers/prisma-mock";
+import {
+  childUserWithFamily,
+  streak,
+  questWithTemplate,
+  questInstance,
+  questDeclaration,
+} from "../../helpers/fixtures";
 
-const mockPrisma = vi.mocked(prisma);
 const mockGetCurrentUser = vi.mocked(getCurrentUser);
 
 beforeEach(() => {
@@ -20,13 +25,13 @@ describe("GET /api/monster-status", () => {
 
   it("モンスター情報とストリーク情報を1レスポンスで返すこと", async () => {
     mockGetCurrentUser.mockResolvedValue(
-      childUser({ evolutionStage: 2, studyPt: 10, staminaPt: 5, lifePt: 3, evolutionPath: "STUDY_STAMINA" }) as any,
+      childUserWithFamily({ evolutionStage: 2, studyPt: 10, staminaPt: 5, lifePt: 3, evolutionPath: "STUDY_STAMINA" }),
     );
     mockPrisma.questInstance.findMany
-      .mockResolvedValueOnce([] as any)       // pendingQuests
-      .mockResolvedValueOnce([] as any);      // monthlyQuests
+      .mockResolvedValueOnce([])       // pendingQuests
+      .mockResolvedValueOnce([]);      // monthlyQuests
     mockPrisma.streak.findUnique.mockResolvedValue(
-      streak({ currentStreak: 7, bestStreak: 15, lastAchievedDate: new Date("2026-03-13") }) as any,
+      streak({ currentStreak: 7, bestStreak: 15, lastAchievedDate: new Date("2026-03-13") }),
     );
 
     const res = await GET();
@@ -53,16 +58,29 @@ describe("GET /api/monster-status", () => {
 
   it("承認待ちクエストのpendingXPをカテゴリ別に集計すること", async () => {
     mockGetCurrentUser.mockResolvedValue(
-      childUser({ monsterName: "ピカ", studyPt: 5, staminaPt: 3, lifePt: 1 }) as any,
+      childUserWithFamily({ monsterName: "ピカ", studyPt: 5, staminaPt: 3, lifePt: 1 }),
     );
     mockPrisma.questInstance.findMany
       .mockResolvedValueOnce([
-        { deadlineBonusEarned: false, photoUrl: null, template: { photoBonus: false, category: "STUDY" } },    // +1
-        { deadlineBonusEarned: true, photoUrl: null, template: { photoBonus: false, category: "STUDY" } },     // +2
-        { deadlineBonusEarned: false, photoUrl: null, template: { photoBonus: false, category: "STAMINA" } },  // +1
-        { deadlineBonusEarned: false, photoUrl: "url", template: { photoBonus: true, category: "LIFE" } },     // +2
-      ] as any)
-      .mockResolvedValueOnce([] as any); // monthlyQuests
+        // snapshotCategory は未設定（旧データ状態を再現）: template.category へフォールバックさせる
+        questWithTemplate(
+          { id: "q1", deadlineBonusEarned: false, photoUrl: null, snapshotCategory: undefined },
+          { category: "STUDY", photoBonus: false },
+        ), // +1
+        questWithTemplate(
+          { id: "q2", deadlineBonusEarned: true, photoUrl: null, snapshotCategory: undefined },
+          { category: "STUDY", photoBonus: false },
+        ), // +2
+        questWithTemplate(
+          { id: "q3", deadlineBonusEarned: false, photoUrl: null, snapshotCategory: undefined },
+          { category: "STAMINA", photoBonus: false },
+        ), // +1
+        questWithTemplate(
+          { id: "q4", deadlineBonusEarned: false, photoUrl: "url", snapshotCategory: undefined },
+          { category: "LIFE", photoBonus: true },
+        ), // +2
+      ])
+      .mockResolvedValueOnce([]); // monthlyQuests
     mockPrisma.streak.findUnique.mockResolvedValue(null);
 
     const res = await GET();
@@ -75,23 +93,29 @@ describe("GET /api/monster-status", () => {
 
   it("「今日やる宣言」つきの REPORTED クエストは pendingXP に宣言ボーナスを含めること", async () => {
     // regression: 育成画面の「+ N (仮)」とクエスト画面のタイル個別 +xpXP が乖離していたバグ
-    mockGetCurrentUser.mockResolvedValue(childUser() as any);
+    mockGetCurrentUser.mockResolvedValue(childUserWithFamily());
     const reportedAt = new Date("2026-05-24T10:00:00+09:00"); // JST 2026-05-24
     mockPrisma.questInstance.findMany
       .mockResolvedValueOnce([
-        {
-          templateId: "t1",
-          reportedAt,
-          deadlineBonusEarned: true,
-          photoUrl: null,
-          snapshotCategory: null,
-          template: { photoBonus: false, category: "STUDY" },
-        },
-      ] as any)
-      .mockResolvedValueOnce([] as any);
+        questWithTemplate(
+          {
+            templateId: "t1",
+            reportedAt,
+            deadlineBonusEarned: true,
+            photoUrl: null,
+            // snapshotCategory は未設定（旧データ状態を再現）: template.category へフォールバックさせる。
+            // 実スキーマでは snapshotCategory は必須（非 null）だが、旧 `as any` テストが
+            // `null` を渡していたのは「フィールド欠落状態」を意図したもの。フィクスチャの
+            // Partial<QuestInstance> では undefined でこれを表現する。
+            snapshotCategory: undefined,
+          },
+          { photoBonus: false, category: "STUDY" },
+        ),
+      ])
+      .mockResolvedValueOnce([]);
     mockPrisma.questDeclaration.findMany.mockResolvedValue([
-      { templateId: "t1", date: new Date("2026-05-24T00:00:00Z") },
-    ] as any);
+      questDeclaration({ templateId: "t1", date: new Date("2026-05-24T00:00:00Z") }),
+    ]);
     mockPrisma.streak.findUnique.mockResolvedValue(null);
 
     const res = await GET();
@@ -101,14 +125,14 @@ describe("GET /api/monster-status", () => {
   });
 
   it("今月の達成日数を正しく返すこと", async () => {
-    mockGetCurrentUser.mockResolvedValue(childUser() as any);
+    mockGetCurrentUser.mockResolvedValue(childUserWithFamily());
     mockPrisma.questInstance.findMany
-      .mockResolvedValueOnce([] as any) // pendingQuests
+      .mockResolvedValueOnce([]) // pendingQuests
       .mockResolvedValueOnce([
-        { date: new Date("2026-03-01") },
-        { date: new Date("2026-03-05") },
-        { date: new Date("2026-03-10") },
-      ] as any);
+        questInstance({ date: new Date("2026-03-01") }),
+        questInstance({ date: new Date("2026-03-05") }),
+        questInstance({ date: new Date("2026-03-10") }),
+      ]);
     mockPrisma.streak.findUnique.mockResolvedValue(null);
 
     const res = await GET();
@@ -118,8 +142,8 @@ describe("GET /api/monster-status", () => {
   });
 
   it("ストリーク未作成の場合、デフォルト値を返すこと", async () => {
-    mockGetCurrentUser.mockResolvedValue(childUser() as any);
-    mockPrisma.questInstance.findMany.mockResolvedValue([] as any);
+    mockGetCurrentUser.mockResolvedValue(childUserWithFamily());
+    mockPrisma.questInstance.findMany.mockResolvedValue([]);
     mockPrisma.streak.findUnique.mockResolvedValue(null);
 
     const res = await GET();
@@ -133,8 +157,8 @@ describe("GET /api/monster-status", () => {
   });
 
   it("REPORTEDクエストのみpending集計に使用すること", async () => {
-    mockGetCurrentUser.mockResolvedValue(childUser() as any);
-    mockPrisma.questInstance.findMany.mockResolvedValue([] as any);
+    mockGetCurrentUser.mockResolvedValue(childUserWithFamily());
+    mockPrisma.questInstance.findMany.mockResolvedValue([]);
     mockPrisma.streak.findUnique.mockResolvedValue(null);
 
     await GET();

--- a/src/__tests__/api/monster/monster.test.ts
+++ b/src/__tests__/api/monster/monster.test.ts
@@ -1,10 +1,9 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { GET } from "@/app/api/monster/route";
-import { prisma } from "@/lib/prisma";
 import { getCurrentUser } from "@/lib/auth";
-import { childUser } from "../../helpers/fixtures";
+import { prismaMock as mockPrisma } from "../../helpers/prisma-mock";
+import { childUserWithFamily, questWithTemplate } from "../../helpers/fixtures";
 
-const mockPrisma = vi.mocked(prisma);
 const mockGetCurrentUser = vi.mocked(getCurrentUser);
 
 beforeEach(() => {
@@ -22,9 +21,9 @@ describe("GET /api/monster", () => {
 
   it("モンスター情報を正しく返すこと", async () => {
     mockGetCurrentUser.mockResolvedValue(
-      childUser({ evolutionStage: 1, studyPt: 10, staminaPt: 5, lifePt: 3, evolutionPath: "STUDY" }) as any,
+      childUserWithFamily({ evolutionStage: 1, studyPt: 10, staminaPt: 5, lifePt: 3, evolutionPath: "STUDY" }),
     );
-    mockPrisma.questInstance.findMany.mockResolvedValue([] as any);
+    mockPrisma.questInstance.findMany.mockResolvedValue([]);
 
     const res = await GET();
     const json = await res.json();
@@ -43,9 +42,9 @@ describe("GET /api/monster", () => {
 
   it("usedEggBonusesを正しく返すこと", async () => {
     mockGetCurrentUser.mockResolvedValue(
-      { ...childUser(), usedEggBonuses: '["STUDY","STAMINA"]' } as any,
+      childUserWithFamily({ usedEggBonuses: '["STUDY","STAMINA"]' }),
     );
-    mockPrisma.questInstance.findMany.mockResolvedValue([] as any);
+    mockPrisma.questInstance.findMany.mockResolvedValue([]);
 
     const res = await GET();
     const json = await res.json();
@@ -55,15 +54,28 @@ describe("GET /api/monster", () => {
 
   it("承認待ちクエストのpendingXPを正しく集計すること", async () => {
     mockGetCurrentUser.mockResolvedValue(
-      childUser({ monsterName: "ピカ", studyPt: 5, staminaPt: 3, lifePt: 1 }) as any,
+      childUserWithFamily({ monsterName: "ピカ", studyPt: 5, staminaPt: 3, lifePt: 1 }),
     );
 
     mockPrisma.questInstance.findMany.mockResolvedValue([
-      { deadlineBonusEarned: false, photoUrl: null, template: { photoBonus: false, category: "STUDY" } },    // +1
-      { deadlineBonusEarned: true, photoUrl: null, template: { photoBonus: false, category: "STUDY" } },     // +2
-      { deadlineBonusEarned: false, photoUrl: null, template: { photoBonus: false, category: "STAMINA" } },  // +1
-      { deadlineBonusEarned: false, photoUrl: "url", template: { photoBonus: true, category: "LIFE" } },     // +2
-    ] as any);
+      // snapshotCategory は未設定（旧データ状態を再現）: template.category へフォールバックさせる
+      questWithTemplate(
+        { id: "q1", deadlineBonusEarned: false, photoUrl: null, snapshotCategory: undefined },
+        { category: "STUDY", photoBonus: false },
+      ), // +1
+      questWithTemplate(
+        { id: "q2", deadlineBonusEarned: true, photoUrl: null, snapshotCategory: undefined },
+        { category: "STUDY", photoBonus: false },
+      ), // +2
+      questWithTemplate(
+        { id: "q3", deadlineBonusEarned: false, photoUrl: null, snapshotCategory: undefined },
+        { category: "STAMINA", photoBonus: false },
+      ), // +1
+      questWithTemplate(
+        { id: "q4", deadlineBonusEarned: false, photoUrl: "url", snapshotCategory: undefined },
+        { category: "LIFE", photoBonus: true },
+      ), // +2
+    ]);
 
     const res = await GET();
     const json = await res.json();
@@ -74,8 +86,8 @@ describe("GET /api/monster", () => {
   });
 
   it("monsterNameがnullの場合、nameにフォールバックすること", async () => {
-    mockGetCurrentUser.mockResolvedValue(childUser({ monsterName: null }) as any);
-    mockPrisma.questInstance.findMany.mockResolvedValue([] as any);
+    mockGetCurrentUser.mockResolvedValue(childUserWithFamily({ monsterName: null }));
+    mockPrisma.questInstance.findMany.mockResolvedValue([]);
 
     const res = await GET();
     const json = await res.json();
@@ -85,9 +97,9 @@ describe("GET /api/monster", () => {
 
   it("monsterNameもnameもnullの場合、デフォルト名を返すこと", async () => {
     mockGetCurrentUser.mockResolvedValue(
-      childUser({ monsterName: null, name: null }) as any,
+      childUserWithFamily({ monsterName: null, name: null }),
     );
-    mockPrisma.questInstance.findMany.mockResolvedValue([] as any);
+    mockPrisma.questInstance.findMany.mockResolvedValue([]);
 
     const res = await GET();
     const json = await res.json();
@@ -98,7 +110,7 @@ describe("GET /api/monster", () => {
 
   it("REPORTEDステータスのクエストのみ集計すること", async () => {
     mockGetCurrentUser.mockResolvedValue(
-      childUser({ monsterName: "テスト", side: "DARK" }) as any,
+      childUserWithFamily({ monsterName: "テスト", side: "DARK" }),
     );
 
     await GET();

--- a/src/__tests__/api/rebirth/rebirth.test.ts
+++ b/src/__tests__/api/rebirth/rebirth.test.ts
@@ -1,10 +1,10 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { POST } from "@/app/api/rebirth/route";
-import { prisma } from "@/lib/prisma";
 import { getCurrentUser } from "@/lib/auth";
 import { checkAndUnlockBadges } from "@/lib/badges";
 import { triggerBadgeLog } from "@/lib/bulletinLog";
-import { childUser, parentUser } from "../../helpers/fixtures";
+import { prismaMock as mockPrisma } from "../../helpers/prisma-mock";
+import { childUser, childUserWithFamily, parentUserWithFamily } from "../../helpers/fixtures";
 import { makeRequest } from "../../helpers/request";
 
 vi.mock("@/lib/badges", async () => {
@@ -23,7 +23,6 @@ vi.mock("@/lib/bulletinLog", async () => {
   };
 });
 
-const mockPrisma = vi.mocked(prisma);
 const mockGetCurrentUser = vi.mocked(getCurrentUser);
 const mockCheckAndUnlockBadges = vi.mocked(checkAndUnlockBadges);
 const mockTriggerBadgeLog = vi.mocked(triggerBadgeLog);
@@ -41,42 +40,36 @@ describe("POST /api/rebirth", () => {
   });
 
   it("PARENTロールでは403を返すこと", async () => {
-    mockGetCurrentUser.mockResolvedValue(parentUser() as any);
+    mockGetCurrentUser.mockResolvedValue(parentUserWithFamily());
     const req = makeRequest("/api/rebirth", { eggType: "STUDY" });
     const res = await POST(req);
     expect(res.status).toBe(403);
   });
 
   it("rebirthPendingがfalseの場合400を返すこと", async () => {
-    mockGetCurrentUser.mockResolvedValue(childUser() as any);
-    mockPrisma.user.findUnique.mockResolvedValue({
-      ...childUser(),
-      rebirthPending: false,
-    } as any);
+    mockGetCurrentUser.mockResolvedValue(childUserWithFamily());
+    mockPrisma.user.findUnique.mockResolvedValue(
+      childUser({ id: "child-1", rebirthPending: false }),
+    );
     const req = makeRequest("/api/rebirth", { eggType: "STUDY" });
     const res = await POST(req);
     expect(res.status).toBe(400);
   });
 
   it("無効なeggTypeの場合400を返すこと", async () => {
-    mockGetCurrentUser.mockResolvedValue(childUser() as any);
-    mockPrisma.user.findUnique.mockResolvedValue({
-      ...childUser(),
-      rebirthPending: true,
-    } as any);
+    mockGetCurrentUser.mockResolvedValue(childUserWithFamily());
+    mockPrisma.user.findUnique.mockResolvedValue(childUser({ id: "child-1", rebirthPending: true }));
     const req = makeRequest("/api/rebirth", { eggType: "INVALID" });
     const res = await POST(req);
     expect(res.status).toBe(400);
   });
 
   it("有効なeggType(STUDY)でrebirthを実行しstage/ptsをリセットすること", async () => {
-    mockGetCurrentUser.mockResolvedValue(childUser({ id: "child-1" }) as any);
-    mockPrisma.user.findUnique.mockResolvedValue({
-      ...childUser({ id: "child-1" }),
-      rebirthPending: true,
-      usedEggBonuses: "[]",
-    } as any);
-    mockPrisma.user.updateMany.mockResolvedValue({ count: 1 } as any);
+    mockGetCurrentUser.mockResolvedValue(childUserWithFamily({ id: "child-1" }));
+    mockPrisma.user.findUnique.mockResolvedValue(
+      childUser({ id: "child-1", rebirthPending: true, usedEggBonuses: "[]" }),
+    );
+    mockPrisma.user.updateMany.mockResolvedValue({ count: 1 });
 
     const req = makeRequest("/api/rebirth", { eggType: "STUDY" });
     const res = await POST(req);
@@ -100,13 +93,11 @@ describe("POST /api/rebirth", () => {
   });
 
   it("既にSTUDYを使用済みの場合、usedEggBonusesに重複追加しないこと", async () => {
-    mockGetCurrentUser.mockResolvedValue(childUser({ id: "child-1" }) as any);
-    mockPrisma.user.findUnique.mockResolvedValue({
-      ...childUser({ id: "child-1" }),
-      rebirthPending: true,
-      usedEggBonuses: '["STUDY"]',
-    } as any);
-    mockPrisma.user.updateMany.mockResolvedValue({ count: 1 } as any);
+    mockGetCurrentUser.mockResolvedValue(childUserWithFamily({ id: "child-1" }));
+    mockPrisma.user.findUnique.mockResolvedValue(
+      childUser({ id: "child-1", rebirthPending: true, usedEggBonuses: '["STUDY"]' }),
+    );
+    mockPrisma.user.updateMany.mockResolvedValue({ count: 1 });
 
     const req = makeRequest("/api/rebirth", { eggType: "STUDY" });
     const res = await POST(req);
@@ -120,13 +111,11 @@ describe("POST /api/rebirth", () => {
   });
 
   it("NORMALの場合、usedEggBonusesを変更しないこと", async () => {
-    mockGetCurrentUser.mockResolvedValue(childUser({ id: "child-1" }) as any);
-    mockPrisma.user.findUnique.mockResolvedValue({
-      ...childUser({ id: "child-1" }),
-      rebirthPending: true,
-      usedEggBonuses: '["STUDY"]',
-    } as any);
-    mockPrisma.user.updateMany.mockResolvedValue({ count: 1 } as any);
+    mockGetCurrentUser.mockResolvedValue(childUserWithFamily({ id: "child-1" }));
+    mockPrisma.user.findUnique.mockResolvedValue(
+      childUser({ id: "child-1", rebirthPending: true, usedEggBonuses: '["STUDY"]' }),
+    );
+    mockPrisma.user.updateMany.mockResolvedValue({ count: 1 });
 
     const req = makeRequest("/api/rebirth", { eggType: "NORMAL" });
     const res = await POST(req);
@@ -140,13 +129,11 @@ describe("POST /api/rebirth", () => {
   });
 
   it("有効なeggType(STAMINA)でrebirthを実行すること", async () => {
-    mockGetCurrentUser.mockResolvedValue(childUser({ id: "child-1" }) as any);
-    mockPrisma.user.findUnique.mockResolvedValue({
-      ...childUser({ id: "child-1" }),
-      rebirthPending: true,
-      usedEggBonuses: "[]",
-    } as any);
-    mockPrisma.user.updateMany.mockResolvedValue({ count: 1 } as any);
+    mockGetCurrentUser.mockResolvedValue(childUserWithFamily({ id: "child-1" }));
+    mockPrisma.user.findUnique.mockResolvedValue(
+      childUser({ id: "child-1", rebirthPending: true, usedEggBonuses: "[]" }),
+    );
+    mockPrisma.user.updateMany.mockResolvedValue({ count: 1 });
 
     const req = makeRequest("/api/rebirth", { eggType: "STAMINA" });
     const res = await POST(req);
@@ -160,13 +147,11 @@ describe("POST /api/rebirth", () => {
   });
 
   it("有効なeggType(LIFE)でrebirthを実行すること", async () => {
-    mockGetCurrentUser.mockResolvedValue(childUser({ id: "child-1" }) as any);
-    mockPrisma.user.findUnique.mockResolvedValue({
-      ...childUser({ id: "child-1" }),
-      rebirthPending: true,
-      usedEggBonuses: "[]",
-    } as any);
-    mockPrisma.user.updateMany.mockResolvedValue({ count: 1 } as any);
+    mockGetCurrentUser.mockResolvedValue(childUserWithFamily({ id: "child-1" }));
+    mockPrisma.user.findUnique.mockResolvedValue(
+      childUser({ id: "child-1", rebirthPending: true, usedEggBonuses: "[]" }),
+    );
+    mockPrisma.user.updateMany.mockResolvedValue({ count: 1 });
 
     const req = makeRequest("/api/rebirth", { eggType: "LIFE" });
     const res = await POST(req);
@@ -178,20 +163,18 @@ describe("POST /api/rebirth", () => {
       }),
     );
   });
-  
+
   it("有効なeggType(NORMAL)でrebirthを実行しrebirthEggBonusがnullになること", async () => {
-    mockGetCurrentUser.mockResolvedValue(childUser({ id: "child-1" }) as any);
-    mockPrisma.user.findUnique.mockResolvedValue({
-      ...childUser({ id: "child-1" }),
-      rebirthPending: true,
-      usedEggBonuses: "[]",
-    } as any);
-    mockPrisma.user.updateMany.mockResolvedValue({ count: 1 } as any);
-    
+    mockGetCurrentUser.mockResolvedValue(childUserWithFamily({ id: "child-1" }));
+    mockPrisma.user.findUnique.mockResolvedValue(
+      childUser({ id: "child-1", rebirthPending: true, usedEggBonuses: "[]" }),
+    );
+    mockPrisma.user.updateMany.mockResolvedValue({ count: 1 });
+
     const req = makeRequest("/api/rebirth", { eggType: "NORMAL" });
     const res = await POST(req);
     expect(res.status).toBe(200);
-    
+
     expect(mockPrisma.user.updateMany).toHaveBeenCalledWith(
       expect.objectContaining({
         data: expect.objectContaining({ rebirthEggBonus: null }),
@@ -200,14 +183,12 @@ describe("POST /api/rebirth", () => {
   });
 
   it("rebirthPending=trueで読み込んだ後、update時には他経路で既に転生済み(count=0)の場合は400を返すこと（TOCTOUレース）", async () => {
-    mockGetCurrentUser.mockResolvedValue(childUser({ id: "child-1" }) as any);
-    mockPrisma.user.findUnique.mockResolvedValue({
-      ...childUser({ id: "child-1" }),
-      rebirthPending: true,
-      usedEggBonuses: "[]",
-    } as any);
+    mockGetCurrentUser.mockResolvedValue(childUserWithFamily({ id: "child-1" }));
+    mockPrisma.user.findUnique.mockResolvedValue(
+      childUser({ id: "child-1", rebirthPending: true, usedEggBonuses: "[]" }),
+    );
     // updateMany が 0 件マッチ = 既に別経路（親代理 or 別端末）で転生済み
-    mockPrisma.user.updateMany.mockResolvedValue({ count: 0 } as any);
+    mockPrisma.user.updateMany.mockResolvedValue({ count: 0 });
 
     const req = makeRequest("/api/rebirth", { eggType: "STUDY" });
     const res = await POST(req);
@@ -215,13 +196,11 @@ describe("POST /api/rebirth", () => {
   });
 
   it("成功時に{ ok: true }を返すこと", async () => {
-    mockGetCurrentUser.mockResolvedValue(childUser({ id: "child-1" }) as any);
-    mockPrisma.user.findUnique.mockResolvedValue({
-      ...childUser({ id: "child-1" }),
-      rebirthPending: true,
-      usedEggBonuses: "[]",
-    } as any);
-    mockPrisma.user.updateMany.mockResolvedValue({ count: 1 } as any);
+    mockGetCurrentUser.mockResolvedValue(childUserWithFamily({ id: "child-1" }));
+    mockPrisma.user.findUnique.mockResolvedValue(
+      childUser({ id: "child-1", rebirthPending: true, usedEggBonuses: "[]" }),
+    );
+    mockPrisma.user.updateMany.mockResolvedValue({ count: 1 });
 
     const req = makeRequest("/api/rebirth", { eggType: "STUDY" });
     const res = await POST(req);
@@ -230,13 +209,11 @@ describe("POST /api/rebirth", () => {
   });
 
   it("転生成功時に checkAndUnlockBadges を呼ぶ（rebirth_egg_used 即時解錠）", async () => {
-    mockGetCurrentUser.mockResolvedValue(childUser({ id: "child-1" }) as any);
-    mockPrisma.user.findUnique.mockResolvedValue({
-      ...childUser({ id: "child-1" }),
-      rebirthPending: true,
-      usedEggBonuses: "[]",
-    } as any);
-    mockPrisma.user.updateMany.mockResolvedValue({ count: 1 } as any);
+    mockGetCurrentUser.mockResolvedValue(childUserWithFamily({ id: "child-1" }));
+    mockPrisma.user.findUnique.mockResolvedValue(
+      childUser({ id: "child-1", rebirthPending: true, usedEggBonuses: "[]" }),
+    );
+    mockPrisma.user.updateMany.mockResolvedValue({ count: 1 });
 
     const req = makeRequest("/api/rebirth", { eggType: "STUDY" });
     const res = await POST(req);
@@ -247,13 +224,11 @@ describe("POST /api/rebirth", () => {
   });
 
   it("新規解錠バッジを掲示板に流す（triggerBadgeLog 呼び出し）", async () => {
-    mockGetCurrentUser.mockResolvedValue(childUser({ id: "child-1" }) as any);
-    mockPrisma.user.findUnique.mockResolvedValue({
-      ...childUser({ id: "child-1" }),
-      rebirthPending: true,
-      usedEggBonuses: "[]",
-    } as any);
-    mockPrisma.user.updateMany.mockResolvedValue({ count: 1 } as any);
+    mockGetCurrentUser.mockResolvedValue(childUserWithFamily({ id: "child-1" }));
+    mockPrisma.user.findUnique.mockResolvedValue(
+      childUser({ id: "child-1", rebirthPending: true, usedEggBonuses: "[]" }),
+    );
+    mockPrisma.user.updateMany.mockResolvedValue({ count: 1 });
     mockCheckAndUnlockBadges.mockResolvedValue([
       { id: "rebirth_egg_used", name: "卵えらびマスター", emoji: "🥚", description: "..." },
     ]);

--- a/src/__tests__/api/users/me.test.ts
+++ b/src/__tests__/api/users/me.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { GET } from "@/app/api/users/me/route";
 import { getCurrentUser } from "@/lib/auth";
-import { childUser } from "../../helpers/fixtures";
+import { childUserWithFamily } from "../../helpers/fixtures";
 
 const mockGetCurrentUser = vi.mocked(getCurrentUser);
 
@@ -17,7 +17,7 @@ describe("GET /api/users/me", () => {
   });
 
   it("reportDeadlineTime が null のユーザーは null を返すこと", async () => {
-    mockGetCurrentUser.mockResolvedValue(childUser() as any);
+    mockGetCurrentUser.mockResolvedValue(childUserWithFamily());
     const res = await GET();
     const data = await res.json();
     expect(res.status).toBe(200);
@@ -26,7 +26,7 @@ describe("GET /api/users/me", () => {
 
   it("reportDeadlineTime が設定されていれば返すこと", async () => {
     mockGetCurrentUser.mockResolvedValue(
-      childUser({ reportDeadlineTime: "20:00" } as any) as any
+      childUserWithFamily({ reportDeadlineTime: "20:00" }),
     );
     const res = await GET();
     const data = await res.json();


### PR DESCRIPTION
## Summary
- `as any` 計120件と型エラー92件（`npm run typecheck`, prisma generate後）を全廃し、`prismaMock` を使った型付きモックに移行
- 転生ロジック: `rebirth.test.ts` の卵選択ボーナス・TOCTOUレース検証はロジック変更なし（code-reviewerが確認済み）
- `$transaction` 配列渡し: `members-id.test.ts` が実際の配列版 `$transaction` 実装を正しく経由してテストできていることを確認済み
- カバレッジの罠: `family/code.test.ts` のフォールバック分岐12箇所が旧テストのフィールド欠落で偶然カバーされていたが、`legacyMemberRow()` ヘルパーで旧データ欠落状態を明示的に再現し branch coverage を完全復元（92.85%で一致）
- テスト件数・`expect` 出現数は全ファイルで変化なし

## Test plan
- [x] `npm test` パス（183 files / 2512 tests all green）
- [x] `npm run typecheck`（prisma generate後）: 92件 → 0件

Closes #49

🤖 Generated with [Claude Code](https://claude.com/claude-code)
