### PR TITLE
fix(e2e): PRごとのVercelプレビューURLに対応しホスト名ハードコード除去

### DIFF
--- a/e2e/baseUrl.ts
+++ b/e2e/baseUrl.ts
@@ -1,0 +1,24 @@
+/**
+ * E2E テストが対象とするデプロイの base URL / hostname 導出ロジック。
+ * - CI やローカルで PR プレビュー URL を指定できるよう `E2E_BASE_URL` を優先する
+ * - 未設定時は develop ブランチの Vercel プレビュー URL にフォールバックする
+ */
+
+export const DEFAULT_BASE_URL =
+  "https://adhd-git-develop-km-copepodas-projects.vercel.app";
+
+/** `E2E_BASE_URL` が設定されていればその値、空文字/未設定なら既定 URL を返す */
+export function getE2EBaseUrl(): string {
+  return process.env.E2E_BASE_URL || DEFAULT_BASE_URL;
+}
+
+/** baseUrl からホスト名を導出する。不正な URL の場合は `new URL()` の例外をそのまま投げる */
+export function getE2EHostname(baseUrl: string = getE2EBaseUrl()): string {
+  return new URL(baseUrl).hostname;
+}
+
+/** Playwright の `page.route()` 用に `<protocol>//<host>/**` 形式のパターンを組み立てる */
+export function getE2ERoutePattern(baseUrl: string = getE2EBaseUrl()): string {
+  const url = new URL(baseUrl);
+  return `${url.protocol}//${url.hostname}/**`;
+}

--- a/e2e/credentials.ts
+++ b/e2e/credentials.ts
@@ -6,9 +6,8 @@
 import fs from "fs";
 import path from "path";
 import type { Browser, Page } from "@playwright/test";
+import { getE2EBaseUrl, getE2EHostname, getE2ERoutePattern } from "./baseUrl";
 
