### PR TITLE
test(final): integration/components残りのas anyを排除しIssue #23を完了

### DIFF
--- a/src/__tests__/api/gathering/stamp.test.ts
+++ b/src/__tests__/api/gathering/stamp.test.ts
@@ -2,10 +2,10 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 import { POST } from "@/app/api/gathering/stamp/route";
 import { GET as GET_TODAY } from "@/app/api/gathering/stamp/today/route";
 import { prisma } from "@/lib/prisma";
+import type { Prisma } from "@/generated/prisma/client";
 import { getCurrentUser } from "@/lib/auth";
 import { sendPushToChild } from "@/lib/push";
 import { triggerStampSentLog } from "@/lib/bulletinLog";
-import { makeRequest } from "../../helpers/request";
 import { childUser, parentUser } from "../../helpers/fixtures";
 
 vi.mock("@/lib/bulletinLog", () => ({
@@ -24,20 +24,20 @@ beforeEach(() => {
 describe("POST /api/gathering/stamp", () => {
   it("未認証は401", async () => {
     mockGetCurrentUser.mockResolvedValue(null);
-    const res = await POST(makeRequest("/api/gathering/stamp", {}));
+    const res = await POST();
     expect(res.status).toBe(401);
   });
 
   it("PARENTは401（子供専用）", async () => {
     mockGetCurrentUser.mockResolvedValue(parentUser() as never);
-    const res = await POST(makeRequest("/api/gathering/stamp", {}));
+    const res = await POST();
     expect(res.status).toBe(401);
   });
 
   it("グループ未参加は404", async () => {
     mockGetCurrentUser.mockResolvedValue(childUser() as never);
     vi.mocked(prisma.gatheringMember.findUnique).mockResolvedValue(null);
-    const res = await POST(makeRequest("/api/gathering/stamp", {}));
+    const res = await POST();
     expect(res.status).toBe(404);
   });
 
@@ -48,7 +48,7 @@ describe("POST /api/gathering/stamp", () => {
       group: { members: [] },
     } as never);
     vi.mocked(prisma.stamp.findUnique).mockResolvedValue({ id: "s-1" } as never);
-    const res = await POST(makeRequest("/api/gathering/stamp", {}));
+    const res = await POST();
     expect(res.status).toBe(409);
     const data = await res.json();
     expect(data.error).toContain("今日");
@@ -71,7 +71,7 @@ describe("POST /api/gathering/stamp", () => {
     // 並行実行のため mockResolvedValueOnce では順序保証できないので一律 0 を返す
     vi.mocked(prisma.questInstance.count).mockResolvedValue(0);
 
-    const res = await POST(makeRequest("/api/gathering/stamp", {}));
+    const res = await POST();
     expect(res.status).toBe(200);
 
     // Stamp 作成
@@ -103,7 +103,7 @@ describe("POST /api/gathering/stamp", () => {
       .mockResolvedValueOnce(3) // total
       .mockResolvedValueOnce(1); // done → IN_PROGRESS
 
-    await POST(makeRequest("/api/gathering/stamp", {}));
+    await POST();
 
     const payload = mockSendPush.mock.calls[0][1];
     // 送信者の monsterName を優先
@@ -127,19 +127,24 @@ describe("POST /api/gathering/stamp", () => {
     vi.mocked(prisma.stamp.findUnique).mockResolvedValue(null);
     vi.mocked(prisma.stamp.create).mockResolvedValue({ id: "s-1" } as never);
     // 各 childId ごとに total/done を返す
-    vi.mocked(prisma.questInstance.count).mockImplementation((args: never) => {
-      const a = args as { where: { childId: string; status?: unknown } };
-      const isDoneCount = !!a.where.status;
-      if (a.where.childId === "child-2") {
-        return Promise.resolve(isDoneCount ? 3 : 3) as never; // DONE
+    vi.mocked(prisma.questInstance.count).mockImplementation((args) => {
+      const where = args?.where as { childId?: string; status?: unknown } | undefined;
+      const isDoneCount = !!where?.status;
+      let result: number;
+      if (where?.childId === "child-2") {
+        result = isDoneCount ? 3 : 3; // DONE
+      } else if (where?.childId === "child-3") {
+        result = isDoneCount ? 1 : 3; // IN_PROGRESS
+      } else {
+        result = 0;
       }
-      if (a.where.childId === "child-3") {
-        return Promise.resolve(isDoneCount ? 1 : 3) as never; // IN_PROGRESS
-      }
-      return Promise.resolve(0) as never;
+      // Prisma.PrismaPromise は `[Symbol.toStringTag]` プロパティを要求し、
+      // 通常の Promise では構造的に代入できない。テストのモック実装として
+      // ランタイムの挙動には影響しないため `as unknown as` で表現する。
+      return Promise.resolve(result) as unknown as Prisma.PrismaPromise<number>;
     });
 
-    const res = await POST(makeRequest("/api/gathering/stamp", {}));
+    const res = await POST();
     expect(res.status).toBe(200);
 
     const pushedIds = mockSendPush.mock.calls.map((c) => c[0]);
@@ -161,7 +166,7 @@ describe("POST /api/gathering/stamp", () => {
       .mockResolvedValueOnce(3)
       .mockResolvedValueOnce(0);
 
-    await POST(makeRequest("/api/gathering/stamp", {}));
+    await POST();
     expect(mockSendPush).toHaveBeenCalledTimes(1);
     expect(mockSendPush.mock.calls[0][0]).toBe("child-2");
   });
@@ -178,7 +183,7 @@ describe("POST /api/gathering/stamp", () => {
       Object.assign(new Error("Unique constraint failed"), { code: "P2002" }),
     );
 
-    const res = await POST(makeRequest("/api/gathering/stamp", {}));
+    const res = await POST();
     expect(res.status).toBe(409);
   });
 
@@ -192,7 +197,7 @@ describe("POST /api/gathering/stamp", () => {
     vi.mocked(prisma.stamp.create).mockResolvedValue({ id: "s-1" } as never);
     vi.mocked(prisma.questInstance.count).mockResolvedValue(0);
 
-    const res = await POST(makeRequest("/api/gathering/stamp", {}));
+    const res = await POST();
     expect(res.status).toBe(200);
 
     expect(mockTriggerStampSentLog).toHaveBeenCalledTimes(1);
@@ -210,7 +215,7 @@ describe("POST /api/gathering/stamp", () => {
       Object.assign(new Error("Unique constraint failed"), { code: "P2002" }),
     );
 
-    await POST(makeRequest("/api/gathering/stamp", {}));
+    await POST();
     expect(mockTriggerStampSentLog).not.toHaveBeenCalled();
   });
 
@@ -222,7 +227,7 @@ describe("POST /api/gathering/stamp", () => {
     } as never);
     vi.mocked(prisma.stamp.findUnique).mockResolvedValue({ id: "s-1" } as never);
 
-    await POST(makeRequest("/api/gathering/stamp", {}));
+    await POST();
     expect(mockTriggerStampSentLog).not.toHaveBeenCalled();
   });
 });

--- a/src/__tests__/components/parent-child-view-collection-page.test.tsx
+++ b/src/__tests__/components/parent-child-view-collection-page.test.tsx
@@ -65,14 +65,14 @@ describe("/app/parent/child-view/[childId]/collection", () => {
     });
 
     await waitFor(() => {
-      const monsterCall = fetchSpy.mock.calls.find((c: any[]) =>
+      const monsterCall = fetchSpy.mock.calls.find((c: unknown[]) =>
         typeof c[0] === "string" && c[0].includes("/parent/child-view/monster?childId=child-1"),
       );
       expect(monsterCall).toBeTruthy();
     });
 
     // 子画面用 API を絶対に呼ばないこと（親モードで子供セッションを混在させない）
-    const childMonsterCall = fetchSpy.mock.calls.find((c: any[]) =>
+    const childMonsterCall = fetchSpy.mock.calls.find((c: unknown[]) =>
       typeof c[0] === "string" && /^\/api\/monster\b/.test(c[0]),
     );
     expect(childMonsterCall).toBeFalsy();
@@ -103,14 +103,14 @@ describe("/app/parent/child-view/[childId]/collection", () => {
     });
 
     await waitFor(() => {
-      const badgesCall = fetchSpy.mock.calls.find((c: any[]) =>
+      const badgesCall = fetchSpy.mock.calls.find((c: unknown[]) =>
         typeof c[0] === "string" && c[0].includes("/parent/child-view/badges?childId=child-1"),
       );
       expect(badgesCall).toBeTruthy();
     });
 
     // 子画面用 API を絶対に呼ばないこと
-    const childBadgesCall = fetchSpy.mock.calls.find((c: any[]) =>
+    const childBadgesCall = fetchSpy.mock.calls.find((c: unknown[]) =>
       typeof c[0] === "string" && /^\/api\/badges(\?|$)/.test(c[0]),
     );
     expect(childBadgesCall).toBeFalsy();

--- a/src/__tests__/components/parent-child-view-treasures-page.test.tsx
+++ b/src/__tests__/components/parent-child-view-treasures-page.test.tsx
@@ -19,6 +19,9 @@ vi.mock("next/navigation", () => ({
 
 import ParentChildViewTreasuresPage from "@/app/app/parent/child-view/[childId]/treasures/page";
 
+/** global.fetch モックへの呼び出し引数のうちテストで参照する形 */
+type FetchCall = [url: string, init?: RequestInit];
+
 const fetchSpy = vi.fn();
 
 beforeEach(() => {
@@ -104,12 +107,12 @@ describe("/app/parent/child-view/[childId]/treasures", () => {
     });
 
     await waitFor(() => {
-      const openCall = fetchSpy.mock.calls.find((c: any[]) =>
+      const openCall = fetchSpy.mock.calls.find((c: unknown[]) =>
         typeof c[0] === "string" && c[0].includes("/treasures/open"),
-      );
+      ) as FetchCall | undefined;
       expect(openCall).toBeTruthy();
-      expect(openCall![1].method).toBe("POST");
-      const body = JSON.parse(openCall![1].body as string);
+      expect(openCall![1]!.method).toBe("POST");
+      const body = JSON.parse(openCall![1]!.body as string);
       expect(body.childId).toBe("child-1");
     });
   });

--- a/src/__tests__/helpers/auth-mock.ts
+++ b/src/__tests__/helpers/auth-mock.ts
@@ -3,16 +3,27 @@
  */
 import { vi } from "vitest";
 import { createClient } from "@/lib/supabase/server";
+import type { SupabaseClient } from "@supabase/supabase-js";
 
 const mockCreateClient = vi.mocked(createClient);
 
+/**
+ * `SupabaseClient` は多数のプロパティ（`auth`/`storage`/`realtime` 等）を持つ大きな型で、
+ * テストで使うのは `auth` の一部メソッドのみ。完全なモックを作るコストに見合わないため、
+ * 呼び出し側が必要とする部分だけを持つオブジェクトを `as unknown as SupabaseClient` で
+ * 表現する（実行時の挙動は変えない、型のみのキャスト）。
+ */
+function asSupabaseClient(auth: Record<string, unknown>): SupabaseClient {
+  return { auth } as unknown as SupabaseClient;
+}
+
 /** supabase.auth.getUser() が返すユーザーをモックする */
 export function mockSupabaseUser(user: { id: string; email?: string } | null) {
-  mockCreateClient.mockResolvedValue({
-    auth: {
+  mockCreateClient.mockResolvedValue(
+    asSupabaseClient({
       getUser: vi.fn().mockResolvedValue({ data: { user } }),
-    },
-  } as any);
+    }),
+  );
 }
 
 /** 匿名サインイン付きの Supabase モック（child-join 用） */
@@ -20,16 +31,16 @@ export function mockSupabaseWithAnonymous(
   existingUser: { id: string } | null,
   anonymousResult: { id: string } | null,
 ) {
-  mockCreateClient.mockResolvedValue({
-    auth: {
+  mockCreateClient.mockResolvedValue(
+    asSupabaseClient({
       getUser: vi.fn().mockResolvedValue({ data: { user: existingUser } }),
       signInAnonymously: vi.fn().mockResolvedValue(
         anonymousResult
           ? { data: { user: anonymousResult }, error: null }
           : { data: { user: null }, error: { message: "failed" } },
       ),
-    },
-  } as any);
+    }),
+  );
 }
 
 /** パスワード認証の Supabase モック（login 用） */
@@ -37,12 +48,12 @@ export function mockSupabaseSignIn(
   result: { user: Record<string, unknown> } | null,
   error: { message: string } | null = null,
 ) {
-  mockCreateClient.mockResolvedValue({
-    auth: {
+  mockCreateClient.mockResolvedValue(
+    asSupabaseClient({
       signInWithPassword: vi.fn().mockResolvedValue({
         data: result ?? { user: null },
         error,
       }),
-    },
-  } as any);
+    }),
+  );
 }

--- a/src/__tests__/integration/approve-guard.test.ts
+++ b/src/__tests__/integration/approve-guard.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, beforeAll, afterAll } from "vitest";
 import { POST as approveQuest } from "@/app/api/approve/[id]/route";
+import type { Family, TaskTemplate, User } from "@/generated/prisma/client";
 import {
     prisma,
     mockAsUser,
@@ -12,10 +13,10 @@ import {
 } from "./helpers";
 
 describe("承認ガード（不正ステータス遷移の防止）", () => {
-    let family: any;
-    let parent: any;
-    let child: any;
-    let task: any;
+    let family: Family;
+    let parent: User;
+    let child: User;
+    let task: TaskTemplate;
 
     beforeAll(async () => {
         await cleanAll();
@@ -33,7 +34,7 @@ describe("承認ガード（不正ステータス遷移の防止）", () => {
     it("PENDINGタスクを承認しようとすると400を返し、XPが加算されないこと", async () => {
         const quest = await seedQuestForDate(task.id, child.id, new Date("2026-04-05"), "PENDING");
 
-        mockAsUser({ ...parent, familyId: family.id, role: "PARENT" });
+        mockAsUser({ ...parent, family, role: "PARENT" });
         const res = await approveQuest(
             makeRequest(`/api/approve/${quest.id}`, { action: "approve" }),
             makeParams(quest.id),
@@ -54,7 +55,7 @@ describe("承認ガード（不正ステータス遷移の防止）", () => {
         // 正規フローで確認する
         const quest = await seedQuestForDate(task.id, child.id, new Date("2026-04-06"), "REPORTED");
 
-        mockAsUser({ ...parent, familyId: family.id, role: "PARENT" });
+        mockAsUser({ ...parent, family, role: "PARENT" });
         const res1 = await approveQuest(
             makeRequest(`/api/approve/${quest.id}`, { action: "approve" }),
             makeParams(quest.id),
@@ -81,7 +82,7 @@ describe("承認ガード（不正ステータス遷移の防止）", () => {
     it("REJECTEDクエストを承認しようとすると400を返すこと", async () => {
         const quest = await seedQuestForDate(task.id, child.id, new Date("2026-04-07"), "REJECTED");
 
-        mockAsUser({ ...parent, familyId: family.id, role: "PARENT" });
+        mockAsUser({ ...parent, family, role: "PARENT" });
         const res = await approveQuest(
             makeRequest(`/api/approve/${quest.id}`, { action: "approve" }),
             makeParams(quest.id),

--- a/src/__tests__/integration/badge-context.test.ts
+++ b/src/__tests__/integration/badge-context.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeAll, beforeEach, afterAll } from "vitest";
 import { loadBadgeContext } from "@/lib/badges";
 import { POST as approveQuest } from "@/app/api/approve/[id]/route";
+import type { Family, TaskTemplate, User } from "@/generated/prisma/client";
 import {
     prisma,
     mockAsUser,
@@ -13,10 +14,10 @@ import {
 } from "./helpers";
 
 describe("バッジコンテキスト計算の正確性", () => {
-    let family: any;
-    let parent: any;
-    let child: any;
-    let task: any;
+    let family: Family;
+    let parent: User;
+    let child: User;
+    let task: TaskTemplate;
 
     beforeAll(async () => {
         await cleanAll();
@@ -78,7 +79,7 @@ describe("バッジコンテキスト計算の正確性", () => {
             const date = new Date(`2026-04-${20 + i * 2}`); // 4/20, 4/22, 4/24
             const quest = await seedQuestForDate(task.id, child.id, date, "REPORTED");
 
-            mockAsUser({ ...parent, familyId: family.id, role: "PARENT" });
+            mockAsUser({ ...parent, family, role: "PARENT" });
             await approveQuest(
                 makeRequest(`/api/approve/${quest.id}`, { action: "approve" }),
                 makeParams(quest.id),

--- a/src/__tests__/integration/evolution-detail.test.ts
+++ b/src/__tests__/integration/evolution-detail.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeAll, afterAll } from "vitest";
 import { POST as approveQuest } from "@/app/api/approve/[id]/route";
 import { POST as rebirthQuest } from "@/app/api/rebirth/route";
+import type { Family, TaskTemplate, User } from "@/generated/prisma/client";
 import {
     prisma,
     mockAsUser,
@@ -13,10 +14,10 @@ import {
 } from "./helpers";
 
 describe("進化詳細（collectedPaths/monsterLevels/転生後の孵化閾値）", () => {
-    let family: any;
-    let parent: any;
-    let child: any;
-    let task: any;
+    let family: Family;
+    let parent: User;
+    let child: User;
+    let task: TaskTemplate;
 
     beforeAll(async () => {
         await cleanAll();
@@ -32,7 +33,7 @@ describe("進化詳細（collectedPaths/monsterLevels/転生後の孵化閾値�
         // stage0, 1ptで孵化（初回閾値=1pt）
         const quest = await seedQuestForDate(task.id, child.id, new Date("2026-04-01"), "REPORTED");
 
-        mockAsUser({ ...parent, familyId: family.id, role: "PARENT" });
+        mockAsUser({ ...parent, family, role: "PARENT" });
         await approveQuest(
             makeRequest(`/api/approve/${quest.id}`, { action: "approve" }),
             makeParams(quest.id),
@@ -62,7 +63,7 @@ describe("進化詳細（collectedPaths/monsterLevels/転生後の孵化閾値�
 
         const quest = await seedQuestForDate(task.id, child.id, new Date("2026-04-10"), "REPORTED");
 
-        mockAsUser({ ...parent, familyId: family.id, role: "PARENT" });
+        mockAsUser({ ...parent, family, role: "PARENT" });
         await approveQuest(
             makeRequest(`/api/approve/${quest.id}`, { action: "approve" }),
             makeParams(quest.id),
@@ -86,7 +87,7 @@ describe("進化詳細（collectedPaths/monsterLevels/転生後の孵化閾値�
         });
 
         const questRebirth = await seedQuestForDate(task.id, child.id, new Date("2026-04-20"), "REPORTED");
-        mockAsUser({ ...parent, familyId: family.id, role: "PARENT" });
+        mockAsUser({ ...parent, family, role: "PARENT" });
         await approveQuest(
             makeRequest(`/api/approve/${questRebirth.id}`, { action: "approve" }),
             makeParams(questRebirth.id),
@@ -97,7 +98,7 @@ describe("進化詳細（collectedPaths/monsterLevels/転生後の孵化閾値�
         expect(c!.rebirthPending).toBe(true);
 
         // 転生実行
-        mockAsUser({ ...child, familyId: family.id, role: "CHILD" });
+        mockAsUser({ ...child, family, role: "CHILD" });
         await rebirthQuest(makeRequest("/api/rebirth", { eggType: "STUDY" }));
 
         c = await prisma.user.findUnique({ where: { id: child.id } });
@@ -106,7 +107,7 @@ describe("進化詳細（collectedPaths/monsterLevels/転生後の孵化閾値�
 
         // 1pt では孵化しないこと（転生後は REBIRTH_EGG_THRESHOLD=5pt）
         const quest1pt = await seedQuestForDate(task.id, child.id, new Date("2026-04-25"), "REPORTED");
-        mockAsUser({ ...parent, familyId: family.id, role: "PARENT" });
+        mockAsUser({ ...parent, family, role: "PARENT" });
         await approveQuest(
             makeRequest(`/api/approve/${quest1pt.id}`, { action: "approve" }),
             makeParams(quest1pt.id),
@@ -123,7 +124,7 @@ describe("進化詳細（collectedPaths/monsterLevels/転生後の孵化閾値�
             date.setDate(date.getDate() + (i * 2));
 
             const q = await seedQuestForDate(task.id, child.id, date, "REPORTED");
-            mockAsUser({ ...parent, familyId: family.id, role: "PARENT" });
+            mockAsUser({ ...parent, family, role: "PARENT" });
             await approveQuest(
                 makeRequest(`/api/approve/${q.id}`, { action: "approve" }),
                 makeParams(q.id),
@@ -136,10 +137,10 @@ describe("進化詳細（collectedPaths/monsterLevels/転生後の孵化閾値�
 });
 
 describe("ストリークマイルストーンボーナスでの進化時にcollectedPathsが更新されること", () => {
-    let family: any;
-    let parent: any;
-    let child: any;
-    let task: any;
+    let family: Family;
+    let parent: User;
+    let child: User;
+    let task: TaskTemplate;
 
     beforeAll(async () => {
         await cleanAll();
@@ -168,7 +169,7 @@ describe("ストリークマイルストーンボーナスでの進化時にcoll
             const date = new Date(`2026-04-${i + 1}`);
             const q= await seedQuestForDate(task.id, child.id, date, "REPORTED");
 
-            mockAsUser({ ...parent, familyId: family.id, role: "PARENT" });
+            mockAsUser({ ...parent, family, role: "PARENT" });
             await approveQuest(
                 makeRequest(`/api/approve/${q.id}`, { action: "approve" }),
                 makeParams(q.id),

--- a/src/__tests__/integration/helpers.ts
+++ b/src/__tests__/integration/helpers.ts
@@ -1,6 +1,7 @@
 import { vi } from "vitest";
 import { prisma } from "@/lib/prisma";
-import { getCurrentUser } from "@/lib/auth";
+import { getCurrentUser, type AuthUser } from "@/lib/auth";
+import type { QuestStatus } from "@/generated/prisma/client";
 
 // 実Prismaクライアントを再エクスポート
 export { prisma };
@@ -9,24 +10,13 @@ export { prisma };
 // Auth ヘルパー
 // ──────────────────────────────────────────────
 
-type MockUser = {
-  id: string;
-  supabaseId: string;
-  role: "PARENT" | "CHILD";
-  name: string;
-  familyId: string;
-  side?: string | null;
-  monsterName?: string | null;
-  evolutionStage?: number;
-  studyPt?: number;
-  staminaPt?: number;
-  lifePt?: number;
-  minTasksForStreak?: number;
-  family?: { id: string; code: string };
-};
-
-export function mockAsUser(user: MockUser) {
-  vi.mocked(getCurrentUser).mockResolvedValue(user as any);
+/**
+ * getCurrentUser() のモック返り値を設定する。
+ * `AuthUser`（`User & { family: Family | null }`）を要求するため、呼び出し側は
+ * `seedFamily()` で作った `family` を含めて渡す（`{ ...parent, family, role: "PARENT" }` 等）。
+ */
+export function mockAsUser(user: AuthUser) {
+  vi.mocked(getCurrentUser).mockResolvedValue(user);
 }
 
 // ──────────────────────────────────────────────
@@ -82,7 +72,7 @@ export async function seedQuestForDate(
   templateId: string,
   childId: string,
   date: Date,
-  status: string = "PENDING",
+  status: QuestStatus = "PENDING",
 ) {
   const template = await prisma.taskTemplate.findUniqueOrThrow({ where: { id: templateId } });
   return prisma.questInstance.create({
@@ -90,7 +80,7 @@ export async function seedQuestForDate(
       templateId,
       childId,
       date,
-      status: status as any,
+      status,
       snapshotTitle: template.title,
       snapshotEmoji: template.emoji,
       snapshotCategory: template.category,

--- a/src/__tests__/integration/login-streak.test.ts
+++ b/src/__tests__/integration/login-streak.test.ts
@@ -1,17 +1,17 @@
 import { describe, it, expect, beforeAll, afterAll } from "vitest";
 import { POST as loginCheck } from "@/app/api/streak/login-check/route";
 import { todayJST } from "@/lib/date";
+import type { Family, User } from "@/generated/prisma/client";
 import {
     prisma,
     mockAsUser,
     seedFamily,
     cleanAll,
-    makeRequest,
 } from "./helpers";
 
 describe("ログインストリーク（記録 => ボーナス付与 -> 進化）", () => {
-    let family: any;
-    let child: any;
+    let family: Family;
+    let child: User;
     
     beforeAll(async () => {
         await cleanAll();
@@ -28,9 +28,9 @@ describe("ログインストリーク（記録 => ボーナス付与 -> 進化�
     });
 
     it("初回ログインでloginCurrentStreak=1になること", async () => {
-        mockAsUser({ ...child, familyId: family.id });
+        mockAsUser({ ...child, family });
 
-        const res = await loginCheck(makeRequest("/api/streak/login-check", {}));
+        const res = await loginCheck();
         const json = await res.json();
 
         expect(json.loginStreak).toBe(1);
@@ -51,8 +51,8 @@ describe("ログインストリーク（記録 => ボーナス付与 -> 進化�
             },
         });
 
-        mockAsUser({ ...child, familyId: family.id });
-        const res = await loginCheck(makeRequest("/api/streak/login-check", {}));
+        mockAsUser({ ...child, family });
+        const res = await loginCheck();
         const json = await res.json();
 
         expect(json.loginStreak).toBe(10);
@@ -90,8 +90,8 @@ describe("ログインストリーク（記録 => ボーナス付与 -> 進化�
             },
         });
 
-        mockAsUser({ ...child, familyId: family.id });
-        const res = await loginCheck(makeRequest("/api/streak/login-check", {}));
+        mockAsUser({ ...child, family });
+        const res = await loginCheck();
         const json = await res.json();
 
         expect(json.loginStreak).toBe(20);

--- a/src/__tests__/integration/quest-flow.test.ts
+++ b/src/__tests__/integration/quest-flow.test.ts
@@ -3,6 +3,7 @@ import { GET as getToday } from "@/app/api/quests/today/route";
 import { POST as reportQuest } from "@/app/api/quests/[id]/report/route";
 import { GET as getPending } from "@/app/api/approve/pending/route";
 import { POST as approveQuest } from "@/app/api/approve/[id]/route";
+import type { Family, TaskTemplate, User } from "@/generated/prisma/client";
 import {
   prisma,
   mockAsUser,
@@ -13,11 +14,19 @@ import {
   makeParams,
 } from "./helpers";
 
+/** GET /api/quests/today, GET /api/approve/pending のレスポンス JSON のうちテストで参照するフィールドのみ */
+type QuestJson = {
+  id: string;
+  status: string;
+  template: { id: string; title: string };
+  child?: { name: string };
+};
+
 describe("クエストフロー（報告→承認→XP付与）", () => {
-  let family: any;
-  let parent: any;
-  let child: any;
-  let task: any;
+  let family: Family;
+  let parent: User;
+  let child: User;
+  let task: TaskTemplate;
 
   beforeAll(async () => {
     await cleanAll();
@@ -33,29 +42,29 @@ describe("クエストフロー（報告→承認→XP付与）", () => {
   });
 
   it("子供が今日のクエストを取得し、QuestInstanceが自動生成されること", async () => {
-    mockAsUser({ ...child, familyId: family.id });
+    mockAsUser({ ...child, family });
 
     const res = await getToday();
-    const quests = await res.json();
+    const quests: QuestJson[] = await res.json();
 
     expect(quests.length).toBeGreaterThanOrEqual(1);
-    const quest = quests.find((q: any) => q.template.id === task.id);
+    const quest = quests.find((q) => q.template.id === task.id);
     expect(quest).toBeDefined();
-    expect(quest.status).toBe("PENDING");
-    expect(quest.template.title).toBe("テストタスク");
+    expect(quest!.status).toBe("PENDING");
+    expect(quest!.template.title).toBe("テストタスク");
   });
 
   it("子供がクエストを報告し、ステータスがREPORTEDになること", async () => {
-    mockAsUser({ ...child, familyId: family.id });
+    mockAsUser({ ...child, family });
 
     // まずクエストIDを取得
     const todayRes = await getToday();
-    const quests = await todayRes.json();
-    const quest = quests.find((q: any) => q.template.id === task.id);
+    const quests: QuestJson[] = await todayRes.json();
+    const quest = quests.find((q) => q.template.id === task.id);
 
     const res = await reportQuest(
-      makeRequest(`/api/quests/${quest.id}/report`, { comment: "やったよ！" }),
-      makeParams(quest.id),
+      makeRequest(`/api/quests/${quest!.id}/report`, { comment: "やったよ！" }),
+      makeParams(quest!.id),
     );
     const json = await res.json();
 
@@ -63,41 +72,41 @@ describe("クエストフロー（報告→承認→XP付与）", () => {
     expect(json.xpAdded).toBe(1); // 基本1pt（期限ボーナス・写真ボーナスなし）
 
     // DB確認
-    const updated = await prisma.questInstance.findUnique({ where: { id: quest.id } });
+    const updated = await prisma.questInstance.findUnique({ where: { id: quest!.id } });
     expect(updated!.status).toBe("REPORTED");
     expect(updated!.comment).toBe("やったよ！");
   });
 
   it("親の承認待ちリストにREPORTEDクエストが表示されること", async () => {
-    mockAsUser({ ...parent, familyId: family.id, role: "PARENT" });
+    mockAsUser({ ...parent, family, role: "PARENT" });
 
     const res = await getPending();
-    const pending = await res.json();
+    const pending: QuestJson[] = await res.json();
 
     expect(pending.length).toBeGreaterThanOrEqual(1);
-    const quest = pending.find((q: any) => q.template.title === "テストタスク");
+    const quest = pending.find((q) => q.template.title === "テストタスク");
     expect(quest).toBeDefined();
-    expect(quest.child.name).toBe("テスト子");
+    expect(quest!.child!.name).toBe("テスト子");
   });
 
   it("親が承認するとAPPROVEDになりXPが付与されること", async () => {
-    mockAsUser({ ...parent, familyId: family.id, role: "PARENT" });
+    mockAsUser({ ...parent, family, role: "PARENT" });
 
     // 承認待ちのクエストIDを取得
     const pendingRes = await getPending();
-    const pending = await pendingRes.json();
-    const quest = pending.find((q: any) => q.template.title === "テストタスク");
+    const pending: QuestJson[] = await pendingRes.json();
+    const quest = pending.find((q) => q.template.title === "テストタスク");
 
     const res = await approveQuest(
-      makeRequest(`/api/approve/${quest.id}`, { action: "approve" }),
-      makeParams(quest.id),
+      makeRequest(`/api/approve/${quest!.id}`, { action: "approve" }),
+      makeParams(quest!.id),
     );
     const json = await res.json();
 
     expect(json.ok).toBe(true);
 
     // DB確認: クエストステータス
-    const updatedQuest = await prisma.questInstance.findUnique({ where: { id: quest.id } });
+    const updatedQuest = await prisma.questInstance.findUnique({ where: { id: quest!.id } });
     expect(updatedQuest!.status).toBe("APPROVED");
     expect(updatedQuest!.approvedAt).toBeTruthy();
 
@@ -109,12 +118,12 @@ describe("クエストフロー（報告→承認→XP付与）", () => {
   });
 
   it("承認後、承認待ちリストからクエストが消えること", async () => {
-    mockAsUser({ ...parent, familyId: family.id, role: "PARENT" });
+    mockAsUser({ ...parent, family, role: "PARENT" });
 
     const res = await getPending();
-    const pending = await res.json();
+    const pending: QuestJson[] = await res.json();
 
-    const quest = pending.find((q: any) => q.template.title === "テストタスク");
+    const quest = pending.find((q) => q.template.title === "テストタスク");
     expect(quest).toBeUndefined();
   });
 });

--- a/src/__tests__/integration/rebirth-flow.test.ts
+++ b/src/__tests__/integration/rebirth-flow.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeAll, afterAll } from "vitest";
 import { POST as approveQuest } from "@/app/api/approve/[id]/route";
 import { POST as rebirthQuest } from "@/app/api/rebirth/route";
+import type { Family, TaskTemplate, User } from "@/generated/prisma/client";
 import {
   prisma,
   mockAsUser,
@@ -13,10 +14,10 @@ import {
 } from "./helpers";
 
 describe("転生フロー（閾値到達 → 卵選択 → 転生実行）", () => {
-  let family: any;
-  let parent: any;
-  let child: any;
-  let task: any;
+  let family: Family;
+  let parent: User;
+  let child: User;
+  let task: TaskTemplate;
 
   beforeAll(async () => {
     await cleanAll();
@@ -41,7 +42,7 @@ describe("転生フロー（閾値到達 → 卵選択 → 転生実行）", () 
     const day1 = new Date("2026-04-01");
     const quest = await seedQuestForDate(task.id, child.id, day1, "REPORTED");
 
-    mockAsUser({ ...parent, familyId: family.id, role: "PARENT" });
+    mockAsUser({ ...parent, family, role: "PARENT" });
     const res = await approveQuest(
       makeRequest(`/api/approve/${quest.id}`, { action: "approve" }),
       makeParams(quest.id),
@@ -60,7 +61,7 @@ describe("転生フロー（閾値到達 → 卵選択 → 転生実行）", () 
     const day2 = new Date("2026-04-02");
     const quest = await seedQuestForDate(task.id, child.id, day2, "REPORTED");
 
-    mockAsUser({ ...parent, familyId: family.id, role: "PARENT" });
+    mockAsUser({ ...parent, family, role: "PARENT" });
     await approveQuest(
       makeRequest(`/api/approve/${quest.id}`, { action: "approve" }),
       makeParams(quest.id),
@@ -73,7 +74,7 @@ describe("転生フロー（閾値到達 → 卵選択 → 転生実行）", () 
   });
 
   it("POST /api/rebirth で卵(STUDY)を選択すると転生が完了しstage/ptsがリセットされること", async () => {
-    mockAsUser({ ...child, familyId: family.id, role: "CHILD" });
+    mockAsUser({ ...child, family, role: "CHILD" });
 
     const res = await rebirthQuest(makeRequest("/api/rebirth", { eggType: "STUDY" }));
     const json = await res.json();
@@ -91,7 +92,7 @@ describe("転生フロー（閾値到達 → 卵選択 → 転生実行）", () 
   });
 
   it("転生完了後（rebirthPending=false）にPOST /api/rebirthを呼ぶと400を返すこと", async () => {
-    mockAsUser({ ...child, familyId: family.id, role: "CHILD" });
+    mockAsUser({ ...child, family, role: "CHILD" });
 
     const res = await rebirthQuest(makeRequest("/api/rebirth", { eggType: "STAMINA" }));
     expect(res.status).toBe(400);

--- a/src/__tests__/integration/skip-flow.test.ts
+++ b/src/__tests__/integration/skip-flow.test.ts
@@ -3,6 +3,7 @@ import { GET as getToday } from "@/app/api/quests/today/route";
 import { POST as skipQuest } from "@/app/api/quests/[id]/skip/route";
 import { GET as getPending } from "@/app/api/approve/pending/route";
 import { POST as approveQuest } from "@/app/api/approve/[id]/route";
+import type { Family, TaskTemplate, User } from "@/generated/prisma/client";
 import {
   prisma,
   mockAsUser,
@@ -13,11 +14,14 @@ import {
   makeParams,
 } from "./helpers";
 
+/** GET /api/quests/today, GET /api/approve/pending のレスポンス JSON のうちテストで参照するフィールドのみ */
+type QuestJson = { id: string; status: string; template: { id: string } };
+
 describe("スキップフロー（申請→親承認→SKIPPED）", () => {
-  let family: any;
-  let parent: any;
-  let child: any;
-  let task: any;
+  let family: Family;
+  let parent: User;
+  let child: User;
+  let task: TaskTemplate;
   let questId: string;
 
   beforeAll(async () => {
@@ -26,10 +30,10 @@ describe("スキップフロー（申請→親承認→SKIPPED）", () => {
     task = await seedTask(family.id, { assignedChildId: child.id });
 
     // クエスト生成
-    mockAsUser({ ...child, familyId: family.id });
+    mockAsUser({ ...child, family });
     const res = await getToday();
-    const quests = await res.json();
-    questId = quests.find((q: any) => q.template.id === task.id).id;
+    const quests: QuestJson[] = await res.json();
+    questId = quests.find((q) => q.template.id === task.id)!.id;
   });
 
   afterAll(async () => {
@@ -37,7 +41,7 @@ describe("スキップフロー（申請→親承認→SKIPPED）", () => {
   });
 
   it("子供がスキップ申請するとSKIP_REPORTEDになること", async () => {
-    mockAsUser({ ...child, familyId: family.id });
+    mockAsUser({ ...child, family });
 
     const req = new Request(`http://localhost/api/quests/${questId}/skip`, {
       method: "POST",
@@ -55,18 +59,18 @@ describe("スキップフロー（申請→親承認→SKIPPED）", () => {
   });
 
   it("親の承認待ちリストにスキップ申請が表示されること", async () => {
-    mockAsUser({ ...parent, familyId: family.id, role: "PARENT" });
+    mockAsUser({ ...parent, family, role: "PARENT" });
 
     const res = await getPending();
-    const pending = await res.json();
+    const pending: QuestJson[] = await res.json();
 
-    const quest = pending.find((q: any) => q.id === questId);
+    const quest = pending.find((q) => q.id === questId);
     expect(quest).toBeDefined();
-    expect(quest.status).toBe("SKIP_REPORTED");
+    expect(quest!.status).toBe("SKIP_REPORTED");
   });
 
   it("親が承認するとSKIPPEDになりXPは付与されないこと", async () => {
-    mockAsUser({ ...parent, familyId: family.id, role: "PARENT" });
+    mockAsUser({ ...parent, family, role: "PARENT" });
 
     const res = await approveQuest(
       makeRequest(`/api/approve/${questId}`, { action: "approve" }),

--- a/src/__tests__/integration/streak-flow.test.ts
+++ b/src/__tests__/integration/streak-flow.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, beforeAll, afterAll } from "vitest";
 import { POST as approveQuest } from "@/app/api/approve/[id]/route";
+import type { Family, TaskTemplate, User } from "@/generated/prisma/client";
 import {
   prisma,
   mockAsUser,
@@ -12,10 +13,10 @@ import {
 } from "./helpers";
 
 describe("ストリークフロー（連続達成→マイルストーン）", () => {
-  let family: any;
-  let parent: any;
-  let child: any;
-  let task: any;
+  let family: Family;
+  let parent: User;
+  let child: User;
+  let task: TaskTemplate;
 
   beforeAll(async () => {
     await cleanAll();
@@ -37,7 +38,7 @@ describe("ストリークフロー（連続達成→マイルストーン）", (
     const day1 = new Date("2026-03-13");
     const quest = await seedQuestForDate(task.id, child.id, day1, "REPORTED");
 
-    mockAsUser({ ...parent, familyId: family.id, role: "PARENT" });
+    mockAsUser({ ...parent, family, role: "PARENT" });
     const res = await approveQuest(
       makeRequest(`/api/approve/${quest.id}`, { action: "approve" }),
       makeParams(quest.id),
@@ -53,7 +54,7 @@ describe("ストリークフロー（連続達成→マイルストーン）", (
     const day2 = new Date("2026-03-14");
     const quest = await seedQuestForDate(task.id, child.id, day2, "REPORTED");
 
-    mockAsUser({ ...parent, familyId: family.id, role: "PARENT" });
+    mockAsUser({ ...parent, family, role: "PARENT" });
     await approveQuest(
       makeRequest(`/api/approve/${quest.id}`, { action: "approve" }),
       makeParams(quest.id),
@@ -72,7 +73,7 @@ describe("ストリークフロー（連続達成→マイルストーン）", (
     const day3 = new Date("2026-03-15");
     const quest = await seedQuestForDate(task.id, child.id, day3, "REPORTED");
 
-    mockAsUser({ ...parent, familyId: family.id, role: "PARENT" });
+    mockAsUser({ ...parent, family, role: "PARENT" });
     await approveQuest(
       makeRequest(`/api/approve/${quest.id}`, { action: "approve" }),
       makeParams(quest.id),
@@ -96,7 +97,7 @@ describe("ストリークフロー（連続達成→マイルストーン）", (
     const day5 = new Date("2026-03-17");
     const quest = await seedQuestForDate(task.id, child.id, day5, "REPORTED");
 
-    mockAsUser({ ...parent, familyId: family.id, role: "PARENT" });
+    mockAsUser({ ...parent, family, role: "PARENT" });
     await approveQuest(
       makeRequest(`/api/approve/${quest.id}`, { action: "approve" }),
       makeParams(quest.id),
@@ -112,7 +113,7 @@ describe("ストリークフロー（連続達成→マイルストーン）", (
     const day6 = new Date("2026-03-18");
     const quest = await seedQuestForDate(task.id, child.id, day6, "SKIP_REPORTED");
 
-    mockAsUser({ ...parent, familyId: family.id, role: "PARENT" });
+    mockAsUser({ ...parent, family, role: "PARENT" });
     await approveQuest(
       makeRequest(`/api/approve/${quest.id}`, { action: "approve" }),
       makeParams(quest.id),

--- a/src/__tests__/integration/task-delete.test.ts
+++ b/src/__tests__/integration/task-delete.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeAll, afterAll } from "vitest";
 import { DELETE as deleteTask } from "@/app/api/tasks/[id]/route";
 import { POST as approveQuest } from "@/app/api/approve/[id]/route";
+import type { Family, User } from "@/generated/prisma/client";
 import {
     prisma,
     mockAsUser,
@@ -13,9 +14,9 @@ import {
 } from "./helpers";
 
 describe("タスク削除時のXP回復（CHILD作成タスクの却下）", () => {
-    let family: any;
-    let parent: any;
-    let child: any;
+    let family: Family;
+    let parent: User;
+    let child: User;
 
     beforeAll(async () => {
         await cleanAll();
@@ -48,7 +49,7 @@ describe("タスク削除時のXP回復（CHILD作成タスクの却下）", () 
         const xpBefore = beforeChild!.studyPt + beforeChild!.staminaPt + beforeChild!.lifePt;
 
         // 親がタスク削除
-        mockAsUser({ ...parent, familyId: family.id, role: "PARENT" });
+        mockAsUser({ ...parent, family, role: "PARENT" });
         const req = new Request(`http://localhost/api/tasks/${task.id}`, {
             method: "DELETE",
             body: "{}",
@@ -82,7 +83,7 @@ describe("タスク削除時のXP回復（CHILD作成タスクの却下）", () 
         const quest = await seedQuestForDate(task.id, child.id, new Date("2026-04-10"), "REPORTED");
 
         // 承認してXP付与
-        mockAsUser({ ...parent, familyId: family.id, role: "PARENT" });
+        mockAsUser({ ...parent, family, role: "PARENT" });
         await approveQuest(
             makeRequest(`/api/approve/${quest.id}`, { action: "approve" }),
             makeParams(quest.id),

--- a/src/__tests__/lib/quest-hint.test.ts
+++ b/src/__tests__/lib/quest-hint.test.ts
@@ -2,22 +2,32 @@ import { shouldShowReportHint } from "@/lib/quest-hint";
 
 describe("shouldShowReportHint", () => {
   it("クエストがあり未報告のものがあり、ヒント未閲覧なら true を返す", () => {
-    expect(shouldShowReportHint({ hasQuests: true, anyReported: false, hasSeen: false })).toBe(true);
+    expect(
+      shouldShowReportHint({ hasQuests: true, anyReported: false, hasSeen: false, hasEverReported: false }),
+    ).toBe(true);
   });
 
   it("ヒント閲覧済みなら false を返す", () => {
-    expect(shouldShowReportHint({ hasQuests: true, anyReported: false, hasSeen: true })).toBe(false);
+    expect(
+      shouldShowReportHint({ hasQuests: true, anyReported: false, hasSeen: true, hasEverReported: false }),
+    ).toBe(false);
   });
 
   it("クエストがない場合は false を返す", () => {
-    expect(shouldShowReportHint({ hasQuests: false, anyReported: false, hasSeen: false })).toBe(false);
+    expect(
+      shouldShowReportHint({ hasQuests: false, anyReported: false, hasSeen: false, hasEverReported: false }),
+    ).toBe(false);
   });
 
   it("すでに報告済みのクエストがある場合は false を返す", () => {
-    expect(shouldShowReportHint({ hasQuests: true, anyReported: true, hasSeen: false })).toBe(false);
+    expect(
+      shouldShowReportHint({ hasQuests: true, anyReported: true, hasSeen: false, hasEverReported: false }),
+    ).toBe(false);
   });
 
   it("報告済みかつ閲覧済みなら false を返す", () => {
-    expect(shouldShowReportHint({ hasQuests: true, anyReported: true, hasSeen: true })).toBe(false);
+    expect(
+      shouldShowReportHint({ hasQuests: true, anyReported: true, hasSeen: true, hasEverReported: false }),
+    ).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary
- `no-explicit-any` を54→0、typecheckエラーを21→0に削減。これでIssue #23（案B: Prismaモック型付け）の子Issue群（#34〜#51）が全て完了する
- `integration/**` はPrismaを実DB接続でモックしない別系統であることを確認した上で、`mockAsUser`/`seedFamily`等をPrisma生成型・`AuthUser`型に型付け
- **重要な発見**: `quest-hint.test.ts`が実装（`ReportHintParams`への`hasEverReported`追加）に追随していなかったテスト側の乖離を発見・修正（`false`で旧来の暗黙的挙動を再現、実装は無変更）。`stamp.test.ts`では0引数ルートハンドラへの余分な引数渡し（テスト側のバグ、ランタイムには影響なし）を発見・修正
- `helpers/auth-mock.ts`に`asSupabaseClient()`ヘルパーを理由コメント付きで導入

## Test plan
- [x] `npm test` パス（2512/2512、変化なし）
- [x] `npx eslint src/__tests__` の `no-explicit-any`: 54→0
- [x] `npm run typecheck`（prisma generate後）: 21→0
- [ ] `npm run test:integration` — **申し送り事項**: ローカルDBスキーマドリフト（`BulletinLog`のunique制約未適用等）により実行不可。これは今回の変更と無関係な既存の環境問題であることをcode-reviewerが`git stash`比較で確認済み。ユーザーのローカル環境の問題として別途対応が必要

## Note
- `expect(`/`it(` の出現数は全ファイルで変化なし（テストケース自体の追加・削除なし、型付けのみ）
- Closes #51。ただしIssue #23自体はこのPRでは自動クローズされないため、マージ後に別途手動でクローズしてください

🤖 Generated with [Claude Code](https://claude.com/claude-code)
