### PR TITLE
feat(monster): 図鑑をテーマ別タブに対応させる（Issue #86 / Stage3）

### DIFF
--- a/src/__tests__/api/monster/monster-status.test.ts
+++ b/src/__tests__/api/monster/monster-status.test.ts
@@ -171,4 +171,19 @@ describe("GET /api/monster-status", () => {
       }),
     );
   });
+
+  // ─── Issue #86: 図鑑（Zukan）のテーマ別タブ対応 ──────────────────────
+  // EggSelectionModal のテーマ卵画像表示に monsterSetId（現在有効なテーマ）が必要になった。
+  it("レスポンスに現在のmonsterSetIdを含めること", async () => {
+    mockGetCurrentUser.mockResolvedValue(
+      childUserWithFamily({ monsterSetId: "buddha" }),
+    );
+    mockPrisma.questInstance.findMany.mockResolvedValue([]);
+    mockPrisma.streak.findUnique.mockResolvedValue(null);
+
+    const res = await GET();
+    const json = await res.json();
+
+    expect(json.monsterSetId).toBe("buddha");
+  });
 });

--- a/src/__tests__/api/monster/monster.test.ts
+++ b/src/__tests__/api/monster/monster.test.ts
@@ -164,7 +164,7 @@ describe("GET /api/monster", () => {
       expect(json.ownedThemes).toHaveLength(3);
     });
 