-export const VERCEL_HOSTNAME = "adhd-git-develop-km-copepodas-projects.vercel.app";
-export const VERCEL_BASE_URL = `https://${VERCEL_HOSTNAME}`;
 export const AUTH_DIR = path.join(process.cwd(), "playwright/.auth");
 
 export type QACredentials = {
@@ -33,9 +32,9 @@ export function getBypassHeaders(): Record<string, string> {
 export async function setupBypassRoute(page: Page): Promise<void> {
   const secret = process.env.VERCEL_BYPASS_SECRET;
   if (!secret) return;
-  // **/${VERCEL_HOSTNAME}/** は https:// の二重スラッシュにマッチしない場合があるため
+  // **/<hostname>/** は https:// の二重スラッシュにマッチしない場合があるため
   // https:// から始まる明示的なパターンを使用する
-  await page.route(`https://${VERCEL_HOSTNAME}/**`, async (route) => {
+  await page.route(getE2ERoutePattern(), async (route) => {
     await route.continue({
       headers: {
         ...route.request().headers(),
@@ -59,7 +58,7 @@ export async function createBrowserContext(
 ) {
   const secret = process.env.VERCEL_BYPASS_SECRET;
   const context = await browser.newContext({
-    baseURL: VERCEL_BASE_URL,
+    baseURL: getE2EBaseUrl(),
     ...(storageStatePath ? { storageState: storageStatePath } : {}),
     ...(secret ? { extraHTTPHeaders: { "x-vercel-protection-bypass": secret } } : {}),
   });
@@ -85,7 +84,7 @@ export async function createBrowserContext(
       };
       const vercelCookies = (parentState.cookies ?? []).filter(
         (c) =>
-          (c.domain.includes(VERCEL_HOSTNAME) ||
+          (c.domain.includes(getE2EHostname()) ||
             c.domain.includes(".vercel.app") ||
             c.domain.includes("vercel.com")) &&
           !c.name.startsWith("sb-"),

--- a/e2e/fixtures.ts
+++ b/e2e/fixtures.ts
@@ -4,8 +4,7 @@
  * - 全 spec ファイルはこのファイルから test / expect をインポートする
  */
 import { test as base, expect } from "@playwright/test";
-
-const VERCEL_HOSTNAME = "adhd-git-develop-km-copepodas-projects.vercel.app";
+import { getE2ERoutePattern } from "./baseUrl";
 
 export const test = base.extend({
   page: async ({ page }, use) => {
@@ -13,7 +12,7 @@ export const test = base.extend({
     if (secret) {
       // Vercel ドメインへのリクエストにのみ bypass ヘッダーを追加
       // Supabase 等の外部 API へのリクエストは変更しない
-      await page.route(`https://${VERCEL_HOSTNAME}/**`, async (route) => {
+      await page.route(getE2ERoutePattern(), async (route) => {
         await route.continue({
           headers: {
             ...route.request().headers(),

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,12 +1,11 @@
 import { defineConfig, devices } from "@playwright/test";
 import { config } from "dotenv";
+import { getE2EBaseUrl } from "./e2e/baseUrl";
 
 // .env.test から E2E 専用の環境変数を読み込む
 config({ path: ".env.test" });
 
-const baseURL =
-  process.env.E2E_BASE_URL ||
-  "https://adhd-git-develop-km-copepodas-projects.vercel.app";
+const baseURL = getE2EBaseUrl();
 
 export default defineConfig({
   testDir: "./e2e",

--- a/src/__tests__/e2e/baseUrl.test.ts
+++ b/src/__tests__/e2e/baseUrl.test.ts
@@ -1,0 +1,134 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+// e2e/ 配下は vitest.config.ts の include 対象外だが、相対パスで直接 import する。
+// @ エイリアスは ./src にしか通っていないため使えない。
+import {
+  DEFAULT_BASE_URL,
+  getE2EBaseUrl,
+  getE2EHostname,
+  getE2ERoutePattern,
+} from "../../../e2e/baseUrl";
+
+/**
+ * Playwright の page.route() が使う glob パターン（`**` は `/` を含め任意文字列にマッチ）を
+ * 簡易的に再現した検証用マッチャー。実際の Playwright ランタイムは起動しない。
+ */
+function matchesRoutePattern(pattern: string, url: string): boolean {
+  const escaped = pattern
+    .split("**")
+    .map((part) => part.replace(/[.*+?^${}()|[\]\\]/g, "\\$&"))
+    .join(".*");
+  const regex = new RegExp(`^${escaped}$`);
+  return regex.test(url);
+}
+
+describe("DEFAULT_BASE_URL", () => {
+  it("develop の既定 URL である", () => {
+    expect(DEFAULT_BASE_URL).toBe(
+      "https://adhd-git-develop-km-copepodas-projects.vercel.app",
+    );
+  });
+});
+
+describe("getE2EBaseUrl", () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it("E2E_BASE_URL が設定されていればその値を返す", () => {
+    vi.stubEnv("E2E_BASE_URL", "https://adhd-git-pr-123-xxx.vercel.app");
+    expect(getE2EBaseUrl()).toBe("https://adhd-git-pr-123-xxx.vercel.app");
+  });
+
+  it("境界値: E2E_BASE_URL が未設定なら develop の既定 URL にフォールバックする", () => {
+    vi.stubEnv("E2E_BASE_URL", undefined);
+    expect(getE2EBaseUrl()).toBe(DEFAULT_BASE_URL);
+  });
+
+  it("境界値: E2E_BASE_URL が空文字なら未設定と同じ扱いで既定 URL にフォールバックする", () => {
+    vi.stubEnv("E2E_BASE_URL", "");
+    expect(getE2EBaseUrl()).toBe(DEFAULT_BASE_URL);
+  });
+
+  it("createBrowserContext の baseURL が E2E_BASE_URL に追従する（戻り値検証）", () => {
+    // createBrowserContext 自体は Playwright の Browser/Page に依存するため実起動しないが、
+    // Green フェーズで createBrowserContext は getE2EBaseUrl() の戻り値を baseURL として使う想定。
+    // ここではその追従元となる戻り値そのものが env に応じて変化することを検証する。
+    vi.stubEnv("E2E_BASE_URL", "https://adhd-git-pr-999-xxx.vercel.app");
+    const baseUrlForContext = getE2EBaseUrl();
+    expect(baseUrlForContext).toBe("https://adhd-git-pr-999-xxx.vercel.app");
+    expect(baseUrlForContext).not.toBe(DEFAULT_BASE_URL);
+  });
+});
+
+describe("getE2EHostname", () => {
+  it("正常系: プレビュー URL からホスト名を導出できる", () => {
+    expect(getE2EHostname("https://adhd-git-pr-123-xxx.vercel.app")).toBe(
+      "adhd-git-pr-123-xxx.vercel.app",
+    );
+  });
+
+  it("境界値: 末尾スラッシュありでもホスト名が正しく取れる", () => {
+    expect(getE2EHostname("https://example.vercel.app/")).toBe(
+      "example.vercel.app",
+    );
+  });
+
+  it("境界値: ポート付き URL でもホスト名が壊れない", () => {
+    expect(getE2EHostname("http://localhost:3000")).toBe("localhost");
+  });
+
+  it("異常系: 不正な URL 文字列を渡すと例外を投げる（無言でフォールバックしない）", () => {
+    expect(() => getE2EHostname("not a url")).toThrow();
+  });
+
+  it("引数省略時は getE2EBaseUrl() の結果からホスト名を導出する", () => {
+    vi.stubEnv("E2E_BASE_URL", "https://adhd-git-pr-42-xxx.vercel.app");
+    expect(getE2EHostname()).toBe("adhd-git-pr-42-xxx.vercel.app");
+    vi.unstubAllEnvs();
+  });
+});
+
+describe("getE2ERoutePattern", () => {
+  it("正常系: https://<host>/** 形式のパターンを組み立てる", () => {
+    expect(getE2ERoutePattern("https://adhd-git-pr-123-xxx.vercel.app")).toBe(
+      "https://adhd-git-pr-123-xxx.vercel.app/**",
+    );
+  });
+
+  it("正常系: プレビュー URL 配下のリクエストにマッチする", () => {
+    const pattern = getE2ERoutePattern("https://adhd-git-pr-123-xxx.vercel.app");
+    expect(
+      matchesRoutePattern(
+        pattern,
+        "https://adhd-git-pr-123-xxx.vercel.app/app/parent/tasks",
+      ),
+    ).toBe(true);
+    expect(
+      matchesRoutePattern(pattern, "https://adhd-git-pr-123-xxx.vercel.app/"),
+    ).toBe(true);
+  });
+
+  it("境界値: 末尾スラッシュありの baseUrl でも壊れないパターンになる", () => {
+    expect(getE2ERoutePattern("https://example.vercel.app/")).toBe(
+      "https://example.vercel.app/**",
+    );
+  });
+
+  it("境界値: ポート付き URL でもパターンが壊れない", () => {
+    expect(getE2ERoutePattern("http://localhost:3000")).toBe(
+      "http://localhost/**",
+    );
+  });
+
+  it("異常系: Supabase 等の外部ドメインにはマッチしない（bypass ヘッダーが漏れない）", () => {
+    const pattern = getE2ERoutePattern("https://adhd-git-pr-123-xxx.vercel.app");
+    expect(
+      matchesRoutePattern(pattern, "https://xxxxx.supabase.co/auth/v1/token"),
+    ).toBe(false);
+  });
+
+  it("引数省略時は getE2EBaseUrl() の結果からパターンを組み立てる", () => {
+    vi.stubEnv("E2E_BASE_URL", undefined);
+    expect(getE2ERoutePattern()).toBe(`${DEFAULT_BASE_URL}/**`);
+  });
+});


### PR DESCRIPTION
## Summary
- `e2e/baseUrl.ts` を新規作成し、`DEFAULT_BASE_URL` / `getE2EBaseUrl()` / `getE2EHostname()` / `getE2ERoutePattern()` に集約
- `e2e/fixtures.ts` / `e2e/credentials.ts` / `playwright.config.ts` の develop 固定ホスト名ハードコード（`VERCEL_HOSTNAME` 重複定義含む）を除去し、共通ヘルパー経由に統一
- これにより E2E が PR ごとの Vercel プレビュー URL を向けられるようになる

## Test plan
- [x] `npm test` パス（184 files / 2558 tests）
- [x] `npx tsc --noEmit`（変更ファイル起因のエラーなし）
- [x] eslint パス
- [x] `npx playwright test s1-landing --project=no-auth` を develop の Vercel プレビュー環境に対して実地実行 → 9 passed
- [x] `src/__tests__/e2e/baseUrl.test.ts` 新規追加（16テストケース）

## Related
- Closes #75

🤖 Generated with [Claude Code](https://claude.com/claude-code)
