### PR TITLE
ci: lintジョブをブロッキングなゲートに切り替える

### DIFF
--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -42,10 +42,9 @@ jobs:
   lint:
     name: Lint
     runs-on: ubuntu-latest
-    # Stage 1: visualize lint results without blocking PRs. There are ~1670
-    # pre-existing errors (see #19-#23 for the cleanup plan). Flip this to
-    # false only after that debt is paid down (tracked in #24).
-    continue-on-error: true
+    # Stage 2: blocking gate. Pre-existing lint debt (see #19-#23) has been
+    # paid down to 0 errors / 0 warnings (see #70), so lint failures now
+    # block the PR (tracked in #24).
     steps:
       - uses: actions/checkout@v4
 
@@ -56,4 +55,4 @@ jobs:
 
       - run: npm ci
       - name: Run ESLint
-        run: npm run lint
+        run: npm run lint -- --max-warnings=0


### PR DESCRIPTION
## Summary
- `lint`ジョブから`continue-on-error: true`を削除し、`npm run lint -- --max-warnings=0`に変更（警告方針は案B: ユーザー選択）
- ジョブ名`Lint`は維持（ブランチ保護のrequired status checkとの紐付けを壊さないため）
- 前提条件（0 errors/0 warnings）はPR #70で達成済み
- ダミーのlintエラー・warning-onlyケースで実際にジョブが失敗することを実測確認済み

## Test plan
- [x] `npm run lint -- --max-warnings=0` パス（exit code 0、0 errors/0 warnings）
- [x] ダミーのlintエラーでジョブが失敗することを実測確認済み
- [x] warning-onlyケースでジョブが失敗することを実測確認済み
- [ ] `npm test` — 該当なし（CIワークフロー設定ファイルのみの変更）

## マージ後に必要な手動作業（リポジトリ管理者）
- [ ] GitHub リポジトリ設定 > Branches > branch protection rule で `Lint` を required status check に追加する（対象: `develop`）
- [ ] `main` も同様に検討する（`restrict-main-merge.yml` により develop 経由でのみ main へマージ可能なため、developで運用できていれば実質的に十分だが、直接保護をかけたい場合は main にも追加する）
- この設定が完了するまでは、lintジョブは失敗として表示されるがマージボタン自体はブロックされない

Closes #24

🤖 Generated with [Claude Code](https://claude.com/claude-code)
