### PR TITLE
test(misc): push/cron/auth/checkin/streak/nav系12ファイルのas anyを型付きモックに移行（移行Issue群完了）

### DIFF
--- a/src/__tests__/api/auth/child-rejoin.test.ts
+++ b/src/__tests__/api/auth/child-rejoin.test.ts
@@ -1,11 +1,9 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { POST } from "@/app/api/auth/child-rejoin/route";
-import { prisma } from "@/lib/prisma";
 import { makeRequest } from "../../helpers/request";
-import { family, childUser } from "../../helpers/fixtures";
+import { prismaMock as mockPrisma } from "../../helpers/prisma-mock";
+import { family, childUser, parentUser } from "../../helpers/fixtures";
 import { mockSupabaseUser } from "../../helpers/auth-mock";
-
-const mockPrisma = vi.mocked(prisma);
 
 const req = (body: Record<string, unknown>) => makeRequest("/api/auth/child-rejoin", body);
 
@@ -14,9 +12,11 @@ beforeEach(() => vi.clearAllMocks());
 describe("POST /api/auth/child-rejoin", () => {
   it("正しいコードの組み合わせで再参加できること", async () => {
     mockSupabaseUser({ id: "sup-new" }); // anonymous session (no email)
-    mockPrisma.family.findUnique.mockResolvedValue(family() as any);
-    mockPrisma.user.findUnique.mockResolvedValue(childUser({ monsterName: "ドラゴン", side: "DARK" }) as any);
-    mockPrisma.user.update.mockResolvedValue({} as any);
+    mockPrisma.family.findUnique.mockResolvedValue(family());
+    mockPrisma.user.findUnique.mockResolvedValue(
+      childUser({ monsterName: "ドラゴン", side: "DARK" }),
+    );
+    mockPrisma.user.update.mockResolvedValue(childUser({ supabaseId: "sup-new" }));
 
     const res = await POST(req({ familyCode: "ABC123", childCode: "1234" }));
     const json = await res.json();
@@ -59,7 +59,7 @@ describe("POST /api/auth/child-rejoin", () => {
 
   it("子どもコードが見つからない場合、404を返すこと", async () => {
     mockSupabaseUser({ id: "sup-new" });
-    mockPrisma.family.findUnique.mockResolvedValue(family() as any);
+    mockPrisma.family.findUnique.mockResolvedValue(family());
     mockPrisma.user.findUnique.mockResolvedValue(null);
     const res = await POST(req({ familyCode: "ABC123", childCode: "9999" }));
     expect(res.status).toBe(404);
@@ -67,17 +67,17 @@ describe("POST /api/auth/child-rejoin", () => {
 
   it("PARENTロールのユーザーでは再参加できないこと", async () => {
     mockSupabaseUser({ id: "sup-new" });
-    mockPrisma.family.findUnique.mockResolvedValue(family() as any);
-    mockPrisma.user.findUnique.mockResolvedValue({ id: "p-1", role: "PARENT" } as any);
+    mockPrisma.family.findUnique.mockResolvedValue(family());
+    mockPrisma.user.findUnique.mockResolvedValue(parentUser({ id: "p-1" }));
     const res = await POST(req({ familyCode: "ABC123", childCode: "1234" }));
     expect(res.status).toBe(404);
   });
 
   it("ファミリーコードを大文字変換して検索すること", async () => {
     mockSupabaseUser({ id: "sup-new" });
-    mockPrisma.family.findUnique.mockResolvedValue(family() as any);
-    mockPrisma.user.findUnique.mockResolvedValue(childUser() as any);
-    mockPrisma.user.update.mockResolvedValue({} as any);
+    mockPrisma.family.findUnique.mockResolvedValue(family());
+    mockPrisma.user.findUnique.mockResolvedValue(childUser());
+    mockPrisma.user.update.mockResolvedValue(childUser({ supabaseId: "sup-new" }));
 
     await POST(req({ familyCode: "abc123", childCode: "5678" }));
     expect(mockPrisma.family.findUnique).toHaveBeenCalledWith({ where: { code: "ABC123" } });
@@ -85,9 +85,11 @@ describe("POST /api/auth/child-rejoin", () => {
 
   it("detachはCHILDロールのみ対象にし、PARENTのsupabaseIdを奪わないこと", async () => {
     mockSupabaseUser({ id: "sup-new" });
-    mockPrisma.family.findUnique.mockResolvedValue(family() as any);
-    mockPrisma.user.findUnique.mockResolvedValue(childUser({ monsterName: "ドラゴン", side: "DARK" }) as any);
-    mockPrisma.user.update.mockResolvedValue({} as any);
+    mockPrisma.family.findUnique.mockResolvedValue(family());
+    mockPrisma.user.findUnique.mockResolvedValue(
+      childUser({ monsterName: "ドラゴン", side: "DARK" }),
+    );
+    mockPrisma.user.update.mockResolvedValue(childUser({ supabaseId: "sup-new" }));
 
     await POST(req({ familyCode: "ABC123", childCode: "1234" }));
 

--- a/src/__tests__/api/auth/register.test.ts
+++ b/src/__tests__/api/auth/register.test.ts
@@ -1,11 +1,9 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { POST } from "@/app/api/auth/register/route";
-import { prisma } from "@/lib/prisma";
 import { makeRequest } from "../../helpers/request";
 import { mockSupabaseUser } from "../../helpers/auth-mock";
-import { family } from "../../helpers/fixtures";
-
-const mockPrisma = vi.mocked(prisma);
+import { prismaMock as mockPrisma } from "../../helpers/prisma-mock";
+import { family, parentUser } from "../../helpers/fixtures";
 
 const req = (body: Record<string, unknown>) => makeRequest("/api/auth/register", body);
 
@@ -14,7 +12,7 @@ beforeEach(() => vi.clearAllMocks());
 describe("POST /api/auth/register", () => {
   it("supabaseId がリクエストに含まれる場合、それを使用すること", async () => {
     mockPrisma.user.findUnique.mockResolvedValue(null);
-    mockPrisma.family.create.mockResolvedValue(family({ code: "TEST12" }) as any);
+    mockPrisma.family.create.mockResolvedValue(family({ code: "TEST12" }));
 
     const res = await POST(req({ email: "test@example.com", supabaseId: "sup-1" }));
     const json = await res.json();
@@ -26,7 +24,7 @@ describe("POST /api/auth/register", () => {
   it("supabaseId がない場合、Supabase からセッション取得すること", async () => {
     mockSupabaseUser({ id: "sup-session" });
     mockPrisma.user.findUnique.mockResolvedValue(null);
-    mockPrisma.family.create.mockResolvedValue(family({ id: "fam-2", code: "CODE22" }) as any);
+    mockPrisma.family.create.mockResolvedValue(family({ id: "fam-2", code: "CODE22" }));
 
     const res = await POST(req({ email: "test@test.com" }));
     expect((await res.json()).familyId).toBe("fam-2");
@@ -39,7 +37,7 @@ describe("POST /api/auth/register", () => {
   });
 
   it("既存ユーザーの場合、既存のfamilyIdを返すこと", async () => {
-    mockPrisma.user.findUnique.mockResolvedValue({ familyId: "fam-existing" } as any);
+    mockPrisma.user.findUnique.mockResolvedValue(parentUser({ familyId: "fam-existing" }));
 
     const res = await POST(req({ email: "test@test.com", supabaseId: "sup-exist" }));
     expect((await res.json()).familyId).toBe("fam-existing");
@@ -48,7 +46,7 @@ describe("POST /api/auth/register", () => {
 
   it("emailからname抽出してPARENTユーザーを作成すること", async () => {
     mockPrisma.user.findUnique.mockResolvedValue(null);
-    mockPrisma.family.create.mockResolvedValue(family() as any);
+    mockPrisma.family.create.mockResolvedValue(family());
 
     await POST(req({ email: "papa@gmail.com", supabaseId: "sup-papa" }));
 
@@ -65,7 +63,7 @@ describe("POST /api/auth/register", () => {
 
   it("emailがない場合、nameを 'parent' にフォールバックすること", async () => {
     mockPrisma.user.findUnique.mockResolvedValue(null);
-    mockPrisma.family.create.mockResolvedValue(family() as any);
+    mockPrisma.family.create.mockResolvedValue(family());
 
     await POST(req({ supabaseId: "sup-noemail" }));
 

--- a/src/__tests__/api/checkin/calendar.test.ts
+++ b/src/__tests__/api/checkin/calendar.test.ts
@@ -1,10 +1,9 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { prisma } from "@/lib/prisma";
 import { getCurrentUser } from "@/lib/auth";
 import { GET } from "@/app/api/checkin/calendar/route";
-import { childUser, parentUser, streak } from "../../helpers/fixtures";
+import { prismaMock as mockPrisma } from "../../helpers/prisma-mock";
+import { childUserWithFamily, parentUserWithFamily, streak, checkinLog } from "../../helpers/fixtures";
 
-const mockPrisma = vi.mocked(prisma);
 const mockGetCurrentUser = vi.mocked(getCurrentUser);
 
 function makeRequest(url: string): Request {
@@ -30,13 +29,13 @@ describe("GET /api/checkin/calendar", () => {
   });
 
   it("親ユーザーは 403", async () => {
-    mockGetCurrentUser.mockResolvedValue(parentUser() as any);
+    mockGetCurrentUser.mockResolvedValue(parentUserWithFamily());
     const res = await GET(makeRequest("http://localhost/api/checkin/calendar"));
     expect(res.status).toBe(403);
   });
 
   it("days が範囲外は 400", async () => {
-    mockGetCurrentUser.mockResolvedValue(childUser() as any);
+    mockGetCurrentUser.mockResolvedValue(childUserWithFamily());
     const res = await GET(makeRequest("http://localhost/api/checkin/calendar?days=0"));
     expect(res.status).toBe(400);
 
@@ -48,16 +47,16 @@ describe("GET /api/checkin/calendar", () => {
   });
 
   it("直近 7 日のログ + enabledSince + ストリークを返す", async () => {
-    mockGetCurrentUser.mockResolvedValue(childUser({ checkinDeadlineTime: "16:00" }) as any);
+    mockGetCurrentUser.mockResolvedValue(childUserWithFamily({ checkinDeadlineTime: "16:00" }));
     mockPrisma.checkinLog.findMany.mockResolvedValue([
-      { date: new Date("2026-06-23T00:00:00Z"), success: true },
-      { date: new Date("2026-06-24T00:00:00Z"), success: false },
-    ] as any);
-    mockPrisma.checkinLog.findFirst.mockResolvedValue({
-      date: new Date("2026-06-22T00:00:00Z"),
-    } as any);
+      checkinLog({ date: new Date("2026-06-23T00:00:00Z"), success: true }),
+      checkinLog({ date: new Date("2026-06-24T00:00:00Z"), success: false }),
+    ]);
+    mockPrisma.checkinLog.findFirst.mockResolvedValue(
+      checkinLog({ date: new Date("2026-06-22T00:00:00Z") }),
+    );
     mockPrisma.streak.findUnique.mockResolvedValue(
-      streak({ checkinCurrentStreak: 5, checkinBestStreak: 12 }) as any,
+      streak({ checkinCurrentStreak: 5, checkinBestStreak: 12 }),
     );
 
     const res = await GET(makeRequest("http://localhost/api/checkin/calendar"));
@@ -77,7 +76,7 @@ describe("GET /api/checkin/calendar", () => {
   });
 
   it("checkinDeadlineTime が未設定なら enabled=false で空", async () => {
-    mockGetCurrentUser.mockResolvedValue(childUser({ checkinDeadlineTime: null }) as any);
+    mockGetCurrentUser.mockResolvedValue(childUserWithFamily({ checkinDeadlineTime: null }));
 
     const res = await GET(makeRequest("http://localhost/api/checkin/calendar"));
     const json = await res.json();
@@ -89,10 +88,10 @@ describe("GET /api/checkin/calendar", () => {
   });
 
   it("CheckinLog が 1 件もなければ enabledSince=今日（過去全部を空表示に）", async () => {
-    mockGetCurrentUser.mockResolvedValue(childUser({ checkinDeadlineTime: "16:00" }) as any);
-    mockPrisma.checkinLog.findMany.mockResolvedValue([] as any);
+    mockGetCurrentUser.mockResolvedValue(childUserWithFamily({ checkinDeadlineTime: "16:00" }));
+    mockPrisma.checkinLog.findMany.mockResolvedValue([]);
     mockPrisma.checkinLog.findFirst.mockResolvedValue(null);
-    mockPrisma.streak.findUnique.mockResolvedValue(streak() as any);
+    mockPrisma.streak.findUnique.mockResolvedValue(streak());
 
     const res = await GET(makeRequest("http://localhost/api/checkin/calendar"));
     const json = await res.json();
@@ -102,10 +101,10 @@ describe("GET /api/checkin/calendar", () => {
   });
 
   it("直近 days 日（既定 7）の範囲のみクエリすること", async () => {
-    mockGetCurrentUser.mockResolvedValue(childUser({ checkinDeadlineTime: "16:00" }) as any);
-    mockPrisma.checkinLog.findMany.mockResolvedValue([] as any);
+    mockGetCurrentUser.mockResolvedValue(childUserWithFamily({ checkinDeadlineTime: "16:00" }));
+    mockPrisma.checkinLog.findMany.mockResolvedValue([]);
     mockPrisma.checkinLog.findFirst.mockResolvedValue(null);
-    mockPrisma.streak.findUnique.mockResolvedValue(streak() as any);
+    mockPrisma.streak.findUnique.mockResolvedValue(streak());
 
     await GET(makeRequest("http://localhost/api/checkin/calendar"));
 

--- a/src/__tests__/api/checkin/today.test.ts
+++ b/src/__tests__/api/checkin/today.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 import { getCurrentUser } from "@/lib/auth";
 import { recordCheckin } from "@/lib/checkin";
 import { POST } from "@/app/api/checkin/today/route";
-import { childUser, parentUser } from "../../helpers/fixtures";
+import { childUserWithFamily, parentUserWithFamily } from "../../helpers/fixtures";
 
 vi.mock("@/lib/checkin", () => ({
   recordCheckin: vi.fn(),
@@ -23,13 +23,13 @@ describe("POST /api/checkin/today", () => {
   });
 
   it("親ユーザーは 403", async () => {
-    mockGetCurrentUser.mockResolvedValue(parentUser() as any);
+    mockGetCurrentUser.mockResolvedValue(parentUserWithFamily());
     const res = await POST();
     expect(res.status).toBe(403);
   });
 
   it("子供のチェックインで recordCheckin の結果をそのまま返す", async () => {
-    mockGetCurrentUser.mockResolvedValue(childUser() as any);
+    mockGetCurrentUser.mockResolvedValue(childUserWithFamily());
     mockRecordCheckin.mockResolvedValue({
       enabled: true,
       deadline: "16:00",

--- a/src/__tests__/api/cron/auto-approve.test.ts
+++ b/src/__tests__/api/cron/auto-approve.test.ts
@@ -1,6 +1,8 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { Prisma } from "@/generated/prisma/client";
 import { GET } from "@/app/api/cron/auto-approve/route";
-import { prisma } from "@/lib/prisma";
+import { prismaMock as mockPrisma } from "../../helpers/prisma-mock";
+import { questInstance } from "../../helpers/fixtures";
 
 vi.mock("@/lib/approve", () => ({
   approveQuestInstance: vi.fn().mockResolvedValue(undefined),
@@ -14,10 +16,76 @@ vi.mock("@/lib/treasureService", () => ({
 import { approveQuestInstance, approveSkipQuestInstance } from "@/lib/approve";
 import { generateProxyTreasure } from "@/lib/treasureService";
 
-const mockPrisma = vi.mocked(prisma);
 const mockApproveQuest = vi.mocked(approveQuestInstance);
 const mockApproveSkip = vi.mocked(approveSkipQuestInstance);
 const mockGenerateAuto = vi.mocked(generateProxyTreasure);
+
+/**
+ * route.ts の findMany が使う include（template/child とも select 付き）に合わせた型。
+ * approveQuestInstance の引数型 `QuestWithRelations`（@/lib/approve）と一致する形状。
+ */
+type PendingQuest = Prisma.QuestInstanceGetPayload<{
+  include: {
+    template: {
+      select: {
+        id: true;
+        category: true;
+        createdBy: true;
+        isTemporary: true;
+        photoBonus: true;
+        repeatDays: true;
+        carryOver: true;
+      };
+    };
+    child: {
+      select: {
+        id: true;
+        evolutionStage: true;
+        evolutionPath: true;
+        collectedPaths: true;
+        studyPt: true;
+        staminaPt: true;
+        lifePt: true;
+      };
+    };
+  };
+}>;
+
+function pendingQuest(overrides: {
+  id: string;
+  status: "REPORTED" | "SKIP_REPORTED";
+  date: Date;
+  childId: string;
+  templateId: string;
+}): PendingQuest {
+  return {
+    ...questInstance({
+      id: overrides.id,
+      status: overrides.status,
+      date: overrides.date,
+      childId: overrides.childId,
+      templateId: overrides.templateId,
+    }),
+    template: {
+      id: overrides.templateId,
+      category: "STUDY",
+      createdBy: "PARENT",
+      isTemporary: false,
+      photoBonus: false,
+      repeatDays: [1, 2, 3, 4, 5],
+      carryOver: false,
+    },
+    child: {
+      id: overrides.childId,
+      evolutionStage: 0,
+      evolutionPath: "",
+      collectedPaths: "[]",
+      studyPt: 0,
+      staminaPt: 0,
+      lifePt: 0,
+    },
+  };
+}
 
 function makeRequest(secret?: string) {
   const headers: Record<string, string> = {};
@@ -48,12 +116,12 @@ describe("GET /api/cron/auto-approve", () => {
 
   it("前日以前のREPORTEDクエストを自動承認すること", async () => {
     const yesterday = new Date("2026-03-21");
-    const reportedQuests = [
-      { id: "q-1", status: "REPORTED", date: yesterday, childId: "c1", templateId: "t1", template: {}, child: {} },
-      { id: "q-2", status: "REPORTED", date: yesterday, childId: "c2", templateId: "t2", template: {}, child: {} },
+    const reportedQuests: PendingQuest[] = [
+      pendingQuest({ id: "q-1", status: "REPORTED", date: yesterday, childId: "c1", templateId: "t1" }),
+      pendingQuest({ id: "q-2", status: "REPORTED", date: yesterday, childId: "c2", templateId: "t2" }),
     ];
 
-    mockPrisma.questInstance.findMany.mockResolvedValue(reportedQuests as any);
+    mockPrisma.questInstance.findMany.mockResolvedValue(reportedQuests);
 
     const res = await GET(makeRequest("test-secret"));
     const body = await res.json();
@@ -67,11 +135,11 @@ describe("GET /api/cron/auto-approve", () => {
 
   it("前日以前のSKIP_REPORTEDクエストを自動承認すること", async () => {
     const yesterday = new Date("2026-03-21");
-    const quests = [
-      { id: "q-3", status: "SKIP_REPORTED", date: yesterday, childId: "c1", templateId: "t1", template: {}, child: {} },
+    const quests: PendingQuest[] = [
+      pendingQuest({ id: "q-3", status: "SKIP_REPORTED", date: yesterday, childId: "c1", templateId: "t1" }),
     ];
 
-    mockPrisma.questInstance.findMany.mockResolvedValue(quests as any);
+    mockPrisma.questInstance.findMany.mockResolvedValue(quests);
 
     const res = await GET(makeRequest("test-secret"));
     const body = await res.json();
@@ -84,12 +152,12 @@ describe("GET /api/cron/auto-approve", () => {
 
   it("REPORTEDとSKIP_REPORTEDが混在する場合、それぞれ正しく処理すること", async () => {
     const yesterday = new Date("2026-03-21");
-    const quests = [
-      { id: "q-1", status: "REPORTED", date: yesterday, childId: "c1", templateId: "t1", template: {}, child: {} },
-      { id: "q-2", status: "SKIP_REPORTED", date: yesterday, childId: "c1", templateId: "t2", template: {}, child: {} },
+    const quests: PendingQuest[] = [
+      pendingQuest({ id: "q-1", status: "REPORTED", date: yesterday, childId: "c1", templateId: "t1" }),
+      pendingQuest({ id: "q-2", status: "SKIP_REPORTED", date: yesterday, childId: "c1", templateId: "t2" }),
     ];
 
-    mockPrisma.questInstance.findMany.mockResolvedValue(quests as any);
+    mockPrisma.questInstance.findMany.mockResolvedValue(quests);
 
     const res = await GET(makeRequest("test-secret"));
     const body = await res.json();
@@ -117,7 +185,11 @@ describe("GET /api/cron/auto-approve", () => {
     await GET(makeRequest("test-secret"));
 
     const call = mockPrisma.questInstance.findMany.mock.calls[0][0];
-    expect(call?.include?.template?.select?.repeatDays).toBe(true);
+    const templateInclude = call?.include?.template;
+    // include.template は `true | TaskTemplateArgs` の union 型になるため、
+    // select 付きの object 形であることを確認してから絞り込む。
+    const templateSelect = typeof templateInclude === "object" ? templateInclude?.select : undefined;
+    expect(templateSelect?.repeatDays).toBe(true);
   });
 
   describe("宝箱（PROXY）は生成しない", () => {
@@ -128,13 +200,13 @@ describe("GET /api/cron/auto-approve", () => {
     it("REPORTED が複数あっても generateProxyTreasure は一度も呼ばれない", async () => {
       const d1 = new Date("2026-03-21");
       const d2 = new Date("2026-03-22");
-      const quests = [
-        { id: "q-1", status: "REPORTED", date: d1, childId: "c1", templateId: "t1", template: {}, child: { id: "c1", minTasksForStreak: 1 } },
-        { id: "q-2", status: "REPORTED", date: d1, childId: "c1", templateId: "t2", template: {}, child: { id: "c1", minTasksForStreak: 1 } },
-        { id: "q-3", status: "REPORTED", date: d2, childId: "c1", templateId: "t1", template: {}, child: { id: "c1", minTasksForStreak: 1 } },
-        { id: "q-4", status: "REPORTED", date: d1, childId: "c2", templateId: "t1", template: {}, child: { id: "c2", minTasksForStreak: 2 } },
+      const quests: PendingQuest[] = [
+        pendingQuest({ id: "q-1", status: "REPORTED", date: d1, childId: "c1", templateId: "t1" }),
+        pendingQuest({ id: "q-2", status: "REPORTED", date: d1, childId: "c1", templateId: "t2" }),
+        pendingQuest({ id: "q-3", status: "REPORTED", date: d2, childId: "c1", templateId: "t1" }),
+        pendingQuest({ id: "q-4", status: "REPORTED", date: d1, childId: "c2", templateId: "t1" }),
       ];
-      mockPrisma.questInstance.findMany.mockResolvedValueOnce(quests as any);
+      mockPrisma.questInstance.findMany.mockResolvedValueOnce(quests);
 
       await GET(makeRequest("test-secret"));
 
@@ -143,10 +215,10 @@ describe("GET /api/cron/auto-approve", () => {
 
     it("SKIP_REPORTED でも generateProxyTreasure は呼ばれない", async () => {
       const d1 = new Date("2026-03-21");
-      const quests = [
-        { id: "q-s1", status: "SKIP_REPORTED", date: d1, childId: "c1", templateId: "t1", template: {}, child: { id: "c1", minTasksForStreak: 1 } },
+      const quests: PendingQuest[] = [
+        pendingQuest({ id: "q-s1", status: "SKIP_REPORTED", date: d1, childId: "c1", templateId: "t1" }),
       ];
-      mockPrisma.questInstance.findMany.mockResolvedValueOnce(quests as any);
+      mockPrisma.questInstance.findMany.mockResolvedValueOnce(quests);
 
       await GET(makeRequest("test-secret"));
 
@@ -162,8 +234,8 @@ describe("GET /api/cron/auto-approve", () => {
     it("レスポンスに autoTreasures フィールドを含めない（廃止）", async () => {
       const yesterday = new Date("2026-03-21");
       mockPrisma.questInstance.findMany.mockResolvedValueOnce([
-        { id: "q-1", status: "REPORTED", date: yesterday, childId: "c1", templateId: "t1", template: {}, child: { id: "c1", minTasksForStreak: 1 } },
-      ] as any);
+        pendingQuest({ id: "q-1", status: "REPORTED", date: yesterday, childId: "c1", templateId: "t1" }),
+      ]);
 
       const res = await GET(makeRequest("test-secret"));
       const body = await res.json();

--- a/src/__tests__/api/cron/quest-time-notify.test.ts
+++ b/src/__tests__/api/cron/quest-time-notify.test.ts
@@ -1,10 +1,22 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { GET } from "@/app/api/cron/quest-time-notify/route";
-import { prisma } from "@/lib/prisma";
 import { sendPushToChild } from "@/lib/push";
+import type { Prisma } from "@/generated/prisma/client";
+import { prismaMock as mockPrisma } from "../../helpers/prisma-mock";
+import { childUser, questInstance } from "../../helpers/fixtures";
 
-const mockPrisma = vi.mocked(prisma);
 const mockSendPush = vi.mocked(sendPushToChild);
+
+/**
+ * `mockImplementation` の戻り値は実際の Prisma メソッドと同じ `PrismaPromise<T>` 型が
+ * 要求されるが、`vitest-mock-extended` の DeepMockProxy はジェネリックオーバーロードを
+ * 保持しないためテストコード側では通常の `Promise` しか作れない。
+ * `PrismaPromise` は実行時には通常の thenable として振る舞うため、型だけ合わせる
+ * （`src/__tests__/lib/quests.test.ts` と同じパターン）。
+ */
+function asPrismaPromise<T>(value: T): Prisma.PrismaPromise<T> {
+  return Promise.resolve(value) as unknown as Prisma.PrismaPromise<T>;
+}
 
 function makeRequest(secret?: string) {
   const headers: Record<string, string> = {};
@@ -55,14 +67,12 @@ describe("GET /api/cron/quest-time-notify", () => {
   });
 
   it("PENDING/REJECTED が残っている子供に Push を送ること", async () => {
-    mockPrisma.user.findMany.mockResolvedValue([
-      { id: "child-1" },
-    ] as any);
+    mockPrisma.user.findMany.mockResolvedValue([childUser({ id: "child-1" })]);
     mockPrisma.questInstance.findMany.mockResolvedValue([
-      { status: "PENDING" },
-      { status: "PENDING" },
-      { status: "APPROVED" }, // 進捗 1/3
-    ] as any);
+      questInstance({ status: "PENDING" }),
+      questInstance({ status: "PENDING" }),
+      questInstance({ status: "APPROVED" }), // 進捗 1/3
+    ]);
 
     const res = await GET(makeRequest("test-secret"));
     const body = await res.json();
@@ -82,14 +92,12 @@ describe("GET /api/cron/quest-time-notify", () => {
   });
 
   it("全クエスト完了済み(100%)の子供には Push を送らずスキップ件数を増やすこと", async () => {
-    mockPrisma.user.findMany.mockResolvedValue([
-      { id: "child-1" },
-    ] as any);
+    mockPrisma.user.findMany.mockResolvedValue([childUser({ id: "child-1" })]);
     mockPrisma.questInstance.findMany.mockResolvedValue([
-      { status: "APPROVED" },
-      { status: "APPROVED" },
-      { status: "SKIPPED" },
-    ] as any);
+      questInstance({ status: "APPROVED" }),
+      questInstance({ status: "APPROVED" }),
+      questInstance({ status: "SKIPPED" }),
+    ]);
 
     const res = await GET(makeRequest("test-secret"));
     const body = await res.json();
@@ -101,10 +109,8 @@ describe("GET /api/cron/quest-time-notify", () => {
   });
 
   it("今日のクエストが0件の子供には Push を送らずスキップすること", async () => {
-    mockPrisma.user.findMany.mockResolvedValue([
-      { id: "child-1" },
-    ] as any);
-    mockPrisma.questInstance.findMany.mockResolvedValue([] as any);
+    mockPrisma.user.findMany.mockResolvedValue([childUser({ id: "child-1" })]);
+    mockPrisma.questInstance.findMany.mockResolvedValue([]);
 
     const res = await GET(makeRequest("test-secret"));
     const body = await res.json();
@@ -116,28 +122,26 @@ describe("GET /api/cron/quest-time-notify", () => {
 
   it("複数の子供がそれぞれ独立して判定されること", async () => {
     mockPrisma.user.findMany.mockResolvedValue([
-      { id: "child-1" },
-      { id: "child-2" },
-      { id: "child-3" },
-    ] as any);
-    mockPrisma.questInstance.findMany.mockImplementation(((args: any) => {
+      childUser({ id: "child-1" }),
+      childUser({ id: "child-2" }),
+      childUser({ id: "child-3" }),
+    ]);
+    mockPrisma.questInstance.findMany.mockImplementation((args?: Prisma.QuestInstanceFindManyArgs) => {
       const childId = args?.where?.childId;
       if (childId === "child-1") {
         // 進捗 0/2 → 送信
-        return Promise.resolve([
-          { status: "PENDING" },
-          { status: "PENDING" },
-        ] as any);
+        return asPrismaPromise([
+          questInstance({ status: "PENDING" }),
+          questInstance({ status: "PENDING" }),
+        ]);
       }
       if (childId === "child-2") {
         // 100% 完了 → スキップ
-        return Promise.resolve([
-          { status: "APPROVED" },
-        ] as any);
+        return asPrismaPromise([questInstance({ status: "APPROVED" })]);
       }
       // child-3: クエスト0件 → スキップ
-      return Promise.resolve([] as any);
-    }) as any);
+      return asPrismaPromise([]);
+    });
 
     const res = await GET(makeRequest("test-secret"));
     const body = await res.json();

--- a/src/__tests__/api/middleware.test.ts
+++ b/src/__tests__/api/middleware.test.ts
@@ -18,11 +18,14 @@ function makeRequest(pathname: string): NextRequest {
 function mockSupabaseAuth(
   user: { id: string; email?: string; is_anonymous?: boolean } | null
 ) {
+  // updateSession は supabase クライアントの `auth.getUser()` しか呼ばないため、
+  // テスト用モックは SupabaseClient のごく一部（auth.getUser）のみを実装する。
+  // 完全な SupabaseClient 型を満たせないため `as unknown as ReturnType<...>` で明示する。
   mockCreateServerClient.mockReturnValue({
     auth: {
       getUser: vi.fn().mockResolvedValue({ data: { user } }),
     },
-  } as any);
+  } as unknown as ReturnType<typeof createServerClient>);
 }
 
 const parentUser = { id: "parent-1", email: "parent@example.com", is_anonymous: false };

--- a/src/__tests__/api/nav/pending-counts.test.ts
+++ b/src/__tests__/api/nav/pending-counts.test.ts
@@ -1,10 +1,9 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { GET } from "@/app/api/nav/pending-counts/route";
-import { prisma } from "@/lib/prisma";
 import { getCurrentUser } from "@/lib/auth";
-import { parentUser, childUser } from "../../helpers/fixtures";
+import { prismaMock as mockPrisma } from "../../helpers/prisma-mock";
+import { parentUserWithFamily, childUserWithFamily } from "../../helpers/fixtures";
 
-const mockPrisma = vi.mocked(prisma);
 const mockGetCurrentUser = vi.mocked(getCurrentUser);
 
 beforeEach(() => {
@@ -19,19 +18,19 @@ describe("GET /api/nav/pending-counts", () => {
   });
 
   it("CHILDロールの場合、両方0を返すこと", async () => {
-    mockGetCurrentUser.mockResolvedValue(childUser() as any);
+    mockGetCurrentUser.mockResolvedValue(childUserWithFamily());
     const res = await GET();
     expect(await res.json()).toEqual({ approvals: 0, tasks: 0 });
   });
 
   it("familyIdがない場合、両方0を返すこと", async () => {
-    mockGetCurrentUser.mockResolvedValue(parentUser({ familyId: null }) as any);
+    mockGetCurrentUser.mockResolvedValue(parentUserWithFamily({ familyId: null }, null));
     const res = await GET();
     expect(await res.json()).toEqual({ approvals: 0, tasks: 0 });
   });
 
   it("承認待ちとタスク申請中の件数を返すこと", async () => {
-    mockGetCurrentUser.mockResolvedValue(parentUser() as any);
+    mockGetCurrentUser.mockResolvedValue(parentUserWithFamily());
     mockPrisma.questInstance.count.mockResolvedValue(3);
     mockPrisma.taskTemplate.count.mockResolvedValue(2);
 
@@ -56,7 +55,7 @@ describe("GET /api/nav/pending-counts", () => {
   });
 
   it("両方0件の場合、0を返すこと", async () => {
-    mockGetCurrentUser.mockResolvedValue(parentUser() as any);
+    mockGetCurrentUser.mockResolvedValue(parentUserWithFamily());
     mockPrisma.questInstance.count.mockResolvedValue(0);
     mockPrisma.taskTemplate.count.mockResolvedValue(0);
 

--- a/src/__tests__/api/push/notify-child.test.ts
+++ b/src/__tests__/api/push/notify-child.test.ts
@@ -1,21 +1,31 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { POST } from "@/app/api/push/notify-child/route";
-import { prisma } from "@/lib/prisma";
 import { getCurrentUser } from "@/lib/auth";
+import type { Prisma, TaskTemplate } from "@/generated/prisma/client";
 import { makeRequest } from "../../helpers/request";
-import { parentUser, childUser, taskTemplate } from "../../helpers/fixtures";
+import { prismaMock as mockPrisma } from "../../helpers/prisma-mock";
+import {
+  parentUserWithFamily,
+  childUser,
+  childUserWithFamily,
+  taskTemplate,
+  questInstance,
+} from "../../helpers/fixtures";
 
 vi.mock("@/lib/push", () => ({
   sendPushToChild: vi.fn().mockResolvedValue(undefined),
 }));
 
-const mockPrisma = vi.mocked(prisma);
 const mockGetCurrentUser = vi.mocked(getCurrentUser);
 
+type QuestWithTemplateTitle = Prisma.QuestInstanceGetPayload<{
+  include: { template: { select: { title: true } } };
+}>;
+
 /** 共通のテンプレート & upsertモック設定 */
-function mockQuestGeneration(templates: any[] = []) {
+function mockQuestGeneration(templates: TaskTemplate[] = []) {
   mockPrisma.taskTemplate.findMany.mockResolvedValue(templates);
-  mockPrisma.questInstance.upsert.mockResolvedValue({} as any);
+  mockPrisma.questInstance.upsert.mockResolvedValue(questInstance());
 }
 
 beforeEach(() => {
@@ -32,33 +42,42 @@ describe("POST /api/push/notify-child", () => {
   });
 
   it("CHILDロールの場合、403を返すこと", async () => {
-    mockGetCurrentUser.mockResolvedValue(childUser() as any);
+    mockGetCurrentUser.mockResolvedValue(childUserWithFamily());
     const res = await POST(makeRequest("/api/push/notify-child", { childId: "child-1" }));
     expect(res.status).toBe(403);
   });
 
   it("childIdが未指定の場合、400を返すこと", async () => {
-    mockGetCurrentUser.mockResolvedValue(parentUser() as any);
+    mockGetCurrentUser.mockResolvedValue(parentUserWithFamily());
     const res = await POST(makeRequest("/api/push/notify-child", {}));
     expect(res.status).toBe(400);
   });
 
   it("対象の子供が同じファミリーでない場合、403を返すこと", async () => {
-    mockGetCurrentUser.mockResolvedValue(parentUser() as any);
+    mockGetCurrentUser.mockResolvedValue(parentUserWithFamily());
     mockPrisma.user.findFirst.mockResolvedValue(null);
     const res = await POST(makeRequest("/api/push/notify-child", { childId: "child-other" }));
     expect(res.status).toBe(403);
   });
 
   it("taskIdなしの場合、未完了タスク一覧を通知すること", async () => {
-    const parent = parentUser();
+    const parent = parentUserWithFamily();
     const child = childUser();
-    mockGetCurrentUser.mockResolvedValue(parent as any);
-    mockPrisma.user.findFirst.mockResolvedValue(child as any);
-    mockPrisma.questInstance.findMany.mockResolvedValue([
-      { id: "q-1", template: { title: "宿題" } },
-      { id: "q-2", template: { title: "運動" } },
-    ] as any);
+    mockGetCurrentUser.mockResolvedValue(parent);
+    mockPrisma.user.findFirst.mockResolvedValue(child);
+    const quests: QuestWithTemplateTitle[] = [
+      // snapshotTitle 未設定（= 旧データ）を再現し `?? q.template.title` の
+      // フォールバック分岐を通す（taskId 指定時のテストと同じ理由）。
+      {
+        ...questInstance({ id: "q-1", templateId: "tpl-1", snapshotTitle: undefined }),
+        template: { title: "宿題" },
+      },
+      {
+        ...questInstance({ id: "q-2", templateId: "tpl-2", snapshotTitle: "運動" }),
+        template: { title: "運動" },
+      },
+    ];
+    mockPrisma.questInstance.findMany.mockResolvedValue(quests);
 
     const { sendPushToChild } = await import("@/lib/push");
 
@@ -78,15 +97,19 @@ describe("POST /api/push/notify-child", () => {
   });
 
   it("taskId指定の場合、そのタスク名で通知すること", async () => {
-    const parent = parentUser();
+    const parent = parentUserWithFamily();
     const child = childUser();
     const tpl = taskTemplate({ title: "漢字練習" });
-    mockGetCurrentUser.mockResolvedValue(parent as any);
-    mockPrisma.user.findFirst.mockResolvedValue(child as any);
-    mockPrisma.questInstance.findFirst.mockResolvedValue({
-      id: "q-1",
+    mockGetCurrentUser.mockResolvedValue(parent);
+    mockPrisma.user.findFirst.mockResolvedValue(child);
+    const quest: QuestWithTemplateTitle = {
+      // snapshotTitle 未設定（= 旧データ）を再現し `?? quest.template.title` の
+      // フォールバック分岐を通す。schema 上は必須の String だが overrides は
+      // Partial のため undefined を明示的に指定できる。
+      ...questInstance({ id: "q-1", snapshotTitle: undefined }),
       template: { title: "漢字練習" },
-    } as any);
+    };
+    mockPrisma.questInstance.findFirst.mockResolvedValue(quest);
 
     const { sendPushToChild } = await import("@/lib/push");
 
@@ -107,10 +130,10 @@ describe("POST /api/push/notify-child", () => {
   });
 
   it("未完了タスクが0件の場合、400を返すこと", async () => {
-    const parent = parentUser();
+    const parent = parentUserWithFamily();
     const child = childUser();
-    mockGetCurrentUser.mockResolvedValue(parent as any);
-    mockPrisma.user.findFirst.mockResolvedValue(child as any);
+    mockGetCurrentUser.mockResolvedValue(parent);
+    mockPrisma.user.findFirst.mockResolvedValue(child);
     mockPrisma.questInstance.findMany.mockResolvedValue([]);
 
     const res = await POST(makeRequest("/api/push/notify-child", { childId: "child-1" }));
@@ -118,27 +141,34 @@ describe("POST /api/push/notify-child", () => {
   });
 
   it("子供がアプリ未起動でもQuestInstanceを生成してリマインドを送ること", async () => {
-    const parent = parentUser();
+    const parent = parentUserWithFamily();
     const child = childUser();
     const tpl1 = taskTemplate({ id: "tpl-1", title: "宿題" });
     const tpl2 = taskTemplate({ id: "tpl-2", title: "運動" });
-    mockGetCurrentUser.mockResolvedValue(parent as any);
-    mockPrisma.user.findFirst.mockResolvedValue(child as any);
-    
+    mockGetCurrentUser.mockResolvedValue(parent);
+    mockPrisma.user.findFirst.mockResolvedValue(child);
+
     // テンプレートが存在 -> upsert でQuestInstanceが生成される
-    mockQuestGeneration([tpl1, tpl2] as any);
-    
+    mockQuestGeneration([tpl1, tpl2]);
+
     // upsert後のfindManyで生成済みQuestInstanceが返る
-    mockPrisma.questInstance.findMany.mockResolvedValue([
-      { id: "q-1", template: { title: "宿題" } },
-      { id: "q-2", template: { title: "運動" } },
-    ] as any);
-    
+    const quests: QuestWithTemplateTitle[] = [
+      {
+        ...questInstance({ id: "q-1", templateId: "tpl-1", snapshotTitle: "宿題" }),
+        template: { title: "宿題" },
+      },
+      {
+        ...questInstance({ id: "q-2", templateId: "tpl-2", snapshotTitle: "運動" }),
+        template: { title: "運動" },
+      },
+    ];
+    mockPrisma.questInstance.findMany.mockResolvedValue(quests);
+
     const { sendPushToChild } = await import("@/lib/push");
-    
+
     const res = await POST(makeRequest("/api/push/notify-child", { childId: "child-1" }));
     expect(res.status).toBe(200);
-    
+
     // 2テンプレート分のupsertが呼ばれること
     expect(mockPrisma.questInstance.upsert).toHaveBeenCalledTimes(2);
     expect(mockPrisma.questInstance.upsert).toHaveBeenCalledWith(
@@ -147,7 +177,7 @@ describe("POST /api/push/notify-child", () => {
         create: expect.objectContaining({ templateId: "tpl-1", childId: "child-1" }),
       })
     );
-    
+
     expect(sendPushToChild).toHaveBeenCalledWith(
       "child-1",
       expect.objectContaining({
@@ -157,19 +187,19 @@ describe("POST /api/push/notify-child", () => {
   });
 
   it("テンプレートがあっても全タスク完了済みなら400を返すこと", async () => {
-    const parent = parentUser();
+    const parent = parentUserWithFamily();
     const child = childUser();
     const tpl = taskTemplate({ id: "tpl-1" });
-    mockGetCurrentUser.mockResolvedValue(parent as any);
-    mockPrisma.user.findFirst.mockResolvedValue(child as any);
-    
+    mockGetCurrentUser.mockResolvedValue(parent);
+    mockPrisma.user.findFirst.mockResolvedValue(child);
+
     // テンプレートは存在するがupsert後のfindManyは0件(すべてAPPROVED済み等）
-    mockQuestGeneration([tpl] as any);
+    mockQuestGeneration([tpl]);
     mockPrisma.questInstance.findMany.mockResolvedValue([]);
-    
+
     const res = await POST(makeRequest("/api/push/notify-child", { childId: "child-1" }));
     expect(res.status).toBe(400);
     const json = await res.json();
     expect(json.error).toBe("未完了のクエストがありません");
-  }); 
+  });
 });

--- a/src/__tests__/api/push/subscribe.test.ts
+++ b/src/__tests__/api/push/subscribe.test.ts
@@ -1,11 +1,10 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { POST } from "@/app/api/push/subscribe/route";
-import { prisma } from "@/lib/prisma";
 import { getCurrentUser } from "@/lib/auth";
 import { makeRequest } from "../../helpers/request";
-import { parentUser, childUser } from "../../helpers/fixtures";
+import { prismaMock as mockPrisma } from "../../helpers/prisma-mock";
+import { parentUserWithFamily, childUserWithFamily, pushSubscription } from "../../helpers/fixtures";
 
-const mockPrisma = vi.mocked(prisma);
 const mockGetCurrentUser = vi.mocked(getCurrentUser);
 
 const subBody = {
@@ -25,8 +24,8 @@ describe("POST /api/push/subscribe", () => {
   });
 
   it("PARENTが購読登録できること", async () => {
-    mockGetCurrentUser.mockResolvedValue(parentUser() as any);
-    mockPrisma.pushSubscription.upsert.mockResolvedValue({} as any);
+    mockGetCurrentUser.mockResolvedValue(parentUserWithFamily());
+    mockPrisma.pushSubscription.upsert.mockResolvedValue(pushSubscription({ userId: "parent-1" }));
 
     const res = await POST(makeRequest("/api/push/subscribe", subBody));
     const json = await res.json();
@@ -50,8 +49,8 @@ describe("POST /api/push/subscribe", () => {
   });
 
   it("CHILDも購読登録できること", async () => {
-    mockGetCurrentUser.mockResolvedValue(childUser() as any);
-    mockPrisma.pushSubscription.upsert.mockResolvedValue({} as any);
+    mockGetCurrentUser.mockResolvedValue(childUserWithFamily());
+    mockPrisma.pushSubscription.upsert.mockResolvedValue(pushSubscription({ userId: "child-1" }));
 
     const res = await POST(makeRequest("/api/push/subscribe", subBody));
     const json = await res.json();

--- a/src/__tests__/api/streak.test.ts
+++ b/src/__tests__/api/streak.test.ts
@@ -1,10 +1,9 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { prisma } from "@/lib/prisma";
 import { getCurrentUser } from "@/lib/auth";
 import { GET } from "@/app/api/streak/route";
-import { childUser, streak } from "../helpers/fixtures";
+import { prismaMock as mockPrisma } from "../helpers/prisma-mock";
+import { childUserWithFamily, streak, questInstance } from "../helpers/fixtures";
 
-const mockPrisma = vi.mocked(prisma);
 const mockGetCurrentUser = vi.mocked(getCurrentUser);
 
 beforeEach(() => {
@@ -20,7 +19,7 @@ describe("GET /api/streak", () => {
   });
 
   it("ストリーク未作成の場合、デフォルト値を返すこと", async () => {
-    mockGetCurrentUser.mockResolvedValue(childUser() as any);
+    mockGetCurrentUser.mockResolvedValue(childUserWithFamily());
     mockPrisma.streak.findUnique.mockResolvedValue(null);
     mockPrisma.questInstance.findMany.mockResolvedValue([]);
 
@@ -35,19 +34,19 @@ describe("GET /api/streak", () => {
   });
 
   it("ストリーク情報を正しく返すこと", async () => {
-    mockGetCurrentUser.mockResolvedValue(childUser() as any);
+    mockGetCurrentUser.mockResolvedValue(childUserWithFamily());
     mockPrisma.streak.findUnique.mockResolvedValue(
       streak({
         currentStreak: 7,
         bestStreak: 15,
         lastAchievedDate: new Date("2026-03-13"),
-      }) as any
+      })
     );
     mockPrisma.questInstance.findMany.mockResolvedValue([
-      { date: new Date("2026-03-01") },
-      { date: new Date("2026-03-05") },
-      { date: new Date("2026-03-10") },
-    ] as any);
+      questInstance({ id: "q-1", date: new Date("2026-03-01") }),
+      questInstance({ id: "q-2", date: new Date("2026-03-05") }),
+      questInstance({ id: "q-3", date: new Date("2026-03-10") }),
+    ]);
 
     const res = await GET();
     const json = await res.json();

--- a/src/__tests__/api/streak/login-check.test.ts
+++ b/src/__tests__/api/streak/login-check.test.ts
@@ -1,10 +1,10 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { prisma } from "@/lib/prisma";
 import { getCurrentUser } from "@/lib/auth";
 import { checkAndUnlockBadges } from "@/lib/badges";
 import { triggerBadgeLog } from "@/lib/bulletinLog";
 import { POST } from "@/app/api/streak/login-check/route";
-import { childUser, streak, parentUser } from "../../helpers/fixtures";
+import { prismaMock as mockPrisma } from "../../helpers/prisma-mock";
+import { childUser, childUserWithFamily, streak, parentUserWithFamily } from "../../helpers/fixtures";
 
 vi.mock("@/lib/badges", () => ({
   checkAndUnlockBadges: vi.fn().mockResolvedValue([]),
@@ -14,7 +14,6 @@ vi.mock("@/lib/bulletinLog", () => ({
   triggerBadgeLog: vi.fn().mockResolvedValue(undefined),
 }));
 
-const mockPrisma = vi.mocked(prisma);
 const mockGetCurrentUser = vi.mocked(getCurrentUser);
 const mockCheckAndUnlockBadges = vi.mocked(checkAndUnlockBadges);
 const mockTriggerBadgeLog = vi.mocked(triggerBadgeLog);
@@ -32,18 +31,18 @@ describe("POST /api/streak/login-check", () => {
   });
 
   it("親ユーザーの場合、403を返すこと", async () => {
-    mockGetCurrentUser.mockResolvedValue(parentUser() as any);
+    mockGetCurrentUser.mockResolvedValue(parentUserWithFamily());
 
     const res = await POST();
     expect(res.status).toBe(403);
   });
 
   it("初回ログインで loginStreak=1 を返すこと", async () => {
-    mockGetCurrentUser.mockResolvedValue(childUser() as any);
+    mockGetCurrentUser.mockResolvedValue(childUserWithFamily());
     mockPrisma.streak.upsert.mockResolvedValue(
-      streak({ loginCurrentStreak: 0, loginBestStreak: 0, lastLoginDate: null }) as any,
+      streak({ loginCurrentStreak: 0, loginBestStreak: 0, lastLoginDate: null }),
     );
-    mockPrisma.streak.update.mockResolvedValue({} as any);
+    mockPrisma.streak.update.mockResolvedValue(streak());
 
     const res = await POST();
     const json = await res.json();
@@ -54,21 +53,21 @@ describe("POST /api/streak/login-check", () => {
   });
 
   it("10日目にボーナスが付与されること", async () => {
-    mockGetCurrentUser.mockResolvedValue(childUser() as any);
+    mockGetCurrentUser.mockResolvedValue(childUserWithFamily());
     // recordLoginActivity と同じ JST ベースで yesterday を計算（タイムゾーン境界バグ防止）
     const jstNow = new Date(Date.now() + 9 * 60 * 60 * 1000);
     const todayNorm = new Date(Date.UTC(jstNow.getUTCFullYear(), jstNow.getUTCMonth(), jstNow.getUTCDate()));
     const yesterday = new Date(todayNorm);
     yesterday.setDate(yesterday.getDate() - 1);
     mockPrisma.streak.upsert.mockResolvedValue(
-      streak({ loginCurrentStreak: 9, loginBestStreak: 9, lastLoginDate: yesterday }) as any,
+      streak({ loginCurrentStreak: 9, loginBestStreak: 9, lastLoginDate: yesterday }),
     );
-    mockPrisma.streak.update.mockResolvedValue({} as any);
+    mockPrisma.streak.update.mockResolvedValue(streak());
     mockPrisma.user.findUnique.mockResolvedValue(
       // stage 1 を使い進化が発動しない範囲に設定
-      childUser({ evolutionStage: 1, evolutionPath: "STUDY", studyPt: 2, staminaPt: 2, lifePt: 2 }) as any,
+      childUser({ evolutionStage: 1, evolutionPath: "STUDY", studyPt: 2, staminaPt: 2, lifePt: 2 }),
     );
-    mockPrisma.user.update.mockResolvedValue({} as any);
+    mockPrisma.user.update.mockResolvedValue(childUser());
 
     const res = await POST();
     const json = await res.json();
@@ -79,11 +78,11 @@ describe("POST /api/streak/login-check", () => {
   });
 
   it("ログインで新規解除されたバッジを掲示板に流すこと（triggerBadgeLog 呼び出し）", async () => {
-    mockGetCurrentUser.mockResolvedValue(childUser() as any);
+    mockGetCurrentUser.mockResolvedValue(childUserWithFamily());
     mockPrisma.streak.upsert.mockResolvedValue(
-      streak({ loginCurrentStreak: 0, loginBestStreak: 0, lastLoginDate: null }) as any,
+      streak({ loginCurrentStreak: 0, loginBestStreak: 0, lastLoginDate: null }),
     );
-    mockPrisma.streak.update.mockResolvedValue({} as any);
+    mockPrisma.streak.update.mockResolvedValue(streak());
     mockCheckAndUnlockBadges.mockResolvedValue([
       { id: "login_14", name: "2週間ログイン", emoji: "🌿", description: "ログインストリーク14日" },
     ]);


### PR DESCRIPTION
## Summary
- `as any` 計95件を全廃し、push/cron/auth/checkin/streak/nav系12ファイルを `prismaMock` に移行（`fixtures.ts` は無変更）
- Cron secret認証・`$transaction` 配列渡し・pushグローバルモック前提が壊れていないことを code-reviewer が確認済み
- `notify-child.test.ts` でカバレッジの罠2箇所に対処（`snapshotTitle` 旧データフォールバック分岐、`overrides` で明示的 `undefined` 指定して復元）
- テスト件数変化なし、`expect` 出現数は全ファイルで変化なし
- 本PRで Issue #23 の子Issue群（#34〜#50）が全て完了。残るのは最終掃討Issue #51のみ

## Test plan
- [x] `npm test` パス（183 test files / 2512 tests、変化なし）
- [x] `npm run typecheck`（prisma generate後、対象12ファイルのエラー0件）
- [x] code-reviewer によるレビュー APPROVED（Cron secret認証・$transaction配列渡し・pushグローバルモック前提を検証済み）

Closes #50

🤖 Generated with [Claude Code](https://claude.com/claude-code)