-    it("ChildMonsterThemeに記録が無いテーマ（一度も有効化されていない）はownedThemesに含まれないこと", async () => {
+    it("isFree:falseのテーマ（buddha）は、ChildMonsterThemeにレコードが無く現在テーマでもない場合はownedThemesに含まれないこと（回帰確認）", async () => {
       mockGetCurrentUser.mockResolvedValue(
         childUserWithFamily({ monsterSetId: "dark" }),
       );
@@ -176,12 +176,10 @@ describe("GET /api/monster", () => {
       const res = await GET();
       const json = await res.json();
 
-      expect(json.ownedThemes).toEqual(["dark"]);
       expect(json.ownedThemes).not.toContain("buddha");
-      expect(json.ownedThemes).not.toContain("light");
     });
 
-    it("境界値: 所持テーマの記録が1件も無い場合、ownedThemesは空配列を返すこと", async () => {
+    it("isFree:trueのテーマ（dark, light）はChildMonsterThemeにレコードが無くてもownedThemesに含まれること", async () => {
       mockGetCurrentUser.mockResolvedValue(
         childUserWithFamily({ monsterSetId: "dark" }),
       );
@@ -191,7 +189,41 @@ describe("GET /api/monster", () => {
       const res = await GET();
       const json = await res.json();
 
-      expect(json.ownedThemes).toEqual([]);
+      expect(json.ownedThemes.slice().sort()).toEqual(["dark", "light"]);
+      expect(json.ownedThemes).not.toContain("buddha");
+    });
+
+    it("現在のmonsterSetId（レコードがまだ無いケース）はisFree:falseのテーマでもownedThemesに含まれること", async () => {
+      // 移行直後など、monsterSetId は buddha だが ChildMonsterTheme レコードがまだ
+      // 作成されていないケースを想定。
+      mockGetCurrentUser.mockResolvedValue(
+        childUserWithFamily({ monsterSetId: "buddha" }),
+      );
+      mockPrisma.questInstance.findMany.mockResolvedValue([]);
+      mockPrisma.childMonsterTheme.findMany.mockResolvedValue([]);
+
+      const res = await GET();
+      const json = await res.json();
+
+      expect(json.ownedThemes).toContain("buddha");
+      expect(json.ownedThemes.slice().sort()).toEqual(["buddha", "dark", "light"]);
+    });
+
+    it("境界値: dark→light切替済みでChildMonsterThemeにlightのレコードのみある場合でも、dark（無料テーマ）とlightの両方がownedThemesに含まれること", async () => {
+      mockGetCurrentUser.mockResolvedValue(
+        childUserWithFamily({ monsterSetId: "light" }),
+      );
+      mockPrisma.questInstance.findMany.mockResolvedValue([]);
+      mockPrisma.childMonsterTheme.findMany.mockResolvedValue([
+        { id: "cmt-1", childId: "child-1", themeId: "light", activatedAt: new Date("2026-03-01"), grantReason: "switch" },
+      ]);
+
+      const res = await GET();
+      const json = await res.json();
+
+      expect(json.ownedThemes).toContain("dark");
+      expect(json.ownedThemes).toContain("light");
+      expect(json.ownedThemes.slice().sort()).toEqual(["dark", "light"]);
     });
 
     it("ChildMonsterThemeの検索はログイン中の子供のchildIdで絞り込むこと", async () => {

--- a/src/__tests__/api/monster/monster.test.ts
+++ b/src/__tests__/api/monster/monster.test.ts
@@ -120,4 +120,94 @@ describe("GET /api/monster", () => {
       include: { template: true },
     });
   });
+
+  // ─── Issue #86: 図鑑（Zukan）のテーマ別タブ対応 ──────────────────────
+  // レスポンスに以下の2フィールドを追加する（未実装）。
+  //   - monsterSetId: string        … 現在有効なテーマ（User.monsterSetId をそのまま返す）
+  //   - ownedThemes: string[]       … ChildMonsterTheme に記録がある themeId の一覧
+  //     （monsterSetId 単体では判定しない。過去に切り替えた履歴があるテーマは全て含む）
+  describe("モンスターテーマ（Issue #86: 図鑑のテーマ別タブ対応）", () => {
+    it("現在のmonsterSetIdと所持テーマ一覧(ownedThemes)を返すこと", async () => {
+      mockGetCurrentUser.mockResolvedValue(
+        childUserWithFamily({ monsterSetId: "light" }),
+      );
+      mockPrisma.questInstance.findMany.mockResolvedValue([]);
+      mockPrisma.childMonsterTheme.findMany.mockResolvedValue([
+        { id: "cmt-1", childId: "child-1", themeId: "dark", activatedAt: new Date("2026-01-01"), grantReason: "default" },
+        { id: "cmt-2", childId: "child-1", themeId: "light", activatedAt: new Date("2026-02-01"), grantReason: "default" },
+      ]);
+
+      const res = await GET();
+      const json = await res.json();
+
+      expect(json.monsterSetId).toBe("light");
+      expect(json.ownedThemes.slice().sort()).toEqual(["dark", "light"]);
+    });
+
+    it("複数テーマを過去に切り替えた履歴がある場合、現在のmonsterSetIdに関わらず全テーマがownedThemesに含まれること", async () => {
+      // dark → buddha → light と切り替えた履歴を想定。現在は light だが、
+      // ownedThemes は monsterSetId 単体ではなく ChildMonsterTheme の記録で決まる。
+      mockGetCurrentUser.mockResolvedValue(
+        childUserWithFamily({ monsterSetId: "light" }),
+      );
+      mockPrisma.questInstance.findMany.mockResolvedValue([]);
+      mockPrisma.childMonsterTheme.findMany.mockResolvedValue([
+        { id: "cmt-1", childId: "child-1", themeId: "dark", activatedAt: new Date("2026-01-01"), grantReason: "default" },
+        { id: "cmt-2", childId: "child-1", themeId: "buddha", activatedAt: new Date("2026-02-01"), grantReason: "purchase" },
+        { id: "cmt-3", childId: "child-1", themeId: "light", activatedAt: new Date("2026-03-01"), grantReason: "switch" },
+      ]);
+
+      const res = await GET();
+      const json = await res.json();
+
+      expect(json.ownedThemes.slice().sort()).toEqual(["buddha", "dark", "light"]);
+      expect(json.ownedThemes).toHaveLength(3);
+    });
+
+    it("ChildMonsterThemeに記録が無いテーマ（一度も有効化されていない）はownedThemesに含まれないこと", async () => {
+      mockGetCurrentUser.mockResolvedValue(
+        childUserWithFamily({ monsterSetId: "dark" }),
+      );
+      mockPrisma.questInstance.findMany.mockResolvedValue([]);
+      mockPrisma.childMonsterTheme.findMany.mockResolvedValue([
+        { id: "cmt-1", childId: "child-1", themeId: "dark", activatedAt: new Date("2026-01-01"), grantReason: "default" },
+      ]);
+
+      const res = await GET();
+      const json = await res.json();
+
+      expect(json.ownedThemes).toEqual(["dark"]);
+      expect(json.ownedThemes).not.toContain("buddha");
+      expect(json.ownedThemes).not.toContain("light");
+    });
+
+    it("境界値: 所持テーマの記録が1件も無い場合、ownedThemesは空配列を返すこと", async () => {
+      mockGetCurrentUser.mockResolvedValue(
+        childUserWithFamily({ monsterSetId: "dark" }),
+      );
+      mockPrisma.questInstance.findMany.mockResolvedValue([]);
+      mockPrisma.childMonsterTheme.findMany.mockResolvedValue([]);
+
+      const res = await GET();
+      const json = await res.json();
+
+      expect(json.ownedThemes).toEqual([]);
+    });
+
+    it("ChildMonsterThemeの検索はログイン中の子供のchildIdで絞り込むこと", async () => {
+      mockGetCurrentUser.mockResolvedValue(
+        childUserWithFamily({ id: "child-99", monsterSetId: "dark" }),
+      );
+      mockPrisma.questInstance.findMany.mockResolvedValue([]);
+      mockPrisma.childMonsterTheme.findMany.mockResolvedValue([]);
+
+      await GET();
+
+      expect(mockPrisma.childMonsterTheme.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({ childId: "child-99" }),
+        }),
+      );
+    });
+  });
 });

--- a/src/__tests__/api/parent/child-view/monster.test.ts
+++ b/src/__tests__/api/parent/child-view/monster.test.ts
@@ -66,4 +66,95 @@ describe("GET /api/parent/child-view/monster", () => {
     expect(json.monsterLevels).toBe('{"STUDY_STUDY_STUDY":2}');
     expect(json.usedEggBonuses).toBe('["STUDY"]');
   });
+
+  // ─── Issue #86: 図鑑（Zukan）のテーマ別タブ対応 ──────────────────────
+  // 親代理ビューの ZukanContent 再利用に monsterSetId / ownedThemes が必要。
+  // /api/monster（子供本人用）に追加済みの5件のテストと同水準のカバレッジを移植する。
+  describe("モンスターテーマ（Issue #86: 図鑑のテーマ別タブ対応）", () => {
+    it("現在のmonsterSetIdと所持テーマ一覧(ownedThemes)を返すこと", async () => {
+      mockGetCurrentUser.mockResolvedValue(parentUserWithFamily());
+      mockPrisma.user.findFirst.mockResolvedValue(
+        childUser({ id: "child-1", monsterSetId: "light" }),
+      );
+      mockPrisma.questInstance.findMany.mockResolvedValue([]);
+      mockPrisma.childMonsterTheme.findMany.mockResolvedValue([
+        { id: "cmt-1", childId: "child-1", themeId: "dark", activatedAt: new Date("2026-01-01"), grantReason: "default" },
+        { id: "cmt-2", childId: "child-1", themeId: "light", activatedAt: new Date("2026-02-01"), grantReason: "default" },
+      ]);
+
+      const res = await GET(makeReq("child-1"));
+      const json = await res.json();
+
+      expect(json.monsterSetId).toBe("light");
+      expect(json.ownedThemes.slice().sort()).toEqual(["dark", "light"]);
+    });
+
+    it("複数テーマを過去に切り替えた履歴がある場合、現在のmonsterSetIdに関わらず全テーマがownedThemesに含まれること", async () => {
+      mockGetCurrentUser.mockResolvedValue(parentUserWithFamily());
+      mockPrisma.user.findFirst.mockResolvedValue(
+        childUser({ id: "child-1", monsterSetId: "light" }),
+      );
+      mockPrisma.questInstance.findMany.mockResolvedValue([]);
+      mockPrisma.childMonsterTheme.findMany.mockResolvedValue([
+        { id: "cmt-1", childId: "child-1", themeId: "dark", activatedAt: new Date("2026-01-01"), grantReason: "default" },
+        { id: "cmt-2", childId: "child-1", themeId: "buddha", activatedAt: new Date("2026-02-01"), grantReason: "purchase" },
+        { id: "cmt-3", childId: "child-1", themeId: "light", activatedAt: new Date("2026-03-01"), grantReason: "switch" },
+      ]);
+
+      const res = await GET(makeReq("child-1"));
+      const json = await res.json();
+
+      expect(json.ownedThemes.slice().sort()).toEqual(["buddha", "dark", "light"]);
+      expect(json.ownedThemes).toHaveLength(3);
+    });
+
+    it("ChildMonsterThemeに記録が無いテーマ（一度も有効化されていない）はownedThemesに含まれないこと", async () => {
+      mockGetCurrentUser.mockResolvedValue(parentUserWithFamily());
+      mockPrisma.user.findFirst.mockResolvedValue(
+        childUser({ id: "child-1", monsterSetId: "dark" }),
+      );
+      mockPrisma.questInstance.findMany.mockResolvedValue([]);
+      mockPrisma.childMonsterTheme.findMany.mockResolvedValue([
+        { id: "cmt-1", childId: "child-1", themeId: "dark", activatedAt: new Date("2026-01-01"), grantReason: "default" },
+      ]);
+
+      const res = await GET(makeReq("child-1"));
+      const json = await res.json();
+
+      expect(json.ownedThemes).toEqual(["dark"]);
+      expect(json.ownedThemes).not.toContain("buddha");
+      expect(json.ownedThemes).not.toContain("light");
+    });
+
+    it("境界値: 所持テーマの記録が1件も無い場合、ownedThemesは空配列を返すこと", async () => {
+      mockGetCurrentUser.mockResolvedValue(parentUserWithFamily());
+      mockPrisma.user.findFirst.mockResolvedValue(
+        childUser({ id: "child-1", monsterSetId: "dark" }),
+      );
+      mockPrisma.questInstance.findMany.mockResolvedValue([]);
+      mockPrisma.childMonsterTheme.findMany.mockResolvedValue([]);
+
+      const res = await GET(makeReq("child-1"));
+      const json = await res.json();
+
+      expect(json.ownedThemes).toEqual([]);
+    });
+
+    it("ChildMonsterThemeの検索は対象の子供のchildIdで絞り込むこと", async () => {
+      mockGetCurrentUser.mockResolvedValue(parentUserWithFamily());
+      mockPrisma.user.findFirst.mockResolvedValue(
+        childUser({ id: "child-99", monsterSetId: "dark" }),
+      );
+      mockPrisma.questInstance.findMany.mockResolvedValue([]);
+      mockPrisma.childMonsterTheme.findMany.mockResolvedValue([]);
+
+      await GET(makeReq("child-99"));
+
+      expect(mockPrisma.childMonsterTheme.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({ childId: "child-99" }),
+        }),
+      );
+    });
+  });
 });

--- a/src/__tests__/api/parent/child-view/monster.test.ts
+++ b/src/__tests__/api/parent/child-view/monster.test.ts
@@ -108,7 +108,7 @@ describe("GET /api/parent/child-view/monster", () => {
       expect(json.ownedThemes).toHaveLength(3);
     });
 
