### PR TITLE
feat(monster): DB直接操作による有料テーマの疑似購入を可能にする

### DIFF
--- a/src/__tests__/api/family/code.test.ts
+++ b/src/__tests__/api/family/code.test.ts
@@ -8,14 +8,23 @@ import type { Prisma } from "@/generated/prisma/client";
 const mockGetCurrentUser = vi.mocked(getCurrentUser);
 
 /**
- * `prisma.family.findUnique` は `include: { users: { include: { streak: { select: ... } } } }`
- * 付きで呼ばれるが、DeepMockProxy の `mockResolvedValue` は関係（リレーション）を含まない
- * ベースの `Family` 型しか受け付けない（`users` プロパティ自体が型エラーになる）。
+ * `prisma.family.findUnique` は
+ * `include: { users: { include: { streak: { select: ... }, monsterThemes: { select: { themeId: true } } } } }`
+ * 付きで呼ばれる想定（Issue #90: ownedThemes をレスポンスに含めるため）が、DeepMockProxy の
+ * `mockResolvedValue` は関係（リレーション）を含まないベースの `Family` 型しか受け付けない
+ * （`users` プロパティ自体が型エラーになる）。
  * `Prisma.FamilyGetPayload<{ include: ... }>` で実際のクエリ形状の値を組み立てたうえで、
  * モック関数の戻り値型へ `as unknown as` でキャストする。
  */
 type FamilyWithUsersAndStreak = Prisma.FamilyGetPayload<{
-  include: { users: { include: { streak: { select: { lastLoginDate: true } } } } };
+  include: {
+    users: {
+      include: {
+        streak: { select: { lastLoginDate: true } };
+        monsterThemes: { select: { themeId: true } };
+      };
+    };
+  };
 }>;
 
 function mockFamilyFindUnique(payload: FamilyWithUsersAndStreak | null) {
@@ -101,6 +110,7 @@ describe("GET /api/family/code", () => {
       monsterSetId: "dark",
       pendingMonsterSetId: null,
       lastLoginDate: null,
+      ownedThemes: ["dark", "light"],
     });
     expect(json.members[1].childCode).toBe("1234");
   });
@@ -143,9 +153,63 @@ describe("GET /api/family/code", () => {
       include: {
         users: {
           orderBy: { createdAt: "asc" },
-          include: { streak: { select: { lastLoginDate: true } } },
+          include: {
+            streak: { select: { lastLoginDate: true } },
+            monsterThemes: { select: { themeId: true } },
+          },
         },
       },
+    });
+  });
+
+  describe("ownedThemes（Issue #90: ChildMonsterThemeレコードの手動付与を反映）", () => {
+    it("buddhaのChildMonsterThemeレコードがある子はownedThemesにbuddhaが含まれること", async () => {
+      mockGetCurrentUser.mockResolvedValue(parentUserWithFamily());
+      mockFamilyFindUnique({
+        ...family(),
+        users: [
+          legacyMemberRow({
+            id: "u2",
+            name: "太郎",
+            role: "CHILD",
+            monsterName: "ドラゴン",
+            side: "DARK",
+            childCode: "1234",
+            monsterSetId: "dark",
+            monsterThemes: [{ themeId: "buddha" }],
+          } as unknown as FamilyWithUsersAndStreak["users"][number]),
+        ],
+      });
+
+      const res = await GET();
+      const json = await res.json();
+
+      expect(json.members[0].ownedThemes).toContain("buddha");
+    });
+
+    it("buddhaのChildMonsterThemeレコードが無い子はownedThemesにbuddhaが含まれないこと", async () => {
+      mockGetCurrentUser.mockResolvedValue(parentUserWithFamily());
+      mockFamilyFindUnique({
+        ...family(),
+        users: [
+          legacyMemberRow({
+            id: "u3",
+            name: "次郎",
+            role: "CHILD",
+            monsterName: "スライム",
+            side: "LIGHT",
+            childCode: "5678",
+            monsterSetId: "light",
+            monsterThemes: [],
+          } as unknown as FamilyWithUsersAndStreak["users"][number]),
+        ],
+      });
+
+      const res = await GET();
+      const json = await res.json();
+
+      expect(json.members[0].ownedThemes).not.toContain("buddha");
+      expect(json.members[0].ownedThemes).toEqual(["dark", "light"]);
     });
   });
 

