### PR TITLE
ci(e2e): PRごとのVercelプレビューでPlaywright E2Eを自動実行

### DIFF
--- a/.env.test.example
+++ b/.env.test.example
@@ -20,3 +20,13 @@ ALLOW_E2E_SETUP=1
 # 対象環境側の E2E_SETUP_SECRET と同じ値を設定すること。任意の推測困難な文字列でよい。
 # こちらも本番環境では絶対に設定しないこと。
 E2E_SETUP_SECRET=your_e2e_setup_secret_here
+
+# --- CI（GitHub Actions）での自動注入について ---
+# 上記はローカルで .env.test を作る開発者向けの説明。CI では .env.test は使わず、
+# .github/workflows/pr-tests.yml の e2e ジョブが以下を実行時の環境変数として直接注入する。
+# ローカルの .env.test に書く値と同じものを GitHub Secrets に登録しておくこと。
+#   - E2E_BASE_URL          … patrickedqvist/wait-for-vercel-preview の出力（PRごとのプレビューURL）
+#   - VERCEL_BYPASS_SECRET  … secrets.VERCEL_BYPASS_SECRET
+#   - E2E_SETUP_SECRET      … secrets.E2E_SETUP_SECRET
+# ALLOW_E2E_SETUP は CI 側では設定しない（Vercel プレビュー環境側の環境変数として
+# 人間が別途 Vercel ダッシュボードで設定済みのものを使う。GitHub Actions 側には不要）。

--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -9,6 +9,36 @@ permissions:
   pull-requests: write
 
 jobs:
+  # UI 関連パス（src/app, src/components, src/hooks, e2e, playwright.config.ts）が
+  # 変更されたかどうかを判定する。e2e ジョブだけを対象にした条件分岐に使う。
+  #
+  # 注意: `on.pull_request.paths` をワークフロー全体のトリガーに付けてしまうと、
+  # 対象外パスのみの変更ではワークフロー自体が起動せず check run が作られないため、
+  # required check に指定した場合に PR が永久に pending となりマージ不能になる
+  # （詳細は Issue #74 参照）。そのため paths フィルタは dorny/paths-filter を使い
+  # e2e ジョブの `if` 条件としてジョブ単位で適用し、unit/lint は無条件のまま維持する。
+  # 対象外の場合 e2e ジョブは "skipped" 扱いになり、required check にしても pending
+  # のままにはならない。
+  changes:
+    name: Detect UI path changes
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
+    outputs:
+      ui: ${{ steps.filter.outputs.ui }}
+    steps:
+      - name: Filter changed paths
+        id: filter
+        uses: dorny/paths-filter@ceb8a2b8f2d89434be7ff52d3de7ec3738c5cc9d # v4.0.3
+        with:
+          filters: |
+            ui:
+              - "src/app/**"
+              - "src/components/**"
+              - "src/hooks/**"
+              - "e2e/**"
+              - "playwright.config.ts"
+
   unit:
     name: Unit tests
     runs-on: ubuntu-latest
@@ -56,3 +86,66 @@ jobs:
       - run: npm ci
       - name: Run ESLint
         run: npm run lint -- --max-warnings=0
+
+  e2e:
+    name: E2E tests (Vercel preview)
+    needs: changes
+    runs-on: ubuntu-latest
+    # Stage 1: non-blocking. Do not add this job to branch protection required
+    # checks yet — E2E depends on external factors (Vercel build time, shared
+    # Supabase DB, network) and is more prone to flakiness than unit/lint.
+    # Promote to a required check only after confirming stability (see #74).
+    if: >
+      needs.changes.outputs.ui == 'true' &&
+      github.event.pull_request.draft == false &&
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      github.actor != 'dependabot[bot]'
+    concurrency:
+      group: e2e-${{ github.event.pull_request.number }}
+      cancel-in-progress: true
+    timeout-minutes: 20
+    permissions:
+      contents: read
+      deployments: read
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Wait for Vercel preview deployment
+        id: wait-for-vercel-preview
+        uses: patrickedqvist/wait-for-vercel-preview@d7982701e6fcd3ae073bff929e408e004404d38d # v1.3.3
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          max_timeout: 600
+          vercel_protection_bypass_header: ${{ secrets.VERCEL_BYPASS_SECRET }}
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: npm
+
+      - run: npm ci
+      - name: Install Playwright browsers
+        run: npx playwright install --with-deps chromium
+
+      - name: Run Playwright E2E tests
+        env:
+          E2E_BASE_URL: ${{ steps.wait-for-vercel-preview.outputs.url }}
+          VERCEL_BYPASS_SECRET: ${{ secrets.VERCEL_BYPASS_SECRET }}
+          E2E_SETUP_SECRET: ${{ secrets.E2E_SETUP_SECRET }}
+        run: npx playwright test --reporter=github
+
+      - name: Upload Playwright report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: playwright-report/
+          retention-days: 7
+
+      - name: Upload Playwright test results (traces/videos)
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-test-results
+          path: test-results/
+          retention-days: 7

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -2694,3 +2694,30 @@
 - `src/__tests__/helpers/prisma-mock.ts` — 新規。型付きアクセサ `prismaMock`
 - `tsconfig.json` — `compilerOptions.types` に `"vitest/globals"` を追加
 
