### PR TITLE
e2e: FREE/PREMIUMプラン別にテストを分離 (#76)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,3 +11,8 @@ DIRECT_URL="postgresql://postgres:postgres@127.0.0.1:54332/postgres"
 VAPID_PUBLIC_KEY=your_vapid_public_key
 VAPID_PRIVATE_KEY=your_vapid_private_key
 NEXT_PUBLIC_VAPID_PUBLIC_KEY=your_vapid_public_key
+
+# e2eテスト専用: POST /api/dev/subscription (テストアカウントへのPREMIUM付与エンドポイント) の有効化スイッチ。
+# 本番環境では絶対に設定しないこと（課金回避の穴になる）。ローカル/CIのe2e実行時のみ一時的に "1" を設定する。
+# ALLOW_E2E_SETUP=1
+# E2E_SETUP_SECRET=change-me-to-a-random-value

--- a/.env.test.example
+++ b/.env.test.example
@@ -8,3 +8,15 @@ VERCEL_BYPASS_SECRET=your_bypass_secret_here
 
 # Optional: E2E target URL. If omitted, the develop Vercel deployment is used.
 E2E_BASE_URL=https://adhd-git-develop-km-copepodas-projects.vercel.app
+
+# e2e テスト専用アカウントの PREMIUM 化 API（POST /api/dev/subscription）を有効化するフラグ。
+# 本番環境の課金フラグとは完全に別物（本番の Stripe プラン管理には一切影響しない）。
+# 本番環境では絶対に設定しないこと（課金回避の穴になる）。ローカル/CIのe2e実行時のみ一時的に設定する。
+# 対象環境（Vercel の develop プレビュー等）側にも同名の環境変数を設定する必要がある
+# （Vercel 側の設定は人間が別途行う。ここでの記述はローカルから .env.test を読む e2e 実行用）。
+ALLOW_E2E_SETUP=1
+
+# 上記 API を叩く際に x-e2e-setup-secret ヘッダーへ付与する共有シークレット。
+# 対象環境側の E2E_SETUP_SECRET と同じ値を設定すること。任意の推測困難な文字列でよい。
+# こちらも本番環境では絶対に設定しないこと。
+E2E_SETUP_SECRET=your_e2e_setup_secret_here

--- a/e2e/auth-free.setup.ts
+++ b/e2e/auth-free.setup.ts
@@ -1,0 +1,70 @@
+/**
+ * 認証セットアップ（QA アカウント新規作成版・FREE）
+ *
+ * 実行ごとに QA_FREE_yyyymmddhhmmss@example.com で新規登録し、
+ * 子供ユーザーを1人だけ作成した上で storageState と qa-credentials-free.json を生成する。
+ *
+ * 新規登録直後のアカウントは自動的に FREE プランのため、PREMIUM 化 API は呼ばない。
+ * FREE 制限テスト（as-parent-free プロジェクト）専用のアカウントを提供する。
+ * PREMIUM 用のセットアップは auth.setup.ts を参照。
+ */
+import { test as setup, expect } from "./fixtures";
+import path from "path";
+import fs from "fs";
+import { AUTH_DIR, getBypassHeaders } from "./credentials";
+
+const CREDENTIALS_FILE = path.join(AUTH_DIR, "qa-credentials-free.json");
+
+setup.beforeAll(() => {
+  if (!fs.existsSync(AUTH_DIR)) {
+    fs.mkdirSync(AUTH_DIR, { recursive: true });
+  }
+});
+
+setup("create FREE QA account and child", async ({ page }) => {
+  // タイムスタンプベースのメール生成（QA_FREE_yyyymmddhhmmss@example.com）
+  const now = new Date();
+  const ts = [
+    now.getFullYear(),
+    String(now.getMonth() + 1).padStart(2, "0"),
+    String(now.getDate()).padStart(2, "0"),
+    String(now.getHours()).padStart(2, "0"),
+    String(now.getMinutes()).padStart(2, "0"),
+    String(now.getSeconds()).padStart(2, "0"),
+  ].join("");
+  const email = `QA_FREE_${ts}@example.com`;
+  const password = "QAPassword123";
+
+  // 1. アカウント新規登録
+  await page.goto("/app/register");
+  await expect(page.getByText("管理者 アカウント作成")).toBeVisible({ timeout: 15000 });
+  await page.fill('input[placeholder="メールアドレス"]', email);
+  await page.fill('input[placeholder="パスワード（6文字以上）"]', password);
+  await page.click('button:has-text("アカウントを作成")');
+  await page.waitForURL("**/app/parent/tasks", { timeout: 30000 });
+
+  // 2. ファミリーコードを API から取得
+  const bypassHeaders = getBypassHeaders();
+  const familyRes = await page.request.get("/api/family/code", { headers: bypassHeaders });
+  const familyData = await familyRes.json();
+  const familyCode: string = familyData.code;
+
+  // 3. 子供ユーザーを1人だけ API で作成
+  const childRes = await page.request.post("/api/family/members", {
+    data: { monsterName: "QA_FREE_child", side: "LIGHT" },
+    headers: bypassHeaders,
+  });
+  const childData = await childRes.json();
+  const childCodeLight: string = childData.childCode;
+
+  // 4. PREMIUM 化 API は呼ばない（新規登録直後は自動的に FREE プランのため）
+
+  // 5. qa-credentials-free.json に保存
+  fs.writeFileSync(
+    CREDENTIALS_FILE,
+    JSON.stringify({ email, password, familyCode, childCodeLight }, null, 2),
+  );
+
+  // 6. 親 storageState を保存
+  await page.context().storageState({ path: path.join(AUTH_DIR, "parent-free.json") });
+});

--- a/e2e/auth.setup.ts
+++ b/e2e/auth.setup.ts
@@ -1,9 +1,14 @@
 /**
- * 認証セットアップ（QA アカウント新規作成版）
+ * 認証セットアップ（QA アカウント新規作成版・PREMIUM）
  *
  * 実行ごとに QA_yyyymmddhhmmss@example.com で新規登録し、
  * 子供ユーザーを作成した上で storageState と qa-credentials.json を生成する。
  * s1-s3（ログイン周り）のテストは固定アカウントを使うためここでは作らない。
+ *
+ * このアカウントは POST /api/dev/subscription で PREMIUM 化される
+ * （as-parent-premium プロジェクトが前提とするアカウント）。
+ * 子供切替 UI の検証用に2人目の子供（QA_child2）も作成する。
+ * FREE プラン用のセットアップは auth-free.setup.ts を参照。
  */
 import { test as setup, expect } from "./fixtures";
 import path from "path";
@@ -56,16 +61,52 @@ setup("create QA account and child", async ({ page, browser }) => {
   const childData = await childRes.json();
   const childCodeLight: string = childData.childCode;
 
-  // 4. qa-credentials.json に保存
+  // 4. このアカウントを PREMIUM 化する（フェーズ1で追加した e2e 専用エンドポイント）
+  //    Vercel 側に ALLOW_E2E_SETUP / E2E_SETUP_SECRET が未設定の場合は 404/401 になるが、
+  //    その場合も setup 自体は失敗させず警告のみ出す（環境変数設定は人間の作業のため）。
+  const premiumHeaders: Record<string, string> = { ...bypassHeaders };
+  if (process.env.E2E_SETUP_SECRET) {
+    premiumHeaders["x-e2e-setup-secret"] = process.env.E2E_SETUP_SECRET;
+  }
+  const premiumRes = await page.request.post("/api/dev/subscription", {
+    headers: premiumHeaders,
+  });
+  if (!premiumRes.ok()) {
+    console.warn(
+      `[auth.setup] PREMIUM化APIが失敗しました（status=${premiumRes.status()}）。` +
+        "ALLOW_E2E_SETUP / E2E_SETUP_SECRET が対象環境に設定されているか確認してください。",
+    );
+  }
+
+  // 5. 2人目の子供を作成（PREMIUM 側の子供切替 UI 検証用）
+  const child2Res = await page.request.post("/api/family/members", {
+    data: { monsterName: "QA_child2", side: "LIGHT" },
+    headers: bypassHeaders,
+  });
+  if (!child2Res.ok()) {
+    throw new Error(
+      `[auth.setup] 2人目の子供作成に失敗しました（status=${child2Res.status()}）。` +
+        `PREMIUM化API結果: ok=${premiumRes.ok()} status=${premiumRes.status()}。` +
+        "ALLOW_E2E_SETUP / E2E_SETUP_SECRET が対象環境に設定されているか確認してください。",
+    );
+  }
+  const child2Data = await child2Res.json();
+  const childCodeLight2: string = child2Data.childCode;
+
+  // 6. qa-credentials.json に保存
   fs.writeFileSync(
     CREDENTIALS_FILE,
-    JSON.stringify({ email, password, familyCode, childCodeLight }, null, 2),
+    JSON.stringify(
+      { email, password, familyCode, childCodeLight, childCodeLight2 },
+      null,
+      2,
+    ),
   );
 
-  // 5. 親 storageState を保存
+  // 7. 親 storageState を保存
   await page.context().storageState({ path: path.join(AUTH_DIR, "parent.json") });
 
-  // 6. 子供ログイン → child-light.json に保存
+  // 8. 子供ログイン（1人目）→ child-light.json に保存
   const { context: childCtx, page: childPage } = await createBrowserContext(browser);
   try {
     await childPage.goto("/app/child/login");

--- a/e2e/credentials.ts
+++ b/e2e/credentials.ts
@@ -15,10 +15,23 @@ export type QACredentials = {
   password: string;
   familyCode: string;
   childCodeLight: string;
+  /** PREMIUM 用アカウントのみ: 2人目の子供（子供切替UIの検証用）。FREE 用アカウントには存在しない。 */
+  childCodeLight2?: string;
 };
 
 export function readCredentials(): QACredentials {
   const file = path.join(AUTH_DIR, "qa-credentials.json");
+  return JSON.parse(fs.readFileSync(file, "utf-8"));
+}
+
+/**
+ * FREE プラン用 QA アカウントの認証情報を読み込む。
+ * `auth-free.setup.ts` が書き出す qa-credentials-free.json（子供1人のみ）を対象とする。
+ * PREMIUM 用の readCredentials() とはファイルが分離されているため、
+ * 既存の readCredentials() 呼び出し元には影響しない。
+ */
+export function readFreeCredentials(): QACredentials {
+  const file = path.join(AUTH_DIR, "qa-credentials-free.json");
   return JSON.parse(fs.readFileSync(file, "utf-8"));
 }
 

--- a/e2e/s10-full-flow.spec.ts
+++ b/e2e/s10-full-flow.spec.ts
@@ -1,6 +1,6 @@
 /**
  * S10: 全フロー統合テスト
- * 前提: as-parent プロジェクト（storageState: parent.json）で実行
+ * 前提: as-parent-premium プロジェクト（storageState: parent.json）で実行
  *
  * 「親がタスク作成 → 子供がクエスト完了報告 → 親が承認 → リストから消える」
  * の一連の流れを1テストで検証する。

--- a/e2e/s11-monster-page.spec.ts
+++ b/e2e/s11-monster-page.spec.ts
@@ -43,7 +43,7 @@ test.describe("S11: 育成画面", () => {
   });
 
   test("たまごまたは進化途中のステージである（孵化/進化テキストが表示される）", async ({ page }) => {
-    // s10（as-parent）でXPが付与されて孵化済みの場合は「進化」、まだなら「孵化」
+    // s10（as-parent-premium）でXPが付与されて孵化済みの場合は「進化」、まだなら「孵化」
     await expect(page.getByText(/孵化|進化/)).toBeVisible();
   });
 

--- a/e2e/s12-skip-approve.spec.ts
+++ b/e2e/s12-skip-approve.spec.ts
@@ -1,6 +1,6 @@
 /**
  * S12: スキップ承認フロー統合テスト
- * 前提: as-parent プロジェクト（storageState: parent.json）で実行
+ * 前提: as-parent-premium プロジェクト（storageState: parent.json）で実行
  *
  * 「親がタスク作成 → 子供がスキップ申請 → 親が承認」の全フローを検証する。
  *

--- a/e2e/s13-deadline-settings.spec.ts
+++ b/e2e/s13-deadline-settings.spec.ts
@@ -1,6 +1,6 @@
 /**
  * S13: 報告期限設定テスト
- * 前提: as-parent プロジェクト（storageState: parent.json）で実行
+ * 前提: as-parent-premium プロジェクト（storageState: parent.json）で実行
  *
  * - ファミリー管理ページで子供ごとに報告期限を設定できる
  * - 期限時刻を保存できる

--- a/e2e/s16-history.spec.ts
+++ b/e2e/s16-history.spec.ts
@@ -1,7 +1,7 @@
 /**
  * S16: 親 - 過去の記録（履歴ヒートマップ）
  * 
- * 前提: as-parent (parent.json で認証された状態) で実行
+ * 前提: as-parent-premium (parent.json で認証された状態) で実行
  * 対象: /app/parent/history
  * 
  * テスト内容:

--- a/e2e/s17-task-edit-delete.spec.ts
+++ b/e2e/s17-task-edit-delete.spec.ts
@@ -1,7 +1,7 @@
 /**
  * S17: 親 - タスクの編集・削除
  * 
- * 前提: as-parent (parent.json で認証済み)
+ * 前提: as-parent-premium (parent.json で認証済み)
  * 対象: /app/parent/tasks
  * 
  * テスト内容:

--- a/e2e/s18-completed-today.spec.ts
+++ b/e2e/s18-completed-today.spec.ts
@@ -1,7 +1,7 @@
 /**
  * S18: 親 - 今日の完了タスクの表示
  * 
- * 前提: as-parent (parent.json で認証済み)
+ * 前提: as-parent-premium (parent.json で認証済み)
  * 対象: /app/parent/completed
  * 
  * テスト内容:

--- a/e2e/s22-parent-treasures.spec.ts
+++ b/e2e/s22-parent-treasures.spec.ts
@@ -1,6 +1,6 @@
 /**
  * S22: 親の宝箱プール（ごほうび）設定ページ
- * 前提: as-parent プロジェクト（storageState: parent.json）で実行
+ * 前提: as-parent-premium プロジェクト（storageState: parent.json）で実行
  *
  * - /app/parent/treasures が表示される（タブ切替）
  * - 「ごほうび設定」見出しと「もらった履歴」タブが表示される

--- a/e2e/s22-parent-treasures.spec.ts
+++ b/e2e/s22-parent-treasures.spec.ts
@@ -5,11 +5,13 @@
  * - /app/parent/treasures が表示される（タブ切替）
  * - 「ごほうび設定」見出しと「もらった履歴」タブが表示される
  * - 子供が1人の場合は子供切替ボタンが表示されない（複数子供時のUIは #76 で扱う）
+ * - 子供が2人以上のとき子供切替ボタンが表示され、切り替えると対象の子のごほうび一覧に切り替わる（#76）
  * - 新しいごほうび追加フォーム（タイトル入力 + レア度 + 「追加」ボタン）
  * - 境界値: タイトル未入力では「追加」ボタンが無効
  * - 既存ごほうびがあれば一覧、なければ「おすすめセットで始める」ボタン
  */
 import { test, expect } from "./fixtures";
+import { getBypassHeaders } from "./credentials";
 
 test.describe("S22: 親のごほうび設定", () => {
   test.beforeEach(async ({ page }) => {
@@ -31,6 +33,44 @@ test.describe("S22: 親のごほうび設定", () => {
     // 複数子供 / PREMIUM での切替UI検証は #76 で扱う
     await expect(page.getByText("対象の子供")).not.toBeVisible();
     await expect(page.locator('input[placeholder="例: アイスを買える"]')).toBeVisible();
+  });
+
+  test("子供が2人以上のとき子供切替ボタンが表示され、切り替えると対象の子のごほうび一覧に切り替わる", async ({
+    page,
+  }) => {
+    // auth.setup.ts が作成する2人目の子供（QA_child2）の id を取得
+    const bypassHeaders = getBypassHeaders();
+    const familyRes = await page.request.get("/api/family/code", { headers: bypassHeaders });
+    const familyData = await familyRes.json();
+    const child2 = familyData.members.find(
+      (m: { role: string; monsterName: string | null }) =>
+        m.role === "CHILD" && m.monsterName === "QA_child2",
+    );
+    expect(child2).toBeTruthy();
+
+    // QA_child2 専用のごほうびを事前に API で作成
+    const title = `E2E_child2限定_${Date.now()}`;
+    const addRes = await page.request.post("/api/treasures", {
+      data: { childId: child2.id, title, rarity: "COMMON" },
+      headers: bypassHeaders,
+    });
+    expect(addRes.ok()).toBeTruthy();
+
+    await page.goto("/app/parent/treasures");
+    await expect(page.getByRole("heading", { name: /ごほうび設定/ })).toBeVisible({
+      timeout: 15000,
+    });
+
+    // 子供が2人以上のため子供切替ボタン（アイコンボタン式）が表示される
+    const child2Button = page.getByRole("button", { name: /QA_child2/ });
+    await expect(child2Button).toBeVisible({ timeout: 10000 });
+
+    // デフォルトでは1人目（QA_child）が選択されているため、QA_child2 専用ごほうびはまだ見えない
+    await expect(page.getByText(title)).not.toBeVisible();
+
+    // 切り替えると対象の子（QA_child2）のごほうび一覧に切り替わる
+    await child2Button.click();
+    await expect(page.getByText(title)).toBeVisible({ timeout: 10000 });
   });
 
   test("「新しいごほうびを追加」フォームが表示される", async ({ page }) => {

--- a/e2e/s23-parent-treasures-pending.spec.ts
+++ b/e2e/s23-parent-treasures-pending.spec.ts
@@ -1,6 +1,6 @@
 /**
  * S23: 親「もらった履歴」ページ — 親メモ「渡したよチェック」
- * 前提: as-parent プロジェクト（storageState: parent.json）で実行
+ * 前提: as-parent-premium プロジェクト（storageState: parent.json）で実行
  *
  * - /app/parent/treasures/pending が表示される
  * - 「もらったごほうび」見出しと、設定タブとの切替リンクが表示される

--- a/e2e/s26-plan-free-limits.spec.ts
+++ b/e2e/s26-plan-free-limits.spec.ts
@@ -1,0 +1,158 @@
+/**
+ * S26: FREE プランの各種上限
+ * 前提: as-parent-free プロジェクト（storageState: parent-free.json）で実行
+ * FREE アカウントの認証情報は e2e/credentials.ts の readFreeCredentials() で取得する
+ * （auth-free.setup.ts が qa-credentials-free.json / parent-free.json を用意する。子供は1人のみ）
+ *
+ * - 「おすすめセットで始める」ボタンは FREE では表示されない（ごほうび0件でも）
+ * - 子アカウント上限（1人）: 2人目追加時にインラインエラーが表示されメンバーに追加されない
+ * - タスク上限（10件/子）: 11件目追加時に alert でエラーが表示される
+ * - ごほうび上限（5件/子）: 6件目追加時に alert でエラーが表示される
+ */
+import { test, expect } from "./fixtures";
+import { readFreeCredentials, getBypassHeaders } from "./credentials";
+
+test.describe("S26: FREE プラン上限", () => {
+  test("「おすすめセットで始める」ボタンはFREEでは表示されない（ごほうび0件）", async ({ page }) => {
+    await page.goto("/app/parent/treasures");
+    await expect(page.getByRole("heading", { name: /ごほうび設定/ })).toBeVisible({
+      timeout: 15000,
+    });
+
+    // 新規 FREE アカウントはごほうび0件のため空状態メッセージが表示される
+    await expect(page.getByText("まだごほうびが登録されていません。")).toBeVisible({
+      timeout: 10000,
+    });
+    // FREE プランでは「おすすめセットで始める」ボタンは非表示
+    await expect(
+      page.getByRole("button", { name: /おすすめセットで始める/ }),
+    ).not.toBeVisible();
+  });
+
+  test("子アカウント上限（1人）: 2人目追加でインラインエラーが表示されメンバーに追加されない", async ({
+    page,
+  }) => {
+    await page.goto("/app/parent/family");
+    await expect(page.getByRole("heading", { name: /ファミリー管理/ })).toBeVisible({
+      timeout: 15000,
+    });
+
+    const childName = `E2E_FREE_over_${Date.now()}`;
+    await page.getByRole("button", { name: /子どもを追加/ }).click();
+    await expect(page.locator('input[placeholder="例: りゅうくん"]')).toBeVisible();
+    await page.fill('input[placeholder="例: りゅうくん"]', childName);
+    await page.getByRole("button", { name: /^追加$/ }).click();
+
+    // src/app/api/family/members/route.ts のエラーメッセージと一致する文言がインライン表示される
+    await expect(
+      page.getByText(
+        "無料プランでは子アカウントは1人までです。プレミアムプランで無制限になります。",
+      ),
+    ).toBeVisible({ timeout: 10000 });
+
+    // メンバー一覧には追加されない
+    await expect(page.getByText(childName)).not.toBeVisible();
+  });
+
+  test("タスク上限（10件/子）: 11件目追加時にalertでエラーが表示される", async ({ page }) => {
+    const creds = readFreeCredentials();
+    const bypassHeaders = getBypassHeaders();
+
+    // 対象の子供（childCodeLight で特定）の id を取得
+    const familyRes = await page.request.get("/api/family/code", { headers: bypassHeaders });
+    const familyData = await familyRes.json();
+    const child = familyData.members.find(
+      (m: { role: string; childCode: string | null }) =>
+        m.role === "CHILD" && m.childCode === creds.childCodeLight,
+    );
+    expect(child).toBeTruthy();
+
+    // API 経由で事前に10件作成（FREE 上限ちょうど）
+    for (let i = 0; i < 10; i++) {
+      const res = await page.request.post("/api/tasks", {
+        data: {
+          title: `E2E_FREE_task_${Date.now()}_${i}`,
+          emoji: "📚",
+          category: "STUDY",
+          repeatDays: [0, 1, 2, 3, 4, 5, 6],
+          isTemporary: false,
+          assignedChildId: child.id,
+        },
+        headers: bypassHeaders,
+      });
+      expect(res.ok()).toBeTruthy();
+    }
+
+    // UI から11件目を追加しようとすると alert でエラーが表示される
+    await page.goto("/app/parent/tasks");
+    await expect(page.getByRole("heading", { name: /タスク管理/ })).toBeVisible({
+      timeout: 15000,
+    });
+
+    await page.getByRole("button", { name: /タスク追加/ }).first().click();
+    await expect(page.locator('input[placeholder="例: 算数ドリルをやる"]')).toBeVisible();
+    await page.fill(
+      'input[placeholder="例: 算数ドリルをやる"]',
+      `E2E_FREE_task_over_${Date.now()}`,
+    );
+
+    let dialogMessage = "";
+    page.once("dialog", async (dialog) => {
+      dialogMessage = dialog.message();
+      await dialog.accept();
+    });
+    await page.getByRole("button", { name: /^作成$/ }).click();
+
+    await expect
+      .poll(() => dialogMessage, { timeout: 10000 })
+      .toContain("無料プランではタスクは10個までです。プレミアムプランで無制限になります。");
+  });
+
+  test("ごほうび上限（5件/子）: 6件目追加時にalertでエラーが表示される", async ({ page }) => {
+    const creds = readFreeCredentials();
+    const bypassHeaders = getBypassHeaders();
+
+    const familyRes = await page.request.get("/api/family/code", { headers: bypassHeaders });
+    const familyData = await familyRes.json();
+    const child = familyData.members.find(
+      (m: { role: string; childCode: string | null }) =>
+        m.role === "CHILD" && m.childCode === creds.childCodeLight,
+    );
+    expect(child).toBeTruthy();
+
+    // API 経由で事前に5件作成（FREE 上限ちょうど）
+    for (let i = 0; i < 5; i++) {
+      const res = await page.request.post("/api/treasures", {
+        data: {
+          childId: child.id,
+          title: `E2E_FREE_treasure_${Date.now()}_${i}`,
+          rarity: "COMMON",
+        },
+        headers: bypassHeaders,
+      });
+      expect(res.ok()).toBeTruthy();
+    }
+
+    // UI から6件目を追加しようとすると alert でエラーが表示される
+    await page.goto("/app/parent/treasures");
+    await expect(page.getByRole("heading", { name: /ごほうび設定/ })).toBeVisible({
+      timeout: 15000,
+    });
+
+    await page.fill(
+      'input[placeholder="例: アイスを買える"]',
+      `E2E_FREE_treasure_over_${Date.now()}`,
+    );
+
+    let dialogMessage = "";
+    page.once("dialog", async (dialog) => {
+      dialogMessage = dialog.message();
+      await dialog.accept();
+    });
+    await page.getByRole("button", { name: /^追加$/ }).click();
+
+    await expect
+      .poll(() => dialogMessage, { timeout: 10000 })
+      .toContain("無料プランではごほうびは5個までです。プレミアムプランで無制限になります。");
+  });
+});

--- a/e2e/s4-task-creation.spec.ts
+++ b/e2e/s4-task-creation.spec.ts
@@ -1,6 +1,6 @@
 /**
  * S4: 親タスク作成（通常タスク & 一時タスク）
- * 前提: as-parent プロジェクトで実行（storageState: parent.json）
+ * 前提: as-parent-premium プロジェクトで実行（storageState: parent.json）
  *
  * - タスク管理ページが表示される
  * - 通常タスクを作成できる

--- a/e2e/s6-quest-approve.spec.ts
+++ b/e2e/s6-quest-approve.spec.ts
@@ -1,6 +1,6 @@
 /**
  * S6: 親クエスト承認フロー
- * 前提: as-parent プロジェクト（storageState: parent.json）で実行
+ * 前提: as-parent-premium プロジェクト（storageState: parent.json）で実行
  *
  * - /app/parent/approve が表示される
  * - 承認待ちのクエストカードが表示される

--- a/e2e/s9-child-management.spec.ts
+++ b/e2e/s9-child-management.spec.ts
@@ -1,6 +1,6 @@
 /**
  * S9: 子供ユーザー管理（作成・ログイン確認・削除）
- * 前提: as-parent プロジェクトで実行（storageState: parent.json）
+ * 前提: as-parent-premium プロジェクトで実行（storageState: parent.json）
  *
  * - ファミリー管理ページが表示される
  * - 境界値: 名前未入力では追加ボタン押下時エラーが表示される

--- a/e2e/s9-child-management.spec.ts
+++ b/e2e/s9-child-management.spec.ts
@@ -44,11 +44,10 @@ test.describe("S9: 子供ユーザー管理", () => {
     await expect(page.locator('input[placeholder="例: りゅうくん"]')).not.toBeVisible();
   });
 
-  // QA アカウントは新規登録直後は FREE プラン（子アカウント上限1人）で、
-  // auth.setup.ts が1人目の子供 "QA_child" を既に作成済みのため、
-  // このテストが2人目を追加しようとすると API が 403 PLAN_LIMIT_EXCEEDED を返し必ず失敗する。
-  // PREMIUM QA アカウントを用意してから有効化する（#76 で対応予定）
-  test.skip("子供ユーザーを作成し削除できる", async ({ page }) => {
+  // PREMIUM化前提で有効化済み（#76 フェーズ4）。
+  // as-parent-premium プロジェクトは auth.setup.ts で PREMIUM 化された QA アカウントを使う
+  // （子アカウント上限が撤廃されるため、1人目 "QA_child" / 2人目 "QA_child2" に続けて3人目を追加できる）。
+  test("子供ユーザーを作成し削除できる", async ({ page }) => {
     const childName = `E2E_${Date.now()}`;
 
     // --- 1. 子供ユーザーを作成 ---

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -24,9 +24,16 @@ export default defineConfig({
   },
   projects: [
     // 認証セットアップ（no-auth の後に実行：S3 が child-rejoin で supabaseId を上書きするため）
+    // PREMIUM 化・2人目の子供作成も行う（as-parent-premium / as-child が使うアカウント）
     {
       name: "setup",
       testMatch: /auth\.setup\.ts/,
+      dependencies: ["no-auth"],
+    },
+    // FREE プラン用の認証セットアップ（別アカウント・子供1人のみ・PREMIUM化なし）
+    {
+      name: "setup-free",
+      testMatch: /auth-free\.setup\.ts/,
       dependencies: ["no-auth"],
     },
     // 未認証テスト（ランディング・ログインフォーム検証・アカウント登録フォーム）
@@ -35,9 +42,9 @@ export default defineConfig({
       testMatch: /\/(s1|s2|s3|s14)-.*\.spec\.ts/,
       use: { ...devices["Desktop Chrome"] },
     },
-    // 親アカウントで実行するテスト（全フロー・スキップ承認・期限設定・履歴・完了・宝箱プールを含む）
+    // 親アカウント（PREMIUM）で実行するテスト（全フロー・スキップ承認・期限設定・履歴・完了・宝箱プールを含む）
     {
-      name: "as-parent",
+      name: "as-parent-premium",
       testMatch: /\/(s4|s6|s9|s10|s12|s13|s16|s17|s18|s22|s23)-.*\.spec\.ts/,
       use: {
         ...devices["Desktop Chrome"],
@@ -54,6 +61,16 @@ export default defineConfig({
         storageState: "playwright/.auth/child-light.json",
       },
       dependencies: ["setup"],
+    },
+    // 親アカウント（FREE）で実行するテスト（プラン別制限の検証。フェーズ4で spec を追加予定）
+    {
+      name: "as-parent-free",
+      testMatch: /\/s26-plan-free-limits\.spec\.ts/,
+      use: {
+        ...devices["Desktop Chrome"],
+        storageState: "playwright/.auth/parent-free.json",
+      },
+      dependencies: ["setup-free"],
     },
   ],
 });

--- a/src/__tests__/api/dev/subscription.test.ts
+++ b/src/__tests__/api/dev/subscription.test.ts
@@ -1,0 +1,173 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+import { POST } from "@/app/api/dev/subscription/route";
+import { getCurrentUser } from "@/lib/auth";
+import { prismaMock as mockPrisma } from "../../helpers/prisma-mock";
+import { parentUserWithFamily, parentUser, subscription } from "../../helpers/fixtures";
+
+const mockGetCurrentUser = vi.mocked(getCurrentUser);
+
+/**
+ * POST /api/dev/subscription 用のテスト専用リクエストビルダー。
+ * ヘッダー(x-e2e-setup-secret)とボディを個別に指定できるようにする。
+ * helpers/request.ts の makeRequest はヘッダーを指定できないためここでは使わない。
+ */
+function makeReq(opts?: {
+  body?: Record<string, unknown>;
+  secretHeader?: string;
+}): NextRequest {
+  const headers: Record<string, string> = { "content-type": "application/json" };
+  if (opts?.secretHeader !== undefined) {
+    headers["x-e2e-setup-secret"] = opts.secretHeader;
+  }
+  return new NextRequest("http://localhost/api/dev/subscription", {
+    method: "POST",
+    headers,
+    body: JSON.stringify(opts?.body ?? {}),
+  });
+}
+
+const VALID_SECRET = "test-e2e-secret";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.unstubAllEnvs();
+  // デフォルトは「有効化 + 正しいシークレット + 認証済みPARENT + 家族にPARENTが存在」という
+  // 全条件を満たす状態にしておき、各テストで必要な条件だけ崩す。
+  vi.stubEnv("ALLOW_E2E_SETUP", "1");
+  vi.stubEnv("E2E_SETUP_SECRET", VALID_SECRET);
+  mockGetCurrentUser.mockResolvedValue(parentUserWithFamily({ id: "parent-1", familyId: "fam-1" }));
+  mockPrisma.user.findFirst.mockResolvedValue(parentUser({ id: "parent-1", familyId: "fam-1" }));
+  mockPrisma.subscription.upsert.mockResolvedValue(
+    subscription({ userId: "parent-1", plan: "PREMIUM", currentPeriodEnd: null }),
+  );
+});
+
+describe("POST /api/dev/subscription — ガード条件（存在の隠蔽 + シークレット認証）", () => {
+  it("ALLOW_E2E_SETUP が未設定(undefined)の場合、シークレットヘッダーが正しくても404を返すこと", async () => {
+    const original = process.env.ALLOW_E2E_SETUP;
+    delete process.env.ALLOW_E2E_SETUP;
+    try {
+      const res = await POST(makeReq({ secretHeader: VALID_SECRET }));
+      expect(res.status).toBe(404);
+      expect(mockPrisma.subscription.upsert).not.toHaveBeenCalled();
+    } finally {
+      if (original !== undefined) process.env.ALLOW_E2E_SETUP = original;
+    }
+  });
+
+  it("ALLOW_E2E_SETUP が '0' の場合、404を返すこと", async () => {
+    vi.stubEnv("ALLOW_E2E_SETUP", "0");
+    const res = await POST(makeReq({ secretHeader: VALID_SECRET }));
+    expect(res.status).toBe(404);
+    expect(mockPrisma.subscription.upsert).not.toHaveBeenCalled();
+  });
+
+  it("ALLOW_E2E_SETUP が 'false' の場合、404を返すこと", async () => {
+    vi.stubEnv("ALLOW_E2E_SETUP", "false");
+    const res = await POST(makeReq({ secretHeader: VALID_SECRET }));
+    expect(res.status).toBe(404);
+    expect(mockPrisma.subscription.upsert).not.toHaveBeenCalled();
+  });
+
+  it("ALLOW_E2E_SETUP が未設定の場合、シークレットヘッダーが誤っていても404を返すこと（存在を隠す）", async () => {
+    vi.stubEnv("ALLOW_E2E_SETUP", "0");
+    const res = await POST(makeReq({ secretHeader: "wrong-secret" }));
+    expect(res.status).toBe(404);
+  });
+
+  it("ALLOW_E2E_SETUP=1 でもシークレットヘッダーが無い場合、401を返すこと", async () => {
+    const res = await POST(makeReq());
+    expect(res.status).toBe(401);
+    expect(mockPrisma.subscription.upsert).not.toHaveBeenCalled();
+  });
+
+  it("ALLOW_E2E_SETUP=1 でもシークレットヘッダーが誤っている場合、401を返すこと", async () => {
+    const res = await POST(makeReq({ secretHeader: "wrong-secret" }));
+    expect(res.status).toBe(401);
+    expect(mockPrisma.subscription.upsert).not.toHaveBeenCalled();
+  });
+
+  it("E2E_SETUP_SECRET が未設定の場合、どんなヘッダー値でも401を返すこと", async () => {
+    vi.stubEnv("E2E_SETUP_SECRET", "");
+    const res = await POST(makeReq({ secretHeader: "" }));
+    expect(res.status).toBe(401);
+  });
+});
+
+describe("POST /api/dev/subscription — 認証・入力検証", () => {
+  it("未認証（getCurrentUserがnull）の場合、403を返すこと", async () => {
+    mockGetCurrentUser.mockResolvedValue(null);
+    const res = await POST(makeReq({ secretHeader: VALID_SECRET }));
+    expect(res.status).toBe(403);
+    expect(mockPrisma.subscription.upsert).not.toHaveBeenCalled();
+  });
+
+  it("認証済みユーザーがfamilyIdを持たない場合、400を返すこと", async () => {
+    mockGetCurrentUser.mockResolvedValue(
+      parentUserWithFamily({ id: "parent-1", familyId: null }, null),
+    );
+    const res = await POST(makeReq({ secretHeader: VALID_SECRET }));
+    expect(res.status).toBe(400);
+    expect(mockPrisma.subscription.upsert).not.toHaveBeenCalled();
+  });
+
+  it("リクエストボディで自分の家族と異なるfamilyIdを指定した場合、403を返すこと（他家族のプラン変更を防止）", async () => {
+    const res = await POST(
+      makeReq({ secretHeader: VALID_SECRET, body: { familyId: "other-fam" } }),
+    );
+    expect(res.status).toBe(403);
+    expect(mockPrisma.subscription.upsert).not.toHaveBeenCalled();
+  });
+
+  it("家族にPARENTユーザーが見つからない場合、500を返すこと", async () => {
+    mockPrisma.user.findFirst.mockResolvedValue(null);
+    const res = await POST(makeReq({ secretHeader: VALID_SECRET }));
+    expect(res.status).toBe(500);
+    expect(mockPrisma.subscription.upsert).not.toHaveBeenCalled();
+  });
+});
+
+describe("POST /api/dev/subscription — 正常系", () => {
+  it("全条件を満たす場合、家族のPARENTユーザーのSubscriptionをPREMIUM・無期限でupsertし200を返すこと", async () => {
+    const res = await POST(makeReq({ secretHeader: VALID_SECRET }));
+    expect(res.status).toBe(200);
+
+    const body = await res.json();
+    expect(body.ok).toBe(true);
+    expect(body.plan).toBe("PREMIUM");
+    expect(body.currentPeriodEnd).toBeNull();
+
+    expect(mockPrisma.subscription.upsert).toHaveBeenCalledWith({
+      where: { userId: "parent-1" },
+      update: { plan: "PREMIUM", currentPeriodEnd: null },
+      create: { userId: "parent-1", plan: "PREMIUM", currentPeriodEnd: null },
+    });
+  });
+
+  it("既にSubscriptionが存在する家族に対して2回連続で呼んでも重複作成エラーにならず200を返すこと（upsertで冪等）", async () => {
+    const res1 = await POST(makeReq({ secretHeader: VALID_SECRET }));
+    const res2 = await POST(makeReq({ secretHeader: VALID_SECRET }));
+
+    expect(res1.status).toBe(200);
+    expect(res2.status).toBe(200);
+    expect(mockPrisma.subscription.upsert).toHaveBeenCalledTimes(2);
+    expect(mockPrisma.subscription.create).not.toHaveBeenCalled();
+  });
+
+  it("リクエストボディに自分自身のfamilyIdを明示指定しても正常に処理されること", async () => {
+    const res = await POST(
+      makeReq({ secretHeader: VALID_SECRET, body: { familyId: "fam-1" } }),
+    );
+    expect(res.status).toBe(200);
+  });
+
+  it("レスポンスに機密情報（supabaseId・email・userId等）を含まないこと", async () => {
+    const res = await POST(makeReq({ secretHeader: VALID_SECRET }));
+    const body = await res.json();
+    expect(body).not.toHaveProperty("supabaseId");
+    expect(body).not.toHaveProperty("email");
+    expect(body).not.toHaveProperty("userId");
+    expect(body).not.toHaveProperty("id");
+  });
+});

--- a/src/__tests__/api/treasures/treasures.test.ts
+++ b/src/__tests__/api/treasures/treasures.test.ts
@@ -11,6 +11,12 @@ const mockGetCurrentUser = vi.mocked(getCurrentUser);
 
 beforeEach(() => {
   vi.clearAllMocks();
+  // vi.clearAllMocks() は mockResolvedValueOnce 等でキューに積んだ未消費の値を
+  // クリアしない（vitest 仕様）。GET テスト側で mockResolvedValueOnce を2連続で
+  // 積んでいるが実装がまだ2回呼ばないケース（Red フェーズ）があるため、
+  // 未消費分が後続テストに漏れないよう明示的に reset しておく。
+  mockPrisma.user.findFirst.mockReset();
+  mockPrisma.subscription.findUnique.mockReset();
 });
 
 // ─── GET /api/treasures ──────────────────────────────────────────────
@@ -51,6 +57,68 @@ describe("GET /api/treasures", () => {
     expect(res.status).toBe(200);
     expect(json.items).toHaveLength(1);
     expect(json.items[0].id).toBe("i1");
+  });
+
+  // ─── plan フィールド (Issue #76: おすすめセットボタンのFREE非表示化用) ──
+  it("レスポンスに plan フィールドが含まれる", async () => {
+    mockGetCurrentUser.mockResolvedValue(parentUserWithFamily());
+    mockPrisma.user.findFirst
+      .mockResolvedValueOnce(childUser({ id: "child-1" })) // ensureFamilyChild
+      .mockResolvedValueOnce(parentUser({ id: "parent-1" })); // getFamilyPlan
+    mockPrisma.subscription.findUnique.mockResolvedValue(null);
+    mockPrisma.treasureItem.findMany.mockResolvedValue([]);
+
+    const res = await listGET(new Request("http://localhost/api/treasures?childId=child-1"));
+    const json = await res.json();
+    expect(res.status).toBe(200);
+    expect(json.plan).toBeDefined();
+    expect(["FREE", "PREMIUM"]).toContain(json.plan);
+  });
+
+  it("FREEプランの家族の場合 plan: FREE が返る", async () => {
+    mockGetCurrentUser.mockResolvedValue(parentUserWithFamily());
+    mockPrisma.user.findFirst
+      .mockResolvedValueOnce(childUser({ id: "child-1" }))
+      .mockResolvedValueOnce(parentUser({ id: "parent-1" }));
+    mockPrisma.subscription.findUnique.mockResolvedValue(null); // サブスクなし = FREE
+    mockPrisma.treasureItem.findMany.mockResolvedValue([]);
+
+    const res = await listGET(new Request("http://localhost/api/treasures?childId=child-1"));
+    const json = await res.json();
+    expect(json.plan).toBe("FREE");
+  });
+
+  it("PREMIUMプランの家族の場合 plan: PREMIUM が返る", async () => {
+    mockGetCurrentUser.mockResolvedValue(parentUserWithFamily());
+    mockPrisma.user.findFirst
+      .mockResolvedValueOnce(childUser({ id: "child-1" }))
+      .mockResolvedValueOnce(parentUser({ id: "parent-1" }));
+    mockPrisma.subscription.findUnique.mockResolvedValue(
+      subscription({ plan: "PREMIUM", currentPeriodEnd: new Date("2099-12-31") }),
+    );
+    mockPrisma.treasureItem.findMany.mockResolvedValue([]);
+
+    const res = await listGET(new Request("http://localhost/api/treasures?childId=child-1"));
+    const json = await res.json();
+    expect(json.plan).toBe("PREMIUM");
+  });
+
+  it("plan フィールド追加後も items フィールドの挙動に変更がない（リグレッション防止）", async () => {
+    mockGetCurrentUser.mockResolvedValue(parentUserWithFamily());
+    mockPrisma.user.findFirst
+      .mockResolvedValueOnce(childUser({ id: "child-1" }))
+      .mockResolvedValueOnce(parentUser({ id: "parent-1" }));
+    mockPrisma.subscription.findUnique.mockResolvedValue(null);
+    mockPrisma.treasureItem.findMany.mockResolvedValue([
+      treasureItem({ id: "i1", title: "おやつ", rarity: "COMMON", sortOrder: 0, isActive: true }),
+    ]);
+
+    const res = await listGET(new Request("http://localhost/api/treasures?childId=child-1"));
+    const json = await res.json();
+    expect(res.status).toBe(200);
+    expect(json.items).toHaveLength(1);
+    expect(json.items[0].id).toBe("i1");
+    expect(json.plan).toBe("FREE");
   });
 });
 

--- a/src/__tests__/components/parent-treasures-page.test.tsx
+++ b/src/__tests__/components/parent-treasures-page.test.tsx
@@ -37,7 +37,7 @@ describe("親 ごほうび（宝箱）ページ: 家族メンバーの取得", (
       if (url.includes("/api/treasures")) {
         return Promise.resolve({
           ok: true,
-          json: () => Promise.resolve({ items: [] }),
+          json: () => Promise.resolve({ items: [], plan: "PREMIUM" }),
         });
       }
       // 想定外URLは404を返す（バグの再現用）
@@ -99,7 +99,7 @@ describe("親 ごほうび（宝箱）ページ: 家族メンバーの取得", (
       if (url.includes("/api/treasures")) {
         return Promise.resolve({
           ok: true,
-          json: () => Promise.resolve({ items: [] }),
+          json: () => Promise.resolve({ items: [], plan: "PREMIUM" }),
         });
       }
       return Promise.resolve({ ok: false, status: 404, json: () => Promise.resolve({}) });
@@ -131,7 +131,7 @@ describe("親 ごほうび（宝箱）ページ: 家族メンバーの取得", (
       if (url.includes("/api/treasures")) {
         return Promise.resolve({
           ok: true,
-          json: () => Promise.resolve({ items: [] }),
+          json: () => Promise.resolve({ items: [], plan: "PREMIUM" }),
         });
       }
       return Promise.resolve({ ok: false, status: 404, json: () => Promise.resolve({}) });
@@ -145,5 +145,73 @@ describe("親 ごほうび（宝箱）ページ: 家族メンバーの取得", (
     });
     // 「対象の子供」セレクトは廃止
     expect(screen.queryByText("対象の子供")).toBeNull();
+  });
+});
+
+// ─── プランによる「おすすめセットで始める」ボタンの表示制御 (Issue #76) ──
+// 背景: TREASURE_TEMPLATES は20件だが FREE プランの treasure_item 上限は5件。
+// import API は「全部か0か」判定 (checkBulkLimit) のため FREE では必ず403になる。
+// ボタン自体をクライアント側で隠す/無効化することで403に遭遇させない。
+describe("親 ごほうび（宝箱）ページ: プランによるおすすめセットボタンの表示制御", () => {
+  let fetchMock: ReturnType<typeof vi.fn>;
+
+  function mockFetchWithPlan(plan: "FREE" | "PREMIUM") {
+    fetchMock = vi.fn().mockImplementation((url: string) => {
+      if (url.includes("/api/family/code")) {
+        return Promise.resolve({
+          ok: true,
+          json: () =>
+            Promise.resolve({
+              code: "ABC123",
+              members: [{ id: "c1", name: "太郎", role: "CHILD" }],
+            }),
+        });
+      }
+      if (url.includes("/api/treasures")) {
+        return Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve({ items: [], plan }),
+        });
+      }
+      return Promise.resolve({ ok: false, status: 404, json: () => Promise.resolve({}) });
+    });
+    global.fetch = fetchMock as unknown as typeof fetch;
+  }
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("PREMIUM かつ items が0件の場合、おすすめセットで始めるボタンが表示される", async () => {
+    mockFetchWithPlan("PREMIUM");
+    render(<ParentTreasuresPage />);
+
+    await waitFor(() => {
+      const body = document.body.textContent ?? "";
+      expect(body).toMatch(/まだごほうびが登録されていません/);
+    });
+
+    const button = screen.getByRole("button", { name: /おすすめセットで始める/ });
+    expect(button).toBeDefined();
+    expect((button as HTMLButtonElement).disabled).toBe(false);
+  });
+
+  it("FREE かつ items が0件の場合、おすすめセットで始めるボタンが表示されない、または無効化されている", async () => {
+    mockFetchWithPlan("FREE");
+    render(<ParentTreasuresPage />);
+
+    await waitFor(() => {
+      const body = document.body.textContent ?? "";
+      expect(body).toMatch(/まだごほうびが登録されていません/);
+    });
+
+    const button = screen.queryByRole("button", { name: /おすすめセットで始める/ });
+    if (button === null) {
+      // 非表示（推奨）
+      expect(button).toBeNull();
+    } else {
+      // 無効化されている場合も許容
+      expect((button as HTMLButtonElement).disabled).toBe(true);
+    }
   });
 });

--- a/src/app/api/dev/subscription/route.ts
+++ b/src/app/api/dev/subscription/route.ts
@@ -1,0 +1,58 @@
+import { NextResponse } from "next/server";
+import type { NextRequest } from "next/server";
+import { getCurrentUser } from "@/lib/auth";
+import { grantPremiumForE2E } from "@/lib/subscriptionService";
+import { routeLogger } from "@/lib/logger";
+
+/**
+ * e2eテスト専用: 自分の家族のPARENTユーザーにPREMIUMプランを無期限で付与する。
+ *
+ * 本番環境で誤って有効化されると課金回避の穴になるため、二重にガードする。
+ * 1. ALLOW_E2E_SETUP !== "1" の場合は 404 を返し、エンドポイントの存在自体を隠す
+ * 2. x-e2e-setup-secret ヘッダーが E2E_SETUP_SECRET と一致しない場合は 401
+ */
+export async function POST(request: NextRequest) {
+  const rlog = routeLogger("POST", "/api/dev/subscription");
+
+  if (process.env.ALLOW_E2E_SETUP !== "1") {
+    return NextResponse.json({ error: "Not Found" }, { status: 404 });
+  }
+
+  const expectedSecret = process.env.E2E_SETUP_SECRET;
+  const providedSecret = request.headers.get("x-e2e-setup-secret");
+  if (!expectedSecret || providedSecret !== expectedSecret) {
+    rlog.warn("Invalid or missing e2e setup secret");
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const user = await getCurrentUser();
+  if (!user) {
+    return NextResponse.json({ error: "権限がありません" }, { status: 403 });
+  }
+  if (!user.familyId) {
+    return NextResponse.json({ error: "familyIdが必要です" }, { status: 400 });
+  }
+
+  const body = await request.json().catch(() => ({}) as Record<string, unknown>);
+  if (
+    typeof body === "object" &&
+    body !== null &&
+    "familyId" in body &&
+    body.familyId !== undefined &&
+    body.familyId !== user.familyId
+  ) {
+    rlog.warn("Attempted to grant premium for a different family", {
+      familyId: user.familyId,
+    });
+    return NextResponse.json({ error: "他の家族のプランは変更できません" }, { status: 403 });
+  }
+
+  const sub = await grantPremiumForE2E(user.familyId);
+  if (!sub) {
+    rlog.error("PARENT user not found for family", { familyId: user.familyId });
+    return NextResponse.json({ error: "家族にPARENTユーザーが見つかりません" }, { status: 500 });
+  }
+
+  rlog.done("E2E premium plan granted", { familyId: user.familyId });
+  return NextResponse.json({ ok: true, plan: "PREMIUM", currentPeriodEnd: null });
+}

--- a/src/app/api/treasures/route.ts
+++ b/src/app/api/treasures/route.ts
@@ -53,8 +53,10 @@ export async function GET(request: Request) {
     },
   });
 
+  const plan = await getFamilyPlan(user.familyId!);
+
   rlog.info("Treasure pool fetched", { parentId: user.id, childId, count: items.length });
-  return NextResponse.json({ items });
+  return NextResponse.json({ items, plan });
 }
 
 export async function POST(request: Request) {

--- a/src/app/app/parent/(app)/treasures/page.tsx
+++ b/src/app/app/parent/(app)/treasures/page.tsx
@@ -27,6 +27,7 @@ export default function ParentTreasuresPage() {
   const [children, setChildren] = useState<ChildOption[]>([]);
   const [selectedChildId, setSelectedChildId] = useState<string>("");
   const [items, setItems] = useState<PoolItem[]>([]);
+  const [plan, setPlan] = useState<"FREE" | "PREMIUM">("PREMIUM");
   const [loading, setLoading] = useState(true);
   const [newTitle, setNewTitle] = useState("");
   const [newRarity, setNewRarity] = useState<Rarity>("COMMON");
@@ -62,6 +63,7 @@ export default function ParentTreasuresPage() {
       }
       const json = await res.json();
       setItems(json.items ?? []);
+      if (json.plan === "FREE" || json.plan === "PREMIUM") setPlan(json.plan);
     } finally {
       setLoading(false);
     }
@@ -181,13 +183,15 @@ export default function ParentTreasuresPage() {
           <p className="text-sm text-quest-dim mb-3">
             まだごほうびが登録されていません。
           </p>
-          <button
-            type="button"
-            onClick={handleImport}
-            className="bg-quest-gold text-quest-bg py-2.5 px-5 rounded-lg font-bold text-sm"
-          >
-            おすすめセットで始める
-          </button>
+          {plan === "PREMIUM" && (
+            <button
+              type="button"
+              onClick={handleImport}
+              className="bg-quest-gold text-quest-bg py-2.5 px-5 rounded-lg font-bold text-sm"
+            >
+              おすすめセットで始める
+            </button>
+          )}
         </div>
       )}
 

--- a/src/lib/subscriptionService.ts
+++ b/src/lib/subscriptionService.ts
@@ -53,3 +53,21 @@ export async function countActiveTasksForChild(
     },
   });
 }
+
+/// e2eテストセットアップ専用。Family内のPARENTユーザーにPREMIUMプランを無期限で付与する。
+/// `Subscription.userId` が @unique のため、Family単位ではなくPARENTユーザー単位でupsertする。
+/// PARENTが見つからない場合は呼び出し側で500として扱えるよう null を返す。
+export async function grantPremiumForE2E(familyId: string) {
+  const parent = await prisma.user.findFirst({
+    where: { familyId, role: "PARENT" },
+    select: { id: true },
+  });
+  if (!parent) return null;
+
+  const sub = await prisma.subscription.upsert({
+    where: { userId: parent.id },
+    update: { plan: "PREMIUM", currentPeriodEnd: null },
+    create: { userId: parent.id, plan: "PREMIUM", currentPeriodEnd: null },
+  });
+  return sub;
+}


### PR DESCRIPTION
## Summary
- FREE/PREMIUMプラン別にe2eテストを分離するため、PREMIUM付与用のテスト専用API（`ALLOW_E2E_SETUP` + シークレットヘッダの二重ガード付き、未設定時404）を追加
- Playwrightアカウント構成を分離: 既存 `as-parent` を `as-parent-premium` にリネームしPREMIUM化、FREE制限テスト専用の `as-parent-free`/`setup-free`/`auth-free.setup.ts` を新設
- `GET /api/treasures` に `plan` フィールドを追加し、FREEプランでは「おすすめセットで始める」ボタンをクライアント側で非表示化（APIの「全部か0か」判定ロジック自体は既存決定を尊重し変更なし）
- 新規 `e2e/s26-plan-free-limits.spec.ts`（FREE上限の「できないこと」検証）、`s9-child-management.spec.ts` の有効化（PREMIUM前提の作成・削除テスト）、`s22-parent-treasures.spec.ts` への子供2人以上の切替UI検証を追加

Closes #76

## 未検証事項（マージ前に要対応）

1. **develop環境のVercelに `ALLOW_E2E_SETUP` / `E2E_SETUP_SECRET` がまだ設定されていません。** そのためフェーズ1のPREMIUM付与APIは実際には動作確認できていません（コード側はfail-fast設計で、未設定時に正しくエラーを返すことのみ確認済みです）。**マージ前にリポジトリ管理者がVercelの環境変数を設定する必要があります。**
2. develop未マージのため、フェーズ3・4の一部（「おすすめセット」非表示テスト、PREMIUM系テスト）はdevelop環境のVercelプレビューに対して未検証です。code-reviewerは「PRプレビュー環境に対してe2eを再実行し緑になることをマージ前に確認することを推奨」としています。

## Test plan
- [x] `npm test` パス（185ファイル / 2579テスト、全フェーズ通じてリグレッションなし）
- [x] `npx tsc --noEmit` パス
- [x] `eslint` パス
- [x] 全4フェーズで code-reviewer が APPROVED
- [ ] Vercel環境変数設定後、PRプレビュー環境でe2e再実行して緑を確認（マージ前必須）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