--- a/src/__tests__/api/family/members-id-monster-theme.test.ts
+++ b/src/__tests__/api/family/members-id-monster-theme.test.ts
@@ -1,11 +1,17 @@
-// Issue #85: 親画面からモンスターテーマの付与・切替を行う（モンスターテーマセット Stage2）
-// 対象: src/app/api/family/members/[id]/monster-theme/route.ts の PATCH (未実装。実装は implementer が行う)
+// Issue #85 / #90: 親画面からモンスターテーマの付与・切替を行う（モンスターテーマセット Stage2/3）
+// 対象: src/app/api/family/members/[id]/monster-theme/route.ts の PATCH (所持チェックは未実装。実装は implementer が行う)
 //
 // 仕様:
 //  - PARENT 認証必須。対象 child が自ファミリーであることを確認する（他ファミリーなら403）
 //  - themeId が @/lib/monsterThemes/index の MONSTER_THEMES に存在しない場合400
-//  - themeId が存在していても isFree: false（現状 buddha。決済導線が未実装のため）の場合は400
-//    （PR #88 Codexレビュー対応: 所持確認手段がまだ無いため、有料テーマは一旦選択不可にする）
+//  - themeId が存在していても isFree: false（現状 buddha）の場合:
+//    prisma.childMonsterTheme.findUnique({ where: { childId_themeId: { childId: id, themeId } } })
+//    でレコードの有無を確認する
+//      - レコードが無ければ400（決済導線は未実装だが、開発者による手動DB挿入で
+//        「購入済み」として付与された子は選択できる。Issue #90）
+//      - レコードがあれば、以降は isFree:true のテーマと同じ即時反映/予約ロジックに進む
+//  - isFree: true のテーマは所持レコードの有無に関わらず選択できる
+//    （childMonsterTheme.findUnique は呼ばれない）
 //  - 即時反映条件（evolutionStage === 0 または rebirthPending === true）を満たす場合:
 //    monsterSetId を更新し、activateChildTheme(childId, themeId, "manual") を呼ぶ
 //    （pendingMonsterSetId は変更しない）