+## 2026-08-14: PRごとのVercelプレビュー環境でPlaywright E2Eを自動実行する。UI関連パス変更時のみ・non-blocking運用で開始（Issue #74）
+
+### 決定内容
+- `.github/workflows/pr-tests.yml` に `e2e` ジョブを追加した。`unit`/`lint` とは独立した並列ジョブで、`patrickedqvist/wait-for-vercel-preview`（コミット SHA ピン留め、`v1.3.3` 相当）で PR プレビューのデプロイ完了を待ち、`environment_url` を `E2E_BASE_URL` として `npx playwright test --reporter=github` に渡す
+- UI 関連パス（`src/app/**` / `src/components/**` / `src/hooks/**` / `e2e/**` / `playwright.config.ts`）の変更時のみ実行する。ただし `on.pull_request.paths` をワークフロー全体のトリガーに追加する素朴な実装は採らず、`dorny/paths-filter`（コミット SHA ピン留め、`v4.0.3` 相当）で判定した結果を `changes` ジョブの output にし、`e2e` ジョブの `if` 条件として使う設計にした
+- フォーク PR・Dependabot PR・Draft PR ではジョブ自体をスキップする（`unit` ジョブの coverage レポートステップと同じ条件パターンに `draft == false` を追加）
+- `concurrency: group: e2e-${{ github.event.pull_request.number }}, cancel-in-progress: true` で同一 PR の古い実行をキャンセルし、`timeout-minutes: 20` でランナー占有を防ぐ
+- `continue-on-error: true` は使わない。Stage 1（本 Issue）では branch protection の required checks に `e2e` を含めないことで non-blocking を実現し、ワークフロー自体は赤/緑がそのまま見える状態にする
+- `playwright-report/` と `test-results/`（trace・video を含む）を `if: always()` で artifact アップロードする（`retention-days: 7`）
+- `playwright.config.ts` の `reporter` を `process.env.CI` で `"github"` / `"html"` に分岐した
+- `.env.test.example` に CI 側（GitHub Actions）で自動注入される環境変数（`E2E_BASE_URL` / `VERCEL_BYPASS_SECRET` / `E2E_SETUP_SECRET`）を追記した。`ALLOW_E2E_SETUP` は Vercel プレビュー環境側に人間が別途設定済みのため GitHub Actions 側では注入しない
+
+### `paths` フィルタをワークフロートリガーではなくジョブ単位にした理由
+- Issue #74 の初期案どおり `on.pull_request.paths` に UI 関連パスを設定すると、`src/lib/**` のみの変更ではワークフロー自体が起動せず check run が作られない。この場合 `unit`/`lint` も含めてワークフロー全体が対象外になってしまい、「UI 以外の変更でもユニットテストは必ず走る」という既存の前提を壊す
+- `e2e` ジョブだけを対象外にしたいので、`dorny/paths-filter` の出力を使い `e2e` ジョブの `if` 条件として評価する形にした。この場合パス不一致時は `e2e` ジョブが "skipped" 扱いになるだけで `unit`/`lint` には影響しない。required check にした場合も "skipped" は "success" 扱いになるため、Issue 本文が指摘していた「required check が永久に pending になる」問題も同時に回避できる
+
+### やってはいけないこと
+- `on.pull_request.paths` をこのワークフローファイル全体のトリガーに追加し、`unit`/`lint` も含めて UI パス変更時のみに限定する
+- サードパーティアクション（`wait-for-vercel-preview` / `paths-filter`）をバージョンタグ（`@v1.3.3` 等）のまま参照する。必ずコミット SHA をピン留めする
+- `continue-on-error: true` で失敗を隠す。non-blocking は required checks 側の設定で実現する
+- `e2e` ジョブを Stage 1 の段階で branch protection の required checks に追加する（flaky 実績を確認してから Stage 2 で昇格する）
+
+### 該当箇所
+- `.github/workflows/pr-tests.yml` — `changes` ジョブ（paths-filter）と `e2e` ジョブを追加
+- `playwright.config.ts` — `reporter` を CI/ローカルで分岐
+- `.env.test.example` — CI 側の自動注入変数を追記
+

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -13,7 +13,9 @@ export default defineConfig({
   forbidOnly: !!process.env.CI,
   retries: process.env.CI ? 1 : 0,
   workers: 1,
-  reporter: "html",
+  // CI では GitHub Actions のログに直接アノテーションを出す "github" reporter を使い、
+  // ローカルでは従来どおり "html" レポートを生成する。
+  reporter: process.env.CI ? "github" : "html",
   use: {
     baseURL,
     trace: "on-first-retry",


### PR DESCRIPTION
## Summary
- `.github/workflows/pr-tests.yml` に `changes`（dorny/paths-filterでUI関連パス変更を判定、SHAピン留め）と `e2e`（wait-for-vercel-previewでVercelプレビューURL取得後Playwright実行、SHAピン留め）の2ジョブを追加。フォークPR/Dependabot PR/Draft PRはスキップ、`concurrency`グループ設定、`timeout-minutes: 20`
- `playwright.config.ts` の reporter を `process.env.CI` で `"github"`/`"html"` に分岐
- `.env.test.example` にCI側で自動注入される環境変数の説明を追記

## Test plan
- [x] `npm run test:coverage` パス（185 test files / 2579 tests 全green）
- [x] `npm run lint -- --max-warnings=0` パス（0 errors/0 warnings）
- [x] YAML構文検証済み
- [ ] 実際のPRでVercelプレビュー環境上でのE2Eジョブ実行を確認（本PRのCI実行で確認）

## Related decision
- `docs/decisions.md#2026-08-14`（PRごとのVercelプレビュー環境でPlaywright E2Eを自動実行する。UI関連パス変更時のみ・non-blocking運用で開始）

Closes #74

🤖 Generated with [Claude Code](https://claude.com/claude-code)
