### PR TITLE
fix(e2e): s23のisVisible()スナップショット判定によるflaky失敗を修正

### DIFF
--- a/e2e/s23-parent-treasures-pending.spec.ts
+++ b/e2e/s23-parent-treasures-pending.spec.ts
@@ -38,6 +38,9 @@ test.describe("S23: 親 もらった履歴（渡したよチェック）", () =>
 
   test("履歴行があれば「渡した」または「取り消し」ボタンが表示される", async ({ page }) => {
     const empty = page.getByText("まだもらったごほうびはありません。");
+    const anyRow = page.locator("li").filter({ hasText: /渡し済み|まだ渡してない/ });
+    await expect(empty.or(anyRow.first())).toBeVisible({ timeout: 10000 });
+
     if (await empty.isVisible()) {
       test.skip(true, "履歴が空のためスキップ");
       return;


### PR DESCRIPTION
## Summary
- `e2e/s23-parent-treasures-pending.spec.ts` の「履歴行があれば「渡した」または「取り消し」ボタンが表示される」テストで、`isVisible()` による即時スナップショット判定の前にリトライ付き待機（`expect(empty.or(anyRow.first())).toBeVisible({ timeout: 10000 })`）を追加
- 非同期データフェッチ完了前の誤判定によるflaky失敗（PR #80のCI初回実行で発生）を修正
- 変更は当該1ファイルのみ

Closes #81

## Test plan
- [x] `npm run lint` パス
- [x] `npm test` パス（185 test files / 2579 tests, 全green。このE2Eスペック修正自体はvitest対象外）
- [ ] CI上のe2eジョブでの実動作確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)