@@ -26,6 +32,17 @@ vi.mock("@/lib/monsterThemes", () => ({
 
 const mockGetCurrentUser = vi.mocked(getCurrentUser);
 const mockActivateChildTheme = vi.mocked(activateChildTheme);
+
+/** ChildMonsterTheme の所持レコード（購入済み扱い）を模したフィクスチャ */
+function ownedThemeRecord(overrides?: { childId?: string; themeId?: string }) {
+  return {
+    id: "cmt-1",
+    childId: overrides?.childId ?? "child-1",
+    themeId: overrides?.themeId ?? "buddha",
+    activatedAt: new Date("2026-01-01T00:00:00Z"),
+    grantReason: "purchase",
+  };
+}
 
 function patchRequest(themeId: unknown) {
   return makeRequest("/api/family/members/child-1/monster-theme", { themeId }, "PATCH");
@@ -141,24 +158,31 @@ describe("PATCH /api/family/members/[id]/monster-theme", () => {
     expect(mockActivateChildTheme).not.toHaveBeenCalled();
   });
 
-  describe("有料テーマ（isFree: false）の選択制限（PR #88 Codexレビュー対応）", () => {
-    it("isFree:falseのテーマ(buddha)を指定した場合、400を返すこと（即時反映条件を満たす卵状態でも拒否されること）", async () => {
+  describe("有料テーマ（isFree: false）の所持チェック（Issue #90: 手動DB挿入による付与）", () => {
+    it("ChildMonsterThemeにbuddhaのレコードが無い場合、400を返すこと（即時反映条件を満たす卵状態でも拒否されること）", async () => {
       mockGetCurrentUser.mockResolvedValue(parentUserWithFamily());
       mockPrisma.user.findFirst.mockResolvedValue(
         childUser({ id: "child-1", evolutionStage: 0, rebirthPending: false }),
       );
+      mockPrisma.childMonsterTheme.findUnique.mockResolvedValue(null);
 
       const res = await PATCH(patchRequest("buddha"), makeParams("child-1"));
       expect(res.status).toBe(400);
       const body = await res.json();
       expect(body.error).toBeTruthy();
+      expect(body.error).toBe("このテーマはまだ購入されていません");
+
+      expect(mockPrisma.childMonsterTheme.findUnique).toHaveBeenCalledWith({
+        where: { childId_themeId: { childId: "child-1", themeId: "buddha" } },
+      });
     });
 
-    it("isFree:falseのテーマ(buddha)を指定した場合、monsterSetId/pendingMonsterSetIdのいずれも変更されず、activateChildThemeも呼ばれないこと", async () => {
+    it("ChildMonsterThemeにbuddhaのレコードが無い場合、monsterSetId/pendingMonsterSetIdのいずれも変更されず、activateChildThemeも呼ばれないこと", async () => {
       mockGetCurrentUser.mockResolvedValue(parentUserWithFamily());
       mockPrisma.user.findFirst.mockResolvedValue(
         childUser({ id: "child-1", evolutionStage: 2, rebirthPending: false }),
       );
+      mockPrisma.childMonsterTheme.findUnique.mockResolvedValue(null);
 
       const res = await PATCH(patchRequest("buddha"), makeParams("child-1"));
       expect(res.status).toBe(400);
@@ -166,7 +190,51 @@ describe("PATCH /api/family/members/[id]/monster-theme", () => {
       expect(mockActivateChildTheme).not.toHaveBeenCalled();
     });
 
-    it("境界値: isFree:trueのテーマ(dark/light)は従来通り成功すること（回帰確認）", async () => {
+    it("ChildMonsterThemeにbuddhaのレコードがある場合、即時反映条件（卵）を満たすと切替が成功すること", async () => {
+      mockGetCurrentUser.mockResolvedValue(parentUserWithFamily());
+      mockPrisma.user.findFirst.mockResolvedValue(
+        childUser({ id: "child-1", evolutionStage: 0, rebirthPending: false }),
+      );
+      mockPrisma.childMonsterTheme.findUnique.mockResolvedValue(ownedThemeRecord());
+      mockPrisma.user.update.mockResolvedValue(childUser({ id: "child-1", monsterSetId: "buddha" }));
+
+      const res = await PATCH(patchRequest("buddha"), makeParams("child-1"));
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body).toEqual({ immediate: true, monsterSetId: "buddha" });
+
+      expect(mockPrisma.user.update).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: { id: "child-1" },
+          data: expect.objectContaining({ monsterSetId: "buddha" }),
+        }),
+      );
+      expect(mockActivateChildTheme).toHaveBeenCalledWith("child-1", "buddha", "manual");
+    });
+
+    it("ChildMonsterThemeにbuddhaのレコードがある場合、育成途中(予約条件)ではpendingMonsterSetIdに保存されること", async () => {
+      mockGetCurrentUser.mockResolvedValue(parentUserWithFamily());
+      mockPrisma.user.findFirst.mockResolvedValue(
+        childUser({ id: "child-1", evolutionStage: 2, rebirthPending: false }),
+      );
+      mockPrisma.childMonsterTheme.findUnique.mockResolvedValue(ownedThemeRecord());
+      mockPrisma.user.update.mockResolvedValue(
+        childUser({ id: "child-1", pendingMonsterSetId: "buddha" }),
+      );
+
+      const res = await PATCH(patchRequest("buddha"), makeParams("child-1"));
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body).toEqual({ immediate: false, pendingMonsterSetId: "buddha" });
+
+      expect(mockPrisma.user.update).toHaveBeenCalledWith({
+        where: { id: "child-1" },
+        data: { pendingMonsterSetId: "buddha" },
+      });
+      expect(mockActivateChildTheme).not.toHaveBeenCalled();
+    });
+
+    it("境界値: isFree:trueのテーマ(dark/light)は所持レコード無しでも従来通り成功すること（回帰確認）", async () => {
       mockGetCurrentUser.mockResolvedValue(parentUserWithFamily());
       mockPrisma.user.findFirst.mockResolvedValue(
         childUser({ id: "child-1", evolutionStage: 0, rebirthPending: false }),
@@ -176,6 +244,8 @@ describe("PATCH /api/family/members/[id]/monster-theme", () => {
       const res = await PATCH(patchRequest("dark"), makeParams("child-1"));
       expect(res.status).toBe(200);
       expect(mockActivateChildTheme).toHaveBeenCalledWith("child-1", "dark", "manual");
+      // isFree:true のテーマでは所持チェックを行わない
+      expect(mockPrisma.childMonsterTheme.findUnique).not.toHaveBeenCalled();
     });
   });
 

--- a/src/__tests__/components/parent-family-monster-theme.test.tsx
+++ b/src/__tests__/components/parent-family-monster-theme.test.tsx
@@ -70,6 +70,7 @@ type MockMember = {
   collectedPaths: string;
   monsterSetId: string;
   pendingMonsterSetId: string | null;
+  ownedThemes: string[];
 };
 
 function makeChild(overrides: Partial<MockMember> = {}): MockMember {
@@ -94,6 +95,7 @@ function makeChild(overrides: Partial<MockMember> = {}): MockMember {
     collectedPaths: "[]",
     monsterSetId: "dark",
     pendingMonsterSetId: null,
+    ownedThemes: ["dark", "light"],
     ...overrides,
   };
 }
@@ -339,6 +341,31 @@ describe("親 ファミリーページ: モンスターテーマ選択（Issue #
           c[0].includes("/api/family/members/child-1/monster-theme"),
       );
       expect(patchCall).toBeFalsy();
+    });
+
+    it("Issue #90: /api/family/code のownedThemesにbuddhaが含まれる子は、buddhaボタンが有効になり選択・送信できること", async () => {
+      mockFetchWithMembers([makeChild({ evolutionStage: 0, ownedThemes: ["dark", "light", "buddha"] })]);
+      render(<FamilyPage />);
+
+      const section = await waitFor(() => screen.getByTestId("monster-theme-section-child-1"));
+      const buddhaBtn = within(section).getByTestId(
+        "monster-theme-option-child-1-buddha",
+      ) as HTMLButtonElement;
+      expect(buddhaBtn.disabled).toBe(false);
+
+      fireEvent.click(buddhaBtn);
+
+      await waitFor(() => {
+        const calls = (global.fetch as ReturnType<typeof vi.fn>).mock.calls;
+        const patchCall = calls.find(
+          (c: unknown[]) =>
+            typeof c[0] === "string" &&
+            c[0].includes("/api/family/members/child-1/monster-theme"),
+        );
+        expect(patchCall).toBeTruthy();
+        const [, options] = patchCall as [string, RequestInit];
+        expect(JSON.parse(options.body as string)).toEqual({ themeId: "buddha" });
+      });
     });
 
     it("境界値: isFree:trueのテーマ(dark/light)は従来通り選択・送信できること（回帰確認）", async () => {

--- a/src/__tests__/components/parent-monster-theme-selector-owned.test.tsx
+++ b/src/__tests__/components/parent-monster-theme-selector-owned.test.tsx
@@ -1,0 +1,120 @@
+// @vitest-environment jsdom
+//
+// Issue #90: 決済導線が未実装のまま、ChildMonsterTheme への手動DB挿入によって
+// 有料テーマ（現状 buddha, isFree: false）を「購入済み」として付与し、親画面から選択できるようにする。
+// 対象: src/components/parent/MonsterThemeSelector.tsx（未実装。`ownedThemes` prop はこれから追加される）
+//
+// 期待するUI契約（implementer 実装時の参照用）:
+//  - `MonsterThemeSelector` は `member` に加えて `ownedThemes: string[]` を prop として受け取る
+//  - `isLocked = theme.isFree === false && !ownedThemes.includes(themeId)`
+//    - isFree:false のテーマでも ownedThemes に含まれていれば選択可能（disabled=false）にする
+//    - isFree:false のテーマが ownedThemes に含まれていなければ、従来通り選択不可（disabled=true, 「準備中」表示）にする
+//  - isFree:true のテーマ（dark/light）は ownedThemes の内容に関わらず常に選択可能
+//
+// 実装がまだ存在しないため、これらのテストはすべて Red（失敗）になる想定。
+
+import { render, screen, fireEvent, waitFor, within } from "@testing-library/react";
+import { describe, it, expect, vi, afterEach } from "vitest";
+import MonsterThemeSelector from "@/components/parent/MonsterThemeSelector";
+
+function baseMember(overrides: Partial<Parameters<typeof MonsterThemeSelector>[0]["member"]> = {}) {
+  return {
+    id: "child-1",
+    evolutionStage: 0,
+    rebirthPending: false,
+    monsterSetId: "dark",
+    pendingMonsterSetId: null,
+    ...overrides,
+  };
+}
+
+describe("MonsterThemeSelector: ownedThemes による有料テーマの選択制御（Issue #90）", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  it("ownedThemesにbuddhaが含まれる場合、buddhaボタンは有効(disabled=false)であること", () => {
+    render(
+      <MonsterThemeSelector member={baseMember()} ownedThemes={["dark", "light", "buddha"]} />,
+    );
+
+    const section = screen.getByTestId("monster-theme-section-child-1");
+    const buddhaBtn = within(section).getByTestId(
+      "monster-theme-option-child-1-buddha",
+    ) as HTMLButtonElement;
+    expect(buddhaBtn.disabled).toBe(false);
+    expect(within(section).queryByText(/準備中/)).toBeNull();
+  });
+
+  it("ownedThemesにbuddhaが含まれる場合、buddhaボタンをクリックするとPATCH APIが呼ばれること", async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ immediate: true, monsterSetId: "buddha" }),
+    }) as unknown as typeof fetch;
+
+    render(
+      <MonsterThemeSelector
+        member={baseMember({ evolutionStage: 0 })}
+        ownedThemes={["dark", "light", "buddha"]}
+      />,
+    );
+
+    const section = screen.getByTestId("monster-theme-section-child-1");
+    fireEvent.click(within(section).getByTestId("monster-theme-option-child-1-buddha"));
+
+    await waitFor(() => {
+      expect(global.fetch).toHaveBeenCalledWith(
+        "/api/family/members/child-1/monster-theme",
+        expect.objectContaining({
+          method: "PATCH",
+          body: JSON.stringify({ themeId: "buddha" }),
+        }),
+      );
+    });
+
+    await waitFor(() => {
+      expect(within(section).getByText(/テーマを変更しました/)).toBeTruthy();
+    });
+  });
+
+  it("ownedThemesにbuddhaが含まれない場合、従来通りbuddhaボタンは無効(disabled=true)で「準備中」と表示されること（回帰確認）", () => {
+    render(<MonsterThemeSelector member={baseMember()} ownedThemes={["dark", "light"]} />);
+
+    const section = screen.getByTestId("monster-theme-section-child-1");
+    const buddhaBtn = within(section).getByTestId(
+      "monster-theme-option-child-1-buddha",
+    ) as HTMLButtonElement;
+    expect(buddhaBtn.disabled).toBe(true);
+    expect(within(section).getByText(/準備中/)).toBeTruthy();
+  });
+
+  it("ownedThemesにbuddhaが含まれない場合、buddhaボタンをクリックしてもPATCH APIが呼ばれないこと（回帰確認）", async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ immediate: true, monsterSetId: "buddha" }),
+    }) as unknown as typeof fetch;
+
+    render(<MonsterThemeSelector member={baseMember()} ownedThemes={["dark", "light"]} />);
+
+    const section = screen.getByTestId("monster-theme-section-child-1");
+    fireEvent.click(within(section).getByTestId("monster-theme-option-child-1-buddha"));
+
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
+
+  it("境界値: ownedThemesが空配列でも、isFree:trueのテーマ(dark/light)は選択可能であること", () => {
+    render(<MonsterThemeSelector member={baseMember()} ownedThemes={[]} />);
+
+    const section = screen.getByTestId("monster-theme-section-child-1");
+    const darkBtn = within(section).getByTestId(
+      "monster-theme-option-child-1-dark",
+    ) as HTMLButtonElement;
+    const lightBtn = within(section).getByTestId(
+      "monster-theme-option-child-1-light",
+    ) as HTMLButtonElement;
+    expect(darkBtn.disabled).toBe(false);
+    expect(lightBtn.disabled).toBe(false);
+  });
+});

--- a/src/app/api/family/code/route.ts
+++ b/src/app/api/family/code/route.ts
@@ -3,6 +3,7 @@ import { prisma } from "@/lib/prisma";
 import { getCurrentUser } from "@/lib/auth";
 import { generateFamilyCode } from "@/lib/categories";
 import { log, routeLogger } from "@/lib/logger";
+import { resolveOwnedThemes } from "@/lib/monsterThemes/ownedThemes";
 
 export async function GET() {
   try {
@@ -16,7 +17,10 @@ export async function GET() {
       include: {
         users: {
           orderBy: { createdAt: "asc" },
-          include: { streak: { select: { lastLoginDate: true } } },
+          include: {
+            streak: { select: { lastLoginDate: true } },
+            monsterThemes: { select: { themeId: true } },
+          },
         },
       },
     });
@@ -45,6 +49,10 @@ export async function GET() {
       lastLoginDate: ((u.streak as { lastLoginDate: Date | null } | null)?.lastLoginDate ?? null)
         ? String((u.streak as { lastLoginDate: Date | null }).lastLoginDate)
         : null,
+      ownedThemes: resolveOwnedThemes(
+        u.monsterThemes as { themeId: string }[] | undefined,
+        (u.monsterSetId as string | null) ?? null,
+      ),
     }));
 
     return NextResponse.json({

--- a/src/app/api/family/members/[id]/monster-theme/route.ts
+++ b/src/app/api/family/members/[id]/monster-theme/route.ts
@@ -33,8 +33,14 @@ export async function PATCH(
     return NextResponse.json({ error: "無効なテーマです" }, { status: 400 });
   }
   if (MONSTER_THEMES[themeId].isFree === false) {
-    // 決済導線が未実装のため、有料テーマは一旦選択不可にする（PR #88 Codexレビュー対応）
-    return NextResponse.json({ error: "このテーマは現在選択できません" }, { status: 400 });
+    // 決済導線は未実装だが、開発者による手動DB挿入で「購入済み」として付与された
+    // 子は選択できる（Issue #90）。ChildMonsterTheme の所持レコードで判定する。
+    const owned = await prisma.childMonsterTheme.findUnique({
+      where: { childId_themeId: { childId: id, themeId } },
+    });
+    if (!owned) {
+      return NextResponse.json({ error: "このテーマはまだ購入されていません" }, { status: 400 });
+    }
   }
 
   // 卵（進化前）または転生準備中は演出上の不整合が起きないため即時反映してよい

--- a/src/app/app/parent/(app)/family/page.tsx
+++ b/src/app/app/parent/(app)/family/page.tsx
@@ -36,6 +36,7 @@ type Member = {
   collectedPaths: string;
   monsterSetId: string;
   pendingMonsterSetId: string | null;
+  ownedThemes: string[];
 };
 
 type FamilyData = {
@@ -529,6 +530,7 @@ export default function FamilyPage() {
                   monsterSetId: member.monsterSetId,
                   pendingMonsterSetId: member.pendingMonsterSetId,
                 }}
+                ownedThemes={member.ownedThemes ?? []}
               />
             </div>
             )}

--- a/src/components/parent/MonsterThemeSelector.tsx
+++ b/src/components/parent/MonsterThemeSelector.tsx
@@ -15,7 +15,13 @@ type Message = { type: "success" | "pending" | "error"; text: string };
 
 const THEME_IDS = Object.keys(MONSTER_THEMES);
 
-export default function MonsterThemeSelector({ member }: { member: ThemeSelectorMember }) {
+export default function MonsterThemeSelector({
+  member,
+  ownedThemes,
+}: {
+  member: ThemeSelectorMember;
+  ownedThemes: string[];
+}) {
   const [currentThemeId, setCurrentThemeId] = useState(member.monsterSetId);
   const [pendingThemeId, setPendingThemeId] = useState<string | null>(member.pendingMonsterSetId);
   const [message, setMessage] = useState<Message | null>(null);
@@ -75,7 +81,7 @@ export default function MonsterThemeSelector({ member }: { member: ThemeSelector
         {THEME_IDS.map((themeId) => {
           const theme = MONSTER_THEMES[themeId];
           const isSelected = themeId === currentThemeId;
-          const isLocked = theme.isFree === false;
+          const isLocked = theme.isFree === false && !ownedThemes.includes(themeId);
           return (
             <button
               key={themeId}


### PR DESCRIPTION
## Summary
- 決済導線（Stripe等）が実装されるまでの暫定運用として、開発者が `ChildMonsterTheme` テーブルへ直接 `INSERT`（Prisma Studio 等）することで有料テーマ（`isFree:false`、例: buddha）を子供に「購入済み」として付与し、親画面から選択できるようにした
- `PATCH /api/family/members/[id]/monster-theme`: `isFree:false` テーマの一律拒否を撤去し、`ChildMonsterTheme` の所持レコード有無（`prisma.childMonsterTheme.findUnique`）で判定するように変更。所持レコードが無ければ 400、あれば通常の切替フロー（即時反映 or 転生時予約）に乗る
- `GET /api/family/code`: レスポンスに `ownedThemes`（子供ごとの所持テーマID配列）を追加。`resolveOwnedThemes()` を利用し N+1 なしで解決
- `MonsterThemeSelector` / `family/page.tsx`: `ownedThemes` prop を追加し、所持済みの有料テーマはロック表示を解除して選択可能にした

## 手動付与のSQL例
`ChildMonsterTheme` の実際のカラム定義は `prisma/schema.prisma` を参照。テーブル名・カラム名は Prisma のデフォルト命名（`@@map` 未使用）に従い、モデル名・フィールド名がそのままテーブル名・カラム名になる。

```sql
INSERT INTO "ChildMonsterTheme" ("id", "childId", "themeId", "grantReason")
VALUES (gen_random_uuid()::text, '<childId>', 'buddha', 'manual');
```

- `childId`: 付与したい子供（`User.role = 'CHILD'`）の `id`
- `themeId`: 付与するテーマID（例: `buddha`。有効な値は `src/lib/monsterThemes/index.ts` の `MONSTER_THEMES` を参照）
- `grantReason`: 付与理由の自由文字列。手動付与の場合は `'manual'` を推奨（コード中の `activateChildTheme()` 経由の自動付与は別の値を使う想定）
- `id` は `@default(cuid())`、`activatedAt` は `@default(now())` のため省略可（上記の `id` 生成例は Prisma Studio 等 GUI 挿入時の一例）
- `(childId, themeId)` に `@@unique` 制約があるため、同じ組み合わせを重複挿入すると失敗する

## Test plan
- [x] `npm test`（`npm run test:coverage`）パス — 195 test files / 2707 tests all green
- [x] `npm run lint` パス（フル実行、0 errors）
- [x] `tsc` パス
- [ ] 手動確認: Prisma Studio 等で `ChildMonsterTheme` に buddha レコードを挿入 → 親画面の家族タブでロック解除・選択・保存できることを確認

## 補足
本PRは既存の decisions.md 記載（2026-08-18: モンスターテーマセット機能 Stage 1）の `ChildMonsterTheme`（所持記録テーブル）をそのまま利用する運用上の変更であり、新規のアーキテクチャ決定を伴わないため、decisions.md への追記は行っていません。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
