### PR TITLE
fix(lint): #24着手前提のlintエラー・警告を解消

### DIFF
--- a/e2e/s17-task-edit-delete.spec.ts
+++ b/e2e/s17-task-edit-delete.spec.ts
@@ -26,7 +26,7 @@ test.describe("S17: タスクの編集・削除", () => {
         // テスト用の通常タスクを作成
         const familyRes = await page.request.get("/api/family/code", { headers: bypassHeaders });
         const familyData = await familyRes.json();
-        const children = familyData.members?.filter((m: any) => m.role === "CHILD") ?? [];
+        const children = familyData.members?.filter((m: { id: string; role: string }) => m.role === "CHILD") ?? [];
         if (children.length === 0) {
             test.skip(true, "テスト用の子供アカウントが見つかりません");
             return;
@@ -66,7 +66,7 @@ test.describe("S17: タスクの編集・削除", () => {
         // テスト用の通常タスクを作成
         const familyRes = await page.request.get("/api/family/code", { headers: bypassHeaders });
         const familyData = await familyRes.json();
-        const children = familyData.members?.filter((m: any) => m.role === "CHILD") ?? [];
+        const children = familyData.members?.filter((m: { id: string; role: string }) => m.role === "CHILD") ?? [];
         if (children.length === 0) {
             test.skip(true, "テスト用の子供アカウントが見つかりません");
             return;
@@ -105,7 +105,7 @@ test.describe("S17: タスクの編集・削除", () => {
         // 削除用の一時タスクを作成
         const familyRes = await page.request.get("/api/family/code", { headers: bypassHeaders });
         const familyData = await familyRes.json();
-        const children = familyData.members?.filter((m: any) => m.role === "CHILD") ?? [];
+        const children = familyData.members?.filter((m: { id: string; role: string }) => m.role === "CHILD") ?? [];
         if (children.length === 0) {
             test.skip(true, "テスト用の子供アカウントが見つかりません");
             return;
@@ -121,6 +121,7 @@ test.describe("S17: タスクの編集・削除", () => {
             },
             headers: bypassHeaders,
         });
+        expect(taskRes.ok()).toBeTruthy();
 
         // リロードしてタスクを表示
         await page.reload();

--- a/src/app/app/child/quests/page.tsx
+++ b/src/app/app/child/quests/page.tsx
@@ -100,6 +100,9 @@ export default function QuestsPage() {
   }
 
   useEffect(() => {
+    // マウント時に一度だけモンスター情報を取得する。fetchMonster内部でsetChildName/setMonsterMiniを呼ぶが、
+    // 外部API（サーバー）との同期が目的でありレンダー時算出はできないためuseEffect内が正しい。
+    // eslint-disable-next-line react-hooks/set-state-in-effect
     fetchMonster();
   }, []);
 

--- a/src/app/app/parent/(app)/tasks/page.tsx
+++ b/src/app/app/parent/(app)/tasks/page.tsx
@@ -85,6 +85,9 @@ export default function TasksPage() {
   }
 
   useEffect(() => {
+    // マウント時に一度だけタスク・子供一覧を取得する。fetchTasks/fetchChildren内部でsetState系を呼ぶが、
+    // 外部API（サーバー）との同期が目的でありレンダー時算出はできないためuseEffect内が正しい。
+    // eslint-disable-next-line react-hooks/set-state-in-effect
     Promise.all([fetchTasks(), fetchChildren()]).finally(() => setLoading(false));
   }, []);
 

--- a/src/hooks/usePendingApprovalCount.ts
+++ b/src/hooks/usePendingApprovalCount.ts
@@ -43,7 +43,7 @@ export function usePendingCounts(): PendingCounts {
       supabase.removeChannel(channel);
       document.removeEventListener("visibilitychange", onVisible);
     };
-  }, []);
+  }, [id]);
 
   return counts;
 }


### PR DESCRIPTION
## Summary
- Issue #24（lintゲート化）の着手前提条件である `npm run lint` の0 errors/0 warnings化のための修正
- `quests/page.tsx` / `tasks/page.tsx`: 過去のIssue #22-3で対応漏れだった `react-hooks/set-state-in-effect` 2件を、既存方針（`docs/decisions.md` 2026-08-12エントリ）に沿って理由コメント付きdisableで解消
- `usePendingApprovalCount.ts`: `useEffect` 依存配列に `id`（`useId()` 由来、安定値）を追加し `exhaustive-deps` 警告を解消
- **重要な修正**: `e2e/s17-task-edit-delete.spec.ts` で、過去のIssue #19対応時に「タスク作成APIの成否検証漏れの可能性が高い実装バグの疑い」として意図的に未修正のまま残されていた箇所に、他の2テストと同一パターンで `expect(taskRes.ok()).toBeTruthy();` を追加。code-reviewerが文脈・意味の一致を確認済み。**E2Eテストのためこの場でサーバーを起動しての実行確認はできておらず、`playwright test --list` によるパース検証のみ実施**
- 修正後、リポジトリ全体で `npx eslint . --max-warnings=0` が0 errors/0 warningsであることを確認済み

## Test plan
- [x] `npm test` パス（183 files / 2512 tests、変化なし）
- [x] `npx eslint . --max-warnings=0`（リポジトリ全体）が0 errors/0 warningsであることを確認済み
- [ ] `e2e/s17-task-edit-delete.spec.ts` の実サーバー起動による実行確認（本PRのスコープ外。`playwright test --list` によるパース検証のみ実施）

## Note
- 本PRは Issue #24（lint ゲート化）本体ではなく、その着手前提条件を満たすための準備PRです。本PRのマージだけで Issue #24 は完了しません。
- `docs/decisions.md` への新規追記はなし（2026-08-12エントリで定めた既存方針の適用のみ）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