-    it("ChildMonsterThemeに記録が無いテーマ（一度も有効化されていない）はownedThemesに含まれないこと", async () => {
+    it("isFree:falseのテーマ（buddha）は、ChildMonsterThemeにレコードが無く現在テーマでもない場合はownedThemesに含まれないこと（回帰確認）", async () => {
       mockGetCurrentUser.mockResolvedValue(parentUserWithFamily());
       mockPrisma.user.findFirst.mockResolvedValue(
         childUser({ id: "child-1", monsterSetId: "dark" }),
@@ -121,12 +121,10 @@ describe("GET /api/parent/child-view/monster", () => {
       const res = await GET(makeReq("child-1"));
       const json = await res.json();
 
-      expect(json.ownedThemes).toEqual(["dark"]);
       expect(json.ownedThemes).not.toContain("buddha");
-      expect(json.ownedThemes).not.toContain("light");
     });
 
-    it("境界値: 所持テーマの記録が1件も無い場合、ownedThemesは空配列を返すこと", async () => {
+    it("isFree:trueのテーマ（dark, light）はChildMonsterThemeにレコードが無くてもownedThemesに含まれること", async () => {
       mockGetCurrentUser.mockResolvedValue(parentUserWithFamily());
       mockPrisma.user.findFirst.mockResolvedValue(
         childUser({ id: "child-1", monsterSetId: "dark" }),
@@ -137,7 +135,41 @@ describe("GET /api/parent/child-view/monster", () => {
       const res = await GET(makeReq("child-1"));
       const json = await res.json();
 
-      expect(json.ownedThemes).toEqual([]);
+      expect(json.ownedThemes.slice().sort()).toEqual(["dark", "light"]);
+      expect(json.ownedThemes).not.toContain("buddha");
+    });
+
+    it("現在のmonsterSetId（レコードがまだ無いケース）はisFree:falseのテーマでもownedThemesに含まれること", async () => {
+      mockGetCurrentUser.mockResolvedValue(parentUserWithFamily());
+      mockPrisma.user.findFirst.mockResolvedValue(
+        childUser({ id: "child-1", monsterSetId: "buddha" }),
+      );
+      mockPrisma.questInstance.findMany.mockResolvedValue([]);
+      mockPrisma.childMonsterTheme.findMany.mockResolvedValue([]);
+
+      const res = await GET(makeReq("child-1"));
+      const json = await res.json();
+
+      expect(json.ownedThemes).toContain("buddha");
+      expect(json.ownedThemes.slice().sort()).toEqual(["buddha", "dark", "light"]);
+    });
+
+    it("境界値: dark→light切替済みでChildMonsterThemeにlightのレコードのみある場合でも、dark（無料テーマ）とlightの両方がownedThemesに含まれること", async () => {
+      mockGetCurrentUser.mockResolvedValue(parentUserWithFamily());
+      mockPrisma.user.findFirst.mockResolvedValue(
+        childUser({ id: "child-1", monsterSetId: "light" }),
+      );
+      mockPrisma.questInstance.findMany.mockResolvedValue([]);
+      mockPrisma.childMonsterTheme.findMany.mockResolvedValue([
+        { id: "cmt-1", childId: "child-1", themeId: "light", activatedAt: new Date("2026-03-01"), grantReason: "switch" },
+      ]);
+
+      const res = await GET(makeReq("child-1"));
+      const json = await res.json();
+
+      expect(json.ownedThemes).toContain("dark");
+      expect(json.ownedThemes).toContain("light");
+      expect(json.ownedThemes.slice().sort()).toEqual(["dark", "light"]);
     });
 
     it("ChildMonsterThemeの検索は対象の子供のchildIdで絞り込むこと", async () => {

--- a/src/__tests__/components/egg-selection-modal-theme.test.tsx
+++ b/src/__tests__/components/egg-selection-modal-theme.test.tsx
@@ -1,0 +1,100 @@
+// @vitest-environment jsdom
+//
+// Issue #86: 図鑑（Zukan）のテーマ別タブ対応 — EggSelectionModal のテーマ対応
+// 対象: src/components/child/EggSelectionModal.tsx（未実装。現状は `side` prop で
+// "/monsters/light/egg.webp" | "/monsters/dark/egg.webp" をハードコード分岐している）
+//
+// 期待するUI契約（implementer 実装時の参照用）:
+//  - `side` prop を `monsterSetId: string | null` に置き換える
+//  - 「ふつうの卵」(NORMAL) の画像は @/lib/monsterThemes/index の
+//    MONSTER_THEMES[monsterSetId].eggImage を使う
+//  - monsterSetId が null、または MONSTER_THEMES に存在しないキーの場合は
+//    既定の dark テーマ（MONSTER_THEMES.dark.eggImage）にフォールバックする
+//    （@/lib/monsters.ts の getMonsterStage と同じフォールバック規約）
+//  - STUDY/STAMINA/LIFE ボーナス卵の画像はテーマ非依存のまま変更しない
+//
+// 実装がまだ存在しないため、これらのテストはすべて Red（失敗）になる想定。
+
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import { describe, it, expect, vi } from "vitest";
+
+vi.mock("next/image", () => ({
+  default: ({ src, alt }: { src: string; alt?: string }) =>
+    React.createElement("img", { src, alt }),
+}));
+
+import EggSelectionModal from "@/components/child/EggSelectionModal";
+import { MONSTER_THEMES } from "@/lib/monsterThemes/index";
+
+describe("EggSelectionModal: 現在のテーマの卵画像を表示すること（Issue #86）", () => {
+  it("monsterSetId='dark' の場合、ふつうの卵はdarkテーマの卵画像であること", () => {
+    render(
+      <EggSelectionModal
+        monsterSetId="dark"
+        loading={false}
+        onSelect={vi.fn()}
+        onCancel={vi.fn()}
+      />,
+    );
+
+    const img = screen.getByAltText("ふつうの卵") as HTMLImageElement;
+    expect(img.getAttribute("src")).toBe(MONSTER_THEMES.dark.eggImage);
+  });
+
+  it("monsterSetId='light' の場合、ふつうの卵はlightテーマの卵画像であること", () => {
+    render(
+      <EggSelectionModal
+        monsterSetId="light"
+        loading={false}
+        onSelect={vi.fn()}
+        onCancel={vi.fn()}
+      />,
+    );
+
+    const img = screen.getByAltText("ふつうの卵") as HTMLImageElement;
+    expect(img.getAttribute("src")).toBe(MONSTER_THEMES.light.eggImage);
+  });
+
+  it("monsterSetId='buddha' の場合、ふつうの卵はbuddhaテーマの卵画像であること", () => {
+    render(
+      <EggSelectionModal
+        monsterSetId="buddha"
+        loading={false}
+        onSelect={vi.fn()}
+        onCancel={vi.fn()}
+      />,
+    );
+
+    const img = screen.getByAltText("ふつうの卵") as HTMLImageElement;
+    expect(img.getAttribute("src")).toBe(MONSTER_THEMES.buddha.eggImage);
+  });
+
+  it("境界値: monsterSetIdがnullの場合、既定のdarkテーマの卵画像にフォールバックすること", () => {
+    render(
+      <EggSelectionModal
+        monsterSetId={null}
+        loading={false}
+        onSelect={vi.fn()}
+        onCancel={vi.fn()}
+      />,
+    );
+
+    const img = screen.getByAltText("ふつうの卵") as HTMLImageElement;
+    expect(img.getAttribute("src")).toBe(MONSTER_THEMES.dark.eggImage);
+  });
+
+  it("境界値: monsterSetIdが未知のテーマIDの場合、既定のdarkテーマの卵画像にフォールバックすること", () => {
+    render(
+      <EggSelectionModal
+        monsterSetId="nonexistent-theme"
+        loading={false}
+        onSelect={vi.fn()}
+        onCancel={vi.fn()}
+      />,
+    );
+
+    const img = screen.getByAltText("ふつうの卵") as HTMLImageElement;
+    expect(img.getAttribute("src")).toBe(MONSTER_THEMES.dark.eggImage);
+  });
+});

--- a/src/__tests__/components/zukan-content-themes.test.tsx
+++ b/src/__tests__/components/zukan-content-themes.test.tsx
@@ -166,9 +166,11 @@ describe("ZukanContent: テーマ別タブ対応（Issue #86）", () => {
   it("テーマ切替でアクティブタブのパネルがテーマ固有のモンスター表に切り替わること", async () => {
     // STUDY を収集済みとし、dark タブでは「ラーン」、buddha タブでは「文殊丸」が
     // 表示されることを確認する（テーマごとに異なる画像・名前を持つ実データを利用）。
+    // collectedPaths はテーマ名前空間付き（"{themeId}:{path}"）で dark/buddha それぞれの
+    // 記録を持たせる（PR #89 Codexレビュー指摘1対応後の正しい形式）。
     mockFetchOnce({
       side: "DARK",
-      collectedPaths: '["STUDY"]',
+      collectedPaths: '["dark:STUDY","buddha:STUDY"]',
       monsterLevels: "{}",
       usedEggBonuses: "[]",
       monsterSetId: "dark",
@@ -206,5 +208,96 @@ describe("ZukanContent: テーマ別タブ対応（Issue #86）", () => {
     expect(img.getAttribute("src")).toBe(
       "/monsters/shadow/buddha/STUDY_もんじゅまる.webp",
     );
+  });
+
+  // ─── PR #89 Codexレビュー指摘1: collectedPathsのテーマ別変換漏れ ──────
+  // collectedPaths の新形式（"{themeId}:{path}"）は、ZukanContent が生の
+  // collectedPaths をそのまま Set にして ZukanEvolutionBranch に渡すと、
+  // ZukanEvolutionBranch 側は collected.has("STUDY") のように裸のパスで
+  // 検索するため、どのテーマでも「未収集」扱いになってしまう。
+  // @/lib/monsterThemes/collectedPaths の hasCollectedPath() を使い、
+  // アクティブテーマに属するパスへ変換してから渡す必要がある。
+  describe("collectedPathsのテーマ別変換（PR #89 Codexレビュー指摘1）", () => {
+    it("新形式(buddha:STUDY)のcollectedPathsで、アクティブテーマがbuddhaの場合は収集済み表示になること", async () => {
+      mockFetchOnce({
+        side: "DARK",
+        collectedPaths: '["buddha:STUDY"]',
+        monsterLevels: "{}",
+        usedEggBonuses: "[]",
+        monsterSetId: "buddha",
+        ownedThemes: ["buddha"],
+      });
+
+      render(<ZukanContent />);
+      const panel = await waitFor(() => screen.getByTestId("zukan-theme-panel-buddha"));
+
+      // 収集済みなら実名が表示され、画像はシルエットではなく実画像になる
+      // （他のブランチ(STAMINA/LIFE)は未収集のため個別に「？？？」を表示する。
+      //  ここでは STUDY 自身が「？？？」のままではないことのみを確認する）
+      expect(within(panel).getByText("文殊丸")).toBeTruthy();
+      const img = within(panel).getByAltText("文殊丸") as HTMLImageElement;
+      expect(img.getAttribute("src")).toBe("/monsters/buddha/STUDY_もんじゅまる.webp");
+    });
+
+    it("回帰確認: 旧形式（裸のパス）のcollectedPathsで、アクティブテーマがdarkの場合は従来通り収集済み判定されること", async () => {
+      mockFetchOnce({
+        side: "DARK",
+        collectedPaths: '["STUDY"]',
+        monsterLevels: "{}",
+        usedEggBonuses: "[]",
+        monsterSetId: "dark",
+        ownedThemes: ["dark"],
+      });
+
+      render(<ZukanContent />);
+      const panel = await waitFor(() => screen.getByTestId("zukan-theme-panel-dark"));
+
+      expect(within(panel).getByText("ラーン")).toBeTruthy();
+      const img = within(panel).getByAltText("ラーン") as HTMLImageElement;
+      expect(img.getAttribute("src")).toBe("/monsters/dark/STUDY_ラーン.webp");
+    });
+
+    it("回帰確認: 旧形式（裸のパス）のcollectedPathsで、アクティブテーマがlightの場合は従来通り収集済み判定されること", async () => {
+      mockFetchOnce({
+        side: "LIGHT",
+        collectedPaths: '["STUDY"]',
+        monsterLevels: "{}",
+        usedEggBonuses: "[]",
+        monsterSetId: "light",
+        ownedThemes: ["light"],
+      });
+
+      render(<ZukanContent />);
+      const panel = await waitFor(() => screen.getByTestId("zukan-theme-panel-light"));
+
+      expect(within(panel).getByText("ルミナ")).toBeTruthy();
+      const img = within(panel).getByAltText("ルミナ") as HTMLImageElement;
+      expect(img.getAttribute("src")).toBe("/monsters/light/STUDY_ルミナ.webp");
+    });
+
+    it("テーマタブを切り替えると、そのテーマの名前空間付きcollectedPathsのみに基づいて収集済み判定が変わること", async () => {
+      // dark:STUDY のみ記録がある状態。dark タブでは収集済み、buddha タブでは
+      // 同じ STUDY パスでも未収集（シルエット）として表示されるべき。
+      mockFetchOnce({
+        side: "DARK",
+        collectedPaths: '["dark:STUDY"]',
+        monsterLevels: "{}",
+        usedEggBonuses: "[]",
+        monsterSetId: "dark",
+        ownedThemes: ["dark", "buddha"],
+      });
+
+      render(<ZukanContent />);
+      const darkPanel = await waitFor(() => screen.getByTestId("zukan-theme-panel-dark"));
+      expect(within(darkPanel).getByText("ラーン")).toBeTruthy();
+
+      fireEvent.click(screen.getByTestId("zukan-theme-tab-buddha"));
+
+      const buddhaPanel = await waitFor(() => screen.getByTestId("zukan-theme-panel-buddha"));
+      // buddha:STUDY の記録は無いため、buddha タブでは未収集（シルエット）扱い
+      expect(within(buddhaPanel).queryByText("文殊丸")).toBeNull();
+      const img = within(buddhaPanel).getByAltText("文殊丸") as HTMLImageElement;
+      expect(img.getAttribute("src")).toBe("/monsters/shadow/buddha/STUDY_もんじゅまる.webp");
+    });
   });
 });

--- a/src/__tests__/components/zukan-content-themes.test.tsx
+++ b/src/__tests__/components/zukan-content-themes.test.tsx
@@ -1,0 +1,210 @@
+// @vitest-environment jsdom
+//
+// Issue #86: 図鑑（Zukan）のテーマ別タブ対応
+// 対象: src/components/child/ZukanContent.tsx（未実装。テーマ別タブ表示はこれから追加される）
+//
+// 前提: /api/monster のレスポンスに以下の2フィールドが追加される（API側テストは
+// src/__tests__/api/monster/monster.test.ts を参照）。
+//   - monsterSetId: string   … 現在有効なテーマ
+//   - ownedThemes: string[]  … ChildMonsterTheme に記録がある themeId の一覧
+//
+// 期待するUI契約（implementer 実装時の参照用）:
+//  - ownedThemes に含まれる themeId ごとにタブボタンを表示する。
+//    `data-testid={`zukan-theme-tab-${themeId}`}`、ラベルは
+//    @/lib/monsterThemes/index の MONSTER_THEMES[themeId].label
+//  - ownedThemes に含まれない themeId のタブ・紹介カードは一切表示しない
+//    （未所持テーマの内容を購入前に見せない、という docs/decisions.md の方針）
+//  - 初期選択タブは monsterSetId（ownedThemes に含まれる場合）。含まれない場合は
+//    ownedThemes の先頭。
+//  - 現在アクティブなタブの内容のみ `data-testid={`zukan-theme-panel-${themeId}`}`
+//    でDOMに存在する。非アクティブなタブの内容はDOMに存在しない（アンマウント）。
+//  - パネル内のモンスター表・卵は @/lib/monsterThemes/index の
+//    MONSTER_THEMES[themeId].table / .eggImage を使う（旧 side ベースの
+//    MONSTER_TABLE / MONSTER_TABLE_LIGHT 直接切り替えは廃止）。
+//  - ヘッダーの "{total} / {max} 体" は total = collectedPaths の件数
+//    （テーマ非依存、全テーマ共通）、max = アクティブテーマの table のキー数（39）。
+//  - 未収集モンスターのシルエット画像は、アクティブテーマの table の image パスに対して
+//    "/monsters/" → "/monsters/shadow/" 置換したパスになる
+//    （table の image が既に "/monsters/{themeId}/..." を含むため、結果として
+//    "/monsters/shadow/{themeId}/..." になる）。
+//
+// 実装がまだ存在しないため、これらのテストはすべて Red（失敗）になる想定。
+
+import React from "react";
+import { render, screen, fireEvent, waitFor, within } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("next/image", () => ({
+  default: ({ src, alt }: { src: string; alt?: string }) =>
+    React.createElement("img", { src, alt }),
+}));
+
+import ZukanContent from "@/components/child/ZukanContent";
+
+type MockApiResponse = {
+  side: string | null;
+  collectedPaths: string;
+  monsterLevels: string;
+  usedEggBonuses: string;
+  monsterSetId: string;
+  ownedThemes: string[];
+};
+
+function mockFetchOnce(data: MockApiResponse) {
+  global.fetch = vi.fn().mockResolvedValue({
+    ok: true,
+    json: () => Promise.resolve(data),
+  }) as unknown as typeof fetch;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  // ZukanContent はマウント時に localStorage へ既読件数を書き込む
+  Object.defineProperty(window, "localStorage", {
+    value: {
+      getItem: vi.fn(),
+      setItem: vi.fn(),
+      removeItem: vi.fn(),
+    },
+    writable: true,
+  });
+});
+
+describe("ZukanContent: テーマ別タブ対応（Issue #86）", () => {
+  it("境界値: 所持テーマが1つ（dark）の場合、タブが1つだけ表示されること", async () => {
+    mockFetchOnce({
+      side: "DARK",
+      collectedPaths: "[]",
+      monsterLevels: "{}",
+      usedEggBonuses: "[]",
+      monsterSetId: "dark",
+      ownedThemes: ["dark"],
+    });
+
+    render(<ZukanContent />);
+
+    const darkTab = await waitFor(() => screen.getByTestId("zukan-theme-tab-dark"));
+    expect(darkTab).toBeTruthy();
+    expect(screen.getAllByTestId(/^zukan-theme-tab-/)).toHaveLength(1);
+  });
+
+  it("境界値: 所持テーマが1つ（light）の場合、タブが1つだけ表示されること", async () => {
+    mockFetchOnce({
+      side: "LIGHT",
+      collectedPaths: "[]",
+      monsterLevels: "{}",
+      usedEggBonuses: "[]",
+      monsterSetId: "light",
+      ownedThemes: ["light"],
+    });
+
+    render(<ZukanContent />);
+
+    const lightTab = await waitFor(() => screen.getByTestId("zukan-theme-tab-light"));
+    expect(lightTab).toBeTruthy();
+    expect(screen.getAllByTestId(/^zukan-theme-tab-/)).toHaveLength(1);
+  });
+
+  it("未所持テーマはタブにも紹介カードにも一切表示されないこと", async () => {
+    mockFetchOnce({
+      side: "DARK",
+      collectedPaths: "[]",
+      monsterLevels: "{}",
+      usedEggBonuses: "[]",
+      monsterSetId: "dark",
+      ownedThemes: ["dark"],
+    });
+
+    render(<ZukanContent />);
+    await waitFor(() => screen.getByTestId("zukan-theme-tab-dark"));
+
+    expect(screen.queryByTestId("zukan-theme-tab-light")).toBeNull();
+    expect(screen.queryByTestId("zukan-theme-tab-buddha")).toBeNull();
+    // ラベル文言も含め一切出ない（紹介カード等も禁止）
+    expect(screen.queryByText("ライト")).toBeNull();
+    expect(screen.queryByText("仏様")).toBeNull();
+  });
+
+  it("複数テーマを所持している場合（過去に切り替えた履歴がある）、すべてタブに表示されること", async () => {
+    // monsterSetId は buddha 単体だが、ownedThemes には dark/light/buddha すべてが
+    // 含まれる想定（過去に dark → buddha → light … と切り替えた履歴がある場合）。
+    // monsterSetId 単体では判定していないことの確認。
+    mockFetchOnce({
+      side: "DARK",
+      collectedPaths: "[]",
+      monsterLevels: "{}",
+      usedEggBonuses: "[]",
+      monsterSetId: "buddha",
+      ownedThemes: ["dark", "light", "buddha"],
+    });
+
+    render(<ZukanContent />);
+    await waitFor(() => screen.getByTestId("zukan-theme-tab-buddha"));
+
+    expect(screen.getByTestId("zukan-theme-tab-dark")).toBeTruthy();
+    expect(screen.getByTestId("zukan-theme-tab-light")).toBeTruthy();
+    expect(screen.getByTestId("zukan-theme-tab-buddha")).toBeTruthy();
+    expect(screen.getAllByTestId(/^zukan-theme-tab-/)).toHaveLength(3);
+  });
+
+  it("図鑑の分母(total/max)が表示中タブのテーマ構成(39体)で正しく算出されること", async () => {
+    mockFetchOnce({
+      side: "DARK",
+      collectedPaths: '["STUDY","STAMINA"]',
+      monsterLevels: "{}",
+      usedEggBonuses: "[]",
+      monsterSetId: "dark",
+      ownedThemes: ["dark"],
+    });
+
+    render(<ZukanContent />);
+    await waitFor(() => screen.getByTestId("zukan-theme-tab-dark"));
+
+    expect(screen.getByText("2 / 39 体")).toBeTruthy();
+  });
+
+  it("テーマ切替でアクティブタブのパネルがテーマ固有のモンスター表に切り替わること", async () => {
+    // STUDY を収集済みとし、dark タブでは「ラーン」、buddha タブでは「文殊丸」が
+    // 表示されることを確認する（テーマごとに異なる画像・名前を持つ実データを利用）。
+    mockFetchOnce({
+      side: "DARK",
+      collectedPaths: '["STUDY"]',
+      monsterLevels: "{}",
+      usedEggBonuses: "[]",
+      monsterSetId: "dark",
+      ownedThemes: ["dark", "buddha"],
+    });
+
+    render(<ZukanContent />);
+    const darkPanel = await waitFor(() => screen.getByTestId("zukan-theme-panel-dark"));
+    expect(within(darkPanel).getByText("ラーン")).toBeTruthy();
+    expect(screen.queryByTestId("zukan-theme-panel-buddha")).toBeNull();
+
+    fireEvent.click(screen.getByTestId("zukan-theme-tab-buddha"));
+
+    const buddhaPanel = await waitFor(() => screen.getByTestId("zukan-theme-panel-buddha"));
+    expect(within(buddhaPanel).getByText("文殊丸")).toBeTruthy();
+    expect(screen.queryByTestId("zukan-theme-panel-dark")).toBeNull();
+  });
+
+  it("未収集モンスターのシルエットがテーマ別パス(/monsters/shadow/{themeId}/)から正しく読み込まれること", async () => {
+    // buddha テーマで何も収集していない状態。STUDY(文殊丸)のシルエット画像 src が
+    // /monsters/shadow/buddha/... になっていることを確認する。
+    mockFetchOnce({
+      side: "DARK",
+      collectedPaths: "[]",
+      monsterLevels: "{}",
+      usedEggBonuses: "[]",
+      monsterSetId: "buddha",
+      ownedThemes: ["buddha"],
+    });
+
+    render(<ZukanContent />);
+    const panel = await waitFor(() => screen.getByTestId("zukan-theme-panel-buddha"));
+
+    const img = within(panel).getByAltText("文殊丸") as HTMLImageElement;
+    expect(img.getAttribute("src")).toBe(
+      "/monsters/shadow/buddha/STUDY_もんじゅまる.webp",
+    );
+  });
+});

--- a/src/app/api/monster-status/route.ts
+++ b/src/app/api/monster-status/route.ts
@@ -52,6 +52,7 @@ export async function GET() {
     // monster fields
     name: user.monsterName || user.name || "ぼうけんしゃ",
     side: user.side,
+    monsterSetId: user.monsterSetId,
     evolutionStage: user.evolutionStage,
     evolutionPath: user.evolutionPath,
     collectedPaths: user.collectedPaths,

--- a/src/app/api/monster/route.ts
+++ b/src/app/api/monster/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from "next/server";
 import { getCurrentUser } from "@/lib/auth";
 import { prisma } from "@/lib/prisma";
 import { pendingXpByCategory } from "@/lib/xp";
+import { resolveOwnedThemes } from "@/lib/monsterThemes/ownedThemes";
 
 export async function GET() {
   const user = await getCurrentUser();
@@ -17,7 +18,7 @@ export async function GET() {
     }),
     prisma.childMonsterTheme.findMany({ where: { childId: user.id } }),
   ]);
-  const ownedThemes = (ownedThemeRecords ?? []).map((t: { themeId: string }) => t.themeId);
+  const ownedThemes = resolveOwnedThemes(ownedThemeRecords, user.monsterSetId);
 
   const templateIds = Array.from(new Set(pendingQuests.map((q: { templateId: string }) => q.templateId)));
   const declarations = templateIds.length

--- a/src/app/api/monster/route.ts
+++ b/src/app/api/monster/route.ts
@@ -9,11 +9,15 @@ export async function GET() {
     return NextResponse.json({ error: "認証が必要です" }, { status: 401 });
   }
 
-  // 承認待ち（REPORTED）クエストのXPをカテゴリ別に集計
-  const pendingQuests = await prisma.questInstance.findMany({
-    where: { childId: user.id, status: "REPORTED" },
-    include: { template: true },
-  });
+  // 承認待ち（REPORTED）クエストのXPをカテゴリ別に集計 と 所持テーマ一覧（Issue #86）を並列取得
+  const [pendingQuests, ownedThemeRecords] = await Promise.all([
+    prisma.questInstance.findMany({
+      where: { childId: user.id, status: "REPORTED" },
+      include: { template: true },
+    }),
+    prisma.childMonsterTheme.findMany({ where: { childId: user.id } }),
+  ]);
+  const ownedThemes = (ownedThemeRecords ?? []).map((t: { themeId: string }) => t.themeId);
 
   const templateIds = Array.from(new Set(pendingQuests.map((q: { templateId: string }) => q.templateId)));
   const declarations = templateIds.length
@@ -42,5 +46,7 @@ export async function GET() {
     pendingStaminaPt,
     pendingLifePt,
     usedEggBonuses: user.usedEggBonuses ?? "[]",
+    monsterSetId: user.monsterSetId,
+    ownedThemes,
   });
 }

--- a/src/app/api/parent/child-view/monster/route.ts
+++ b/src/app/api/parent/child-view/monster/route.ts
@@ -8,6 +8,7 @@ import { getCurrentUser } from "@/lib/auth";
 import { prisma } from "@/lib/prisma";
 import { pendingXpByCategory } from "@/lib/xp";
 import { resolveTargetChild } from "@/lib/parentChildView";
+import { resolveOwnedThemes } from "@/lib/monsterThemes/ownedThemes";
 
 export async function GET(request: Request) {
   const parent = await getCurrentUser();
@@ -30,7 +31,7 @@ export async function GET(request: Request) {
     }),
     prisma.childMonsterTheme.findMany({ where: { childId: child.id } }),
   ]);
-  const ownedThemes = (ownedThemeRecords ?? []).map((t) => t.themeId);
+  const ownedThemes = resolveOwnedThemes(ownedThemeRecords, child.monsterSetId);
 
   const templateIds = Array.from(new Set(pendingQuests.map((q) => q.templateId)));
   const declarations = templateIds.length

--- a/src/app/api/parent/child-view/monster/route.ts
+++ b/src/app/api/parent/child-view/monster/route.ts
@@ -23,10 +23,14 @@ export async function GET(request: Request) {
   }
   const child = resolved.child;
 
-  const pendingQuests = await prisma.questInstance.findMany({
-    where: { childId: child.id, status: "REPORTED" },
-    include: { template: true },
-  });
+  const [pendingQuests, ownedThemeRecords] = await Promise.all([
+    prisma.questInstance.findMany({
+      where: { childId: child.id, status: "REPORTED" },
+      include: { template: true },
+    }),
+    prisma.childMonsterTheme.findMany({ where: { childId: child.id } }),
+  ]);
+  const ownedThemes = (ownedThemeRecords ?? []).map((t) => t.themeId);
 
   const templateIds = Array.from(new Set(pendingQuests.map((q) => q.templateId)));
   const declarations = templateIds.length
@@ -55,5 +59,7 @@ export async function GET(request: Request) {
     pendingStaminaPt,
     pendingLifePt,
     usedEggBonuses: child.usedEggBonuses ?? "[]",
+    monsterSetId: child.monsterSetId,
+    ownedThemes,
   });
 }

--- a/src/app/app/child/monster/page.tsx
+++ b/src/app/app/child/monster/page.tsx
@@ -46,7 +46,7 @@ export default function MonsterPage() {
         const newData = await fetchStatus();
         if (!newData) return;
         setData({
-          name: newData.name, side: newData.side ?? null,
+          name: newData.name, side: newData.side ?? null, monsterSetId: newData.monsterSetId ?? "dark",
           evolutionStage: newData.evolutionStage, evolutionPath: newData.evolutionPath ?? "",
           collectedPaths: newData.collectedPaths ?? "[]",
           studyPt: newData.studyPt, staminaPt: newData.staminaPt, lifePt: newData.lifePt,
@@ -134,7 +134,7 @@ export default function MonsterPage() {
       {/* Egg selection overlay */}
       {showEggSelection && (
         <EggSelectionModal
-          side={data.side}
+          monsterSetId={data.monsterSetId}
           loading={rebirthLoading}
           onSelect={handleRebirth}
           onCancel={() => setShowEggSelection(false)}

--- a/src/components/child/EggSelectionModal.tsx
+++ b/src/components/child/EggSelectionModal.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import Image from "next/image";
+import { MONSTER_THEMES } from "@/lib/monsterThemes/index";
 
 const EGG_OPTIONS = [
   {
@@ -34,13 +35,16 @@ const EGG_OPTIONS = [
 ] as const;
 
 type Props = {
-  side: string | null;
+  /** 現在有効なモンスターテーマセット id（@/lib/monsterThemes/index の MONSTER_THEMES キー）。
+   *  null、または未知のテーマ id の場合は既定の dark テーマにフォールバックする。 */
+  monsterSetId: string | null;
   loading: boolean;
   onSelect: (eggType: string) => void;
   onCancel: () => void;
 };
 
-export default function EggSelectionModal({ side, loading, onSelect, onCancel }: Props) {
+export default function EggSelectionModal({ monsterSetId, loading, onSelect, onCancel }: Props) {
+  const normalEggImage = (monsterSetId && MONSTER_THEMES[monsterSetId]?.eggImage) ?? MONSTER_THEMES.dark.eggImage;
   return (
     <div
       className="fixed inset-0 z-[60] bg-black/95 flex flex-col items-center justify-center px-4"
@@ -52,7 +56,7 @@ export default function EggSelectionModal({ side, loading, onSelect, onCancel }:
       </p>
       <div className="flex flex-col gap-3 w-full max-w-sm">
         {EGG_OPTIONS.map(({ type, name, img, desc, color }) => {
-          const eggImg = img || (side === "LIGHT" ? "/monsters/light/egg.webp" : "/monsters/dark/egg.webp");
+          const eggImg = img || normalEggImage;
           return (
             <button
               key={type}

--- a/src/components/child/ZukanContent.tsx
+++ b/src/components/child/ZukanContent.tsx
@@ -16,6 +16,7 @@
 import { useEffect, useState } from "react";
 import { getEvolutionChildren, themeIdFromSide } from "@/lib/monsters";
 import { MONSTER_THEMES } from "@/lib/monsterThemes/index";
+import { hasCollectedPath } from "@/lib/monsterThemes/collectedPaths";
 import LoadingSpinner from "@/components/LoadingSpinner";
 import MonsterImageModal from "@/components/MonsterImageModal";
 import { getZukanStageLabel } from "@/lib/zukanStageLabel";
@@ -94,7 +95,7 @@ export default function ZukanContent({
 
   if (loading || !data || !activeTheme) return <LoadingSpinner />;
 
-  const collected = new Set<string>(JSON.parse(data.collectedPaths) as string[]);
+  const collectedPathsList = JSON.parse(data.collectedPaths) as string[];
   const usedEggs = new Set<string>(JSON.parse(data.usedEggBonuses) as string[]);
   const monsterLevels = JSON.parse(data.monsterLevels) as Record<string, number>;
 
@@ -104,8 +105,17 @@ export default function ZukanContent({
   const activeThemeDef = MONSTER_THEMES[activeTheme];
   const monsterTable = activeThemeDef.table;
   const eggData = { image: activeThemeDef.eggImage };
-  const total = collected.size;
+  const total = collectedPathsList.length;
   const max = Object.keys(monsterTable).length;
+
+  // collectedPaths はテーマ名前空間付き（"{themeId}:{path}"）または旧形式（裸のパス、
+  // 無料テーマのみ）で記録されている。ZukanEvolutionBranch は裸のパスで collected.has()
+  // を検索するため、アクティブテーマに属するパスのみを含む Set に変換して渡す。
+  const collected = new Set<string>(
+    Object.keys(monsterTable).filter((path) =>
+      hasCollectedPath(collectedPathsList, activeTheme, path),
+    ),
+  );
 
   const stage1Keys = getEvolutionChildren("");
 

--- a/src/components/child/ZukanContent.tsx
+++ b/src/components/child/ZukanContent.tsx
@@ -5,20 +5,37 @@
 // と既存 `/app/child/zukan` の両方から同じ内容を表示できるようにした。
 // マウント時に lastSeenCollectedCount を更新して BottomNav バッジを既読化する副作用は
 // このコンポーネント側に持たせる（旧ページからもタブからも自動で動く）。
+//
+// Issue #86: 図鑑のテーマ別タブ対応。
+// 所持テーマ（ownedThemes）ごとにタブを表示し、アクティブなタブのモンスター表・卵のみを
+// DOM に描画する（非アクティブなタブの内容はアンマウントする）。未所持テーマのタブ・
+// 紹介カードは一切表示しない（購入前に内容を見せない、という docs/decisions.md の方針）。
+// テーマ構成（モンスター表・卵画像）は @/lib/monsterThemes/index の MONSTER_THEMES を正とし、
+// 旧 side ベースの MONSTER_TABLE / MONSTER_TABLE_LIGHT 直接切り替えは行わない。
 
 import { useEffect, useState } from "react";
-import { MONSTER_TABLE, MONSTER_TABLE_LIGHT, EGG_STAGE, EGG_STAGE_LIGHT, getEvolutionChildren } from "@/lib/monsters";
+import { getEvolutionChildren, themeIdFromSide } from "@/lib/monsters";
+import { MONSTER_THEMES } from "@/lib/monsterThemes/index";
 import LoadingSpinner from "@/components/LoadingSpinner";
 import MonsterImageModal from "@/components/MonsterImageModal";
 import { getZukanStageLabel } from "@/lib/zukanStageLabel";
 import ZukanEggSection from "./ZukanEggSection";
 import ZukanEvolutionBranch from "./ZukanEvolutionBranch";
 
+type ZukanApiResponse = {
+  side?: string | null;
+  collectedPaths?: string;
+  monsterLevels?: string;
+  usedEggBonuses?: string;
+  monsterSetId?: string;
+  ownedThemes?: string[];
+};
+
 type ZukanData = {
-  side: string | null;
   collectedPaths: string;
   monsterLevels: string;
   usedEggBonuses: string;
+  ownedThemes: string[];
 };
 
 type SelectedMonster = { image: string; name: string; stageLabel: string };
@@ -30,6 +47,21 @@ interface ZukanContentProps {
   trackVisit?: boolean;
 }
 
+/**
+ * API レスポンスから所持テーマ一覧を決定する。
+ * ownedThemes を返さない旧レスポンス（親代理ビュー等）との後方互換のため、
+ * ownedThemes が空・未指定の場合は現在のテーマ（monsterSetId、無ければ side から変換）
+ * のみを所持テーマとして扱う。
+ */
+function resolveOwnedThemes(d: ZukanApiResponse): { ownedThemes: string[]; currentTheme: string } {
+  const currentTheme = d.monsterSetId && MONSTER_THEMES[d.monsterSetId]
+    ? d.monsterSetId
+    : themeIdFromSide(d.side);
+  const owned = (d.ownedThemes ?? []).filter((id) => MONSTER_THEMES[id]);
+  const ownedThemes = owned.length > 0 ? owned : [currentTheme];
+  return { ownedThemes, currentTheme };
+}
+
 export default function ZukanContent({
   fetchUrl = "/api/monster",
   trackVisit = true,
@@ -37,13 +69,21 @@ export default function ZukanContent({
   const [data, setData] = useState<ZukanData | null>(null);
   const [loading, setLoading] = useState(true);
   const [selected, setSelected] = useState<SelectedMonster | null>(null);
+  const [activeTheme, setActiveTheme] = useState<string | null>(null);
 
   useEffect(() => {
     fetch(fetchUrl)
       .then((r) => r.json())
-      .then((d: ZukanData) => {
+      .then((d: ZukanApiResponse) => {
         const paths = d.collectedPaths ?? "[]";
-        setData({ side: d.side ?? null, collectedPaths: paths, monsterLevels: d.monsterLevels ?? "{}", usedEggBonuses: d.usedEggBonuses ?? "[]" });
+        const { ownedThemes, currentTheme } = resolveOwnedThemes(d);
+        setData({
+          collectedPaths: paths,
+          monsterLevels: d.monsterLevels ?? "{}",
+          usedEggBonuses: d.usedEggBonuses ?? "[]",
+          ownedThemes,
+        });
+        setActiveTheme(ownedThemes.includes(currentTheme) ? currentTheme : ownedThemes[0]);
         if (trackVisit) {
           const count = (JSON.parse(paths) as string[]).length;
           localStorage.setItem("lastSeenCollectedCount", String(count));
@@ -52,18 +92,20 @@ export default function ZukanContent({
       .finally(() => setLoading(false));
   }, [fetchUrl, trackVisit]);
 
-  if (loading || !data) return <LoadingSpinner />;
+  if (loading || !data || !activeTheme) return <LoadingSpinner />;
 
   const collected = new Set<string>(JSON.parse(data.collectedPaths) as string[]);
   const usedEggs = new Set<string>(JSON.parse(data.usedEggBonuses) as string[]);
+  const monsterLevels = JSON.parse(data.monsterLevels) as Record<string, number>;
 
   const openModal = (image: string, name: string, path: string) =>
     setSelected({ image, name, stageLabel: getZukanStageLabel(path) });
-  const monsterLevels = JSON.parse(data.monsterLevels) as Record<string, number>;
-  const monsterTable = data.side === "LIGHT" ? MONSTER_TABLE_LIGHT : MONSTER_TABLE;
-  const eggData = data.side === "LIGHT" ? EGG_STAGE_LIGHT : EGG_STAGE;
+
+  const activeThemeDef = MONSTER_THEMES[activeTheme];
+  const monsterTable = activeThemeDef.table;
+  const eggData = { image: activeThemeDef.eggImage };
   const total = collected.size;
-  const max = Object.keys(MONSTER_TABLE).length;
+  const max = Object.keys(monsterTable).length;
 
   const stage1Keys = getEvolutionChildren("");
 
@@ -83,20 +125,52 @@ export default function ZukanContent({
         {total} / {max} 体
       </p>
 
-      {/* ── 卵 ── */}
-      <ZukanEggSection eggData={eggData} usedEggs={usedEggs} />
+      {/* ── テーマタブ（所持テーマのみ表示） ── */}
+      {data.ownedThemes.length > 0 && (
+        <div className="flex gap-1 justify-center mb-4" role="tablist">
+          {data.ownedThemes.map((themeId) => {
+            const theme = MONSTER_THEMES[themeId];
+            if (!theme) return null;
+            const isActive = themeId === activeTheme;
+            return (
+              <button
+                key={themeId}
+                type="button"
+                data-testid={`zukan-theme-tab-${themeId}`}
+                aria-selected={isActive}
+                role="tab"
+                onClick={() => setActiveTheme(themeId)}
+                className="flex-1 text-xs py-1.5 rounded-md font-bold tracking-wider transition-colors"
+                style={
+                  isActive
+                    ? { background: "rgba(251,191,36,0.2)", color: "var(--quest-gold, #fbbf24)", border: "1px solid rgba(251,191,36,0.3)" }
+                    : { color: "var(--quest-dim, #9a8c6e)", border: "1px solid transparent" }
+                }
+              >
+                {theme.label}
+              </button>
+            );
+          })}
+        </div>
+      )}
 
-      {/* ── 3系統ブランチ ── */}
-      {stage1Keys.map((s1) => (
-        <ZukanEvolutionBranch
-          key={s1}
-          s1={s1}
-          collected={collected}
-          monsterLevels={monsterLevels}
-          monsterTable={monsterTable}
-          openModal={openModal}
-        />
-      ))}
+      {/* ── アクティブテーマのパネル（非アクティブなタブの内容はアンマウント） ── */}
+      <div key={activeTheme} data-testid={`zukan-theme-panel-${activeTheme}`}>
+        {/* ── 卵 ── */}
+        <ZukanEggSection eggData={eggData} usedEggs={usedEggs} />
+
+        {/* ── 3系統ブランチ ── */}
+        {stage1Keys.map((s1) => (
+          <ZukanEvolutionBranch
+            key={s1}
+            s1={s1}
+            collected={collected}
+            monsterLevels={monsterLevels}
+            monsterTable={monsterTable}
+            openModal={openModal}
+          />
+        ))}
+      </div>
 
       {selected && (
         <MonsterImageModal

--- a/src/hooks/useMonsterStatus.ts
+++ b/src/hooks/useMonsterStatus.ts
@@ -8,6 +8,7 @@ import type { MonsterStatusResponse } from "@/types";
 export type MonsterData = {
   name: string;
   side: string | null;
+  monsterSetId: string;
   evolutionStage: number;
   evolutionPath: string;
   collectedPaths: string;
@@ -65,7 +66,7 @@ export function useMonsterStatus(): UseMonsterStatusResult {
 
   function applyStatus(d: MonsterStatusResponse) {
     setData({
-      name: d.name, side: d.side ?? null, evolutionStage: d.evolutionStage, evolutionPath: d.evolutionPath ?? "",
+      name: d.name, side: d.side ?? null, monsterSetId: d.monsterSetId ?? "dark", evolutionStage: d.evolutionStage, evolutionPath: d.evolutionPath ?? "",
       collectedPaths: d.collectedPaths ?? "[]",
       studyPt: d.studyPt, staminaPt: d.staminaPt, lifePt: d.lifePt,
       pendingStudyPt: d.pendingStudyPt, pendingStaminaPt: d.pendingStaminaPt, pendingLifePt: d.pendingLifePt,

--- a/src/lib/monsterThemes/ownedThemes.ts
+++ b/src/lib/monsterThemes/ownedThemes.ts
@@ -1,0 +1,33 @@
+// 所持テーマ一覧（ownedThemes）を決定する純粋関数（ビジネスロジック層）。
+//
+// ChildMonsterTheme のレコードのみから ownedThemes を構築すると、以下が漏れる:
+//   - isFree: true のテーマ（dark/light）は付与レコードが無くても所持しているはず
+//   - 現在有効な monsterSetId（移行直後などレコードがまだ無いケース）
+// このため、以下の3種類をマージした一覧を返す。
+//   - MONSTER_THEMES で isFree === true の全テーマID
+//   - 現在の monsterSetId
+//   - 既存の ChildMonsterTheme レコード由来の themeId
+//
+// isFree: false のテーマ（buddha 等）は、ChildMonsterTheme にレコードが無い限り含めない
+// （PR #89 Codexレビュー指摘2）。
+
+import { MONSTER_THEMES } from "@/lib/monsterThemes/index";
+
+export function resolveOwnedThemes(
+  ownedThemeRecords: { themeId: string }[] | null | undefined,
+  monsterSetId: string | null | undefined,
+): string[] {
+  const themeIds = new Set<string>();
+
+  for (const theme of Object.values(MONSTER_THEMES)) {
+    if (theme.isFree) themeIds.add(theme.id);
+  }
+
+  if (monsterSetId) themeIds.add(monsterSetId);
+
+  for (const record of ownedThemeRecords ?? []) {
+    themeIds.add(record.themeId);
+  }
+
+  return Array.from(themeIds);
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -11,6 +11,8 @@ export type QuestStatus = "PENDING" | "REPORTED" | "APPROVED" | "REJECTED" | "SK
 export type MonsterStatusResponse = {
   name: string;
   side: Side | null;
+  /** 現在有効なモンスターテーマセット id（@/lib/monsterThemes/index の MONSTER_THEMES キー）。 */
+  monsterSetId: string;
   evolutionStage: number;
   evolutionPath: string;
   collectedPaths: string;


### PR DESCRIPTION
## Summary
- 図鑑（Zukan）を `MONSTER_THEMES` ベースのテーマ別タブ表示に改修。未所持テーマは紹介カードも含め一切表示しない
- `/api/monster`・`/api/parent/child-view/monster` に `monsterSetId` と `ownedThemes`（`ChildMonsterTheme` 由来の所持テーマ一覧）を追加
- `/api/monster-status` に `monsterSetId` を追加し、`EggSelectionModal` の `side` prop を `monsterSetId` prop に置換してテーマの `eggImage` を表示するよう変更

これはモンスターテーマセット機能（Issue #73 Stage1 / #85 Stage2）の最終段階（Stage3）で、テーマ切り替え機能一式が完成します。

Closes #86

## Test plan
- [x] `npm test` パス（194 test files / 2689 tests all green）
- [x] `npm run lint` パス
- [x] `tsc` パス
- [ ] 子画面での図鑑テーマタブ切り替え・未所持テーマ非表示の手動確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)
