### PR TITLE
fix(monster): monsterLevelsをテーマ名前空間対応し既存DBを移行

### DIFF
--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -2749,3 +2749,21 @@
 - `src/lib/monsterThemes/` — テーマデータレジストリ
 - `docs/未実装仕様書/monster-theme-sets.md` — 各テーマセットのモンスターデータ仕様
 
+## 2026-08-20: monsterLevels のテーマ名前空間対応と既存DB移行（Issue #93）
+
+### 決定内容
+- `collectedPaths` は Stage 1（Issue #73）の時点で `hasCollectedPath`/`addCollectedPath` によりテーマ名前空間（`"{themeId}:{path}"`）対応済みだったが、`monsterLevels`（進化Stage3到達カウント）は対応漏れで裸のパスキーのまま書き込まれ続けていた。これを`getMonsterLevel`/`incrementMonsterLevel`（`src/lib/monsterThemes/monsterLevels.ts`）で`collectedPaths`と同じ設計に揃えた
+- 既存DBの`collectedPaths`・`monsterLevels`双方について、名前空間の付いていない旧形式エントリを**各ユーザーの`side`から導出したテーマ**（`LIGHT`→`"light"`、それ以外→`"dark"`。Stage1の`monsterSetId`バックフィルと同じ導出ロジック）で一括変換するマイグレーションを実行した（`monsterSetId`ではなく`side`を根拠にした。理由は後述）
+
+### 既知のトレードオフ
+- Issue #73マージ〜本マイグレーション実行までの間に、有料テーマ（buddha等）へ切り替えて実際にStage3到達した進行度があった場合、その進行度は`side`ベースの変換により`dark:`/`light:`名前空間に帰属してしまう（`buddha:`ではなく）。買い切りテーマは決済導線が無い間はAPI側で一律拒否されており（PR #88）、DB直接操作による疑似購入（PR #90）を経て初めて選択可能になった経緯があるため、この移行時点でこのケースに該当する実データは存在しない見込みだが、将来同様の移行を行う際は同じ制約に留意すること
+
+### やってはいけないこと
+- `monsterLevels`を新たに書き込む箇所で、`incrementMonsterLevel()`を経由せず生のパスキーへ直書きする
+- 同種の移行マイグレーションを、冪等性を確認せずに実行する
+
+### 該当箇所
+- `src/lib/monsterThemes/monsterLevels.ts` — `getMonsterLevel`/`incrementMonsterLevel`
+- `src/lib/approve.ts` / `src/lib/streak.ts` / `src/lib/loginStreak.ts` — `monsterLevels`更新箇所
+- `prisma/migrations/20260820000001_namespace_legacy_monster_progress/` — 既存DB移行マイグレーション
+

--- a/prisma/migrations/20260820000001_namespace_legacy_monster_progress/migration.sql
+++ b/prisma/migrations/20260820000001_namespace_legacy_monster_progress/migration.sql
@@ -1,0 +1,48 @@
+-- Issue #93: monsterLevels のテーマ名前空間対応 — 既存DB(collectedPaths/monsterLevels)の
+-- 一括変換マイグレーション。
+--
+-- collectedPaths (JSON配列文字列) と monsterLevels (JSON文字列 {path: count}) について、
+-- 名前空間の付いていない旧形式エントリを、各ユーザーの side から導出したテーマ
+-- (LIGHT → "light"、それ以外（DARK/null）→ "dark") で "{themeId}:{path}" 形式に変換する。
+-- 既に "dark:"/"light:"/"buddha:" のいずれかで始まる要素・キーはそのまま維持する。
+--
+-- 冪等性: 既に名前空間付きの要素・キーはそのまま素通りするため、本SQLは何度実行しても
+-- 結果が変わらない。
+--
+-- NULL または空 ("[]"/"{}") の行は対象外（変換不要のため WHERE 句で UPDATE 自体をスキップする）。
+
+-- collectedPaths: JSON配列の各要素を変換する。
+-- WITH ORDINALITY で元の並び順を維持したまま jsonb_agg に渡す。
+UPDATE "User"
+SET "collectedPaths" = (
+  SELECT jsonb_agg(
+           CASE
+             WHEN elem LIKE 'dark:%' OR elem LIKE 'light:%' OR elem LIKE 'buddha:%' THEN elem
+             ELSE (CASE WHEN "User"."side" = 'LIGHT' THEN 'light' ELSE 'dark' END) || ':' || elem
+           END
+           ORDER BY ord
+         )::text
+  FROM jsonb_array_elements_text("User"."collectedPaths"::jsonb) WITH ORDINALITY AS t(elem, ord)
+)
+WHERE "collectedPaths" IS NOT NULL
+  AND "collectedPaths" NOT IN ('[]', '');
+
+-- monsterLevels: JSONオブジェクトの各キーを変換する。
+-- 変換後のキーが衝突するケース（例: 新形式で書かれた最新の記録と、未変換の旧形式キーが
+-- 同じ変換先を指す場合）に備え、旧形式由来のエントリを先、既に名前空間付きだったエントリを
+-- 後に処理させる。jsonb_object_agg は重複キーの場合「最後に処理された値」を採用する仕様の
+-- ため、結果的に既に名前空間付きだった（＝新しい）値が優先される。
+UPDATE "User"
+SET "monsterLevels" = (
+  SELECT jsonb_object_agg(
+           CASE
+             WHEN key LIKE 'dark:%' OR key LIKE 'light:%' OR key LIKE 'buddha:%' THEN key
+             ELSE (CASE WHEN "User"."side" = 'LIGHT' THEN 'light' ELSE 'dark' END) || ':' || key
+           END,
+           value
+           ORDER BY (CASE WHEN key LIKE 'dark:%' OR key LIKE 'light:%' OR key LIKE 'buddha:%' THEN 1 ELSE 0 END)
+         )::text
+  FROM jsonb_each("User"."monsterLevels"::jsonb)
+)
+WHERE "monsterLevels" IS NOT NULL
+  AND "monsterLevels" NOT IN ('{}', '');

--- a/src/__tests__/components/zukan-content-themes.test.tsx
+++ b/src/__tests__/components/zukan-content-themes.test.tsx
@@ -300,4 +300,51 @@ describe("ZukanContent: テーマ別タブ対応（Issue #86）", () => {
       expect(img.getAttribute("src")).toBe("/monsters/shadow/buddha/STUDY_もんじゅまる.webp");
     });
   });
+
+  // ─── Issue #93: monsterLevels のテーマ別変換漏れ ──────────────────────
+  // monsterLevels は collectedPaths と違いテーマ名前空間対応していない。
+  // 生の path をキーに直書きしているため、あるテーマ(例: dark)で積んだ
+  // stage3到達回数が、無関係な別テーマ(例: buddha)の図鑑Lv表示に混入してしまう。
+  // ZukanEvolutionBranch (呼び出し元 ZukanContent) が
+  // @/lib/monsterThemes/monsterLevels の getMonsterLevel() を使い、
+  // アクティブテーマの名前空間付きキーで読むよう修正されることを期待する。
+  describe("monsterLevelsのテーマ別変換（Issue #93）", () => {
+    it("旧形式（裸のパス）由来のmonsterLevelsが、無関係な有料テーマ(buddha)のLv表示に混入しないこと", async () => {
+      mockFetchOnce({
+        side: "DARK",
+        // buddha でのみ STUDY_STUDY_STUDY まで収集済み（namespace付き）
+        collectedPaths: '["buddha:STUDY","buddha:STUDY_STUDY","buddha:STUDY_STUDY_STUDY"]',
+        // 旧形式の裸キーに既存値7がある（dark/light 由来、または旧実装のバグで書かれたデータ）。
+        // buddha は有料テーマなのでこの値を自分の記録として読んではならない。
+        monsterLevels: '{"STUDY_STUDY_STUDY":7}',
+        usedEggBonuses: "[]",
+        monsterSetId: "buddha",
+        ownedThemes: ["buddha"],
+      });
+
+      render(<ZukanContent />);
+      const buddhaPanel = await waitFor(() => screen.getByTestId("zukan-theme-panel-buddha"));
+
+      // 汚染された旧形式の値(7)が表示されてはならない
+      expect(within(buddhaPanel).queryByText("Lv 7")).toBeNull();
+      // 収集済みだが buddha 名前空間の記録がまだ無いので、Lv 1（デフォルト）になること
+      expect(within(buddhaPanel).getByText("Lv 1")).toBeTruthy();
+    });
+
+    it("無料テーマ(dark)は新形式のmonsterLevelsを正しくLv表示に反映すること", async () => {
+      mockFetchOnce({
+        side: "DARK",
+        collectedPaths: '["dark:STUDY","dark:STUDY_STUDY","dark:STUDY_STUDY_STUDY"]',
+        monsterLevels: '{"dark:STUDY_STUDY_STUDY":4}',
+        usedEggBonuses: "[]",
+        monsterSetId: "dark",
+        ownedThemes: ["dark"],
+      });
+
+      render(<ZukanContent />);
+      const darkPanel = await waitFor(() => screen.getByTestId("zukan-theme-panel-dark"));
+
+      expect(within(darkPanel).getByText("Lv 4")).toBeTruthy();
+    });
+  });
 });

--- a/src/__tests__/lib/approve.test.ts
+++ b/src/__tests__/lib/approve.test.ts
@@ -466,6 +466,98 @@ describe("monsterLevels（最終形態レベル）", () => {
   });
 });
 
+// ─── Issue #93: monsterLevels のテーマ名前空間対応 ─────────────────────
+// @/lib/monsterThemes/monsterLevels.ts の getMonsterLevel/incrementMonsterLevel を
+// 使い、"{monsterSetId}:{path}" 形式で monsterLevels を更新することを検証する。
+// 現状の approve.ts は `monsterLevels[evolution.newPath] = ... + 1` と生キーで
+// 直書きしているため、これらのテストは Red（失敗）になる想定。
+describe("monsterLevels のテーマ名前空間対応（Issue #93）", () => {
+  beforeEach(() => {
+    mockPrisma.questInstance.update.mockResolvedValue(questInstance());
+    mockPrisma.user.update.mockResolvedValue(childUser());
+    vi.spyOn(Math, "random").mockReturnValue(0); // STUDY が選ばれる
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("有料テーマ(buddha)でstage3到達時、monsterLevelsが'buddha:'名前空間付きキーで保存されること", async () => {
+    mockPrisma.user.findUnique.mockResolvedValue(
+      childUser({
+        monsterSetId: "buddha",
+        evolutionStage: 2,
+        evolutionPath: "STUDY_STUDY",
+        studyPt: 29,
+        staminaPt: 0,
+        lifePt: 0,
+        monsterLevels: "{}",
+      }),
+    );
+    await approveQuestInstance(baseQuest);
+    const call = mockPrisma.user.update.mock.calls[0][0];
+    const levels = JSON.parse(call.data.monsterLevels as string) as Record<string, number>;
+    expect(levels).toEqual({ "buddha:STUDY_STUDY_STUDY": 1 });
+  });
+
+  it("有料テーマ(buddha)は無料テーマ由来の旧形式（裸のパス）データを自分の記録として引き継がないこと", async () => {
+    // 旧形式の裸キーに既に値7がある（例: dark/light 時代の記録、または旧実装のバグで書かれたデータ）。
+    // buddha は有料テーマなので、この値を自分のレベルとして引き継いではならない（1から開始する）。
+    mockPrisma.user.findUnique.mockResolvedValue(
+      childUser({
+        monsterSetId: "buddha",
+        evolutionStage: 2,
+        evolutionPath: "STUDY_STUDY",
+        studyPt: 29,
+        staminaPt: 0,
+        lifePt: 0,
+        monsterLevels: '{"STUDY_STUDY_STUDY":7}',
+      }),
+    );
+    await approveQuestInstance(baseQuest);
+    const call = mockPrisma.user.update.mock.calls[0][0];
+    const levels = JSON.parse(call.data.monsterLevels as string) as Record<string, number>;
+    expect(levels["buddha:STUDY_STUDY_STUDY"]).toBe(1);
+  });
+
+  it("無料テーマ(dark)は旧形式（裸のパス）の既存値を引き継いで+1すること", async () => {
+    mockPrisma.user.findUnique.mockResolvedValue(
+      childUser({
+        monsterSetId: "dark",
+        evolutionStage: 2,
+        evolutionPath: "STUDY_STUDY",
+        studyPt: 29,
+        staminaPt: 0,
+        lifePt: 0,
+        monsterLevels: '{"STUDY_STUDY_STUDY":3}',
+      }),
+    );
+    await approveQuestInstance(baseQuest);
+    const call = mockPrisma.user.update.mock.calls[0][0];
+    const levels = JSON.parse(call.data.monsterLevels as string) as Record<string, number>;
+    // 旧形式キーは引き継ぎ元として残ってよいが、新形式キーが 3+1=4 で保存されること
+    expect(levels["dark:STUDY_STUDY_STUDY"]).toBe(4);
+  });
+
+  it("新形式キーが既にある場合は単純に+1すること", async () => {
+    mockPrisma.user.findUnique.mockResolvedValue(
+      childUser({
+        monsterSetId: "buddha",
+        evolutionStage: 2,
+        evolutionPath: "STUDY_STUDY",
+        studyPt: 29,
+        staminaPt: 0,
+        lifePt: 0,
+        monsterLevels: '{"buddha:STUDY_STUDY_STUDY":2}',
+      }),
+    );
+    await approveQuestInstance(baseQuest);
+    const call = mockPrisma.user.update.mock.calls[0][0];
+    const levels = JSON.parse(call.data.monsterLevels as string) as Record<string, number>;
+    expect(levels["buddha:STUDY_STUDY_STUDY"]).toBe(3);
+  });
+});
+
 describe("approveSkipQuestInstance", () => {
   it("SKIPPED に更新しストリークを記録すること", async () => {
     mockPrisma.questInstance.update.mockResolvedValue(questInstance());

--- a/src/__tests__/lib/loginStreak.test.ts
+++ b/src/__tests__/lib/loginStreak.test.ts
@@ -298,4 +298,70 @@ describe("recordLoginActivity", () => {
 
     expect(mockTriggerMonsterEvolvedLog).not.toHaveBeenCalled();
   });
+
+  // ─── Issue #93: monsterLevels のテーマ名前空間対応 ───────────────────
+  // ログインストリークボーナスで stage3 に到達した際、monsterLevels が
+  // "{monsterSetId}:{path}" 形式で保存されることを検証する。
+  // 現状の loginStreak.ts は `monsterLevels[evolution.newPath] = ... + 1` と
+  // 生キーで直書きしているため、これらのテストは Red（失敗）になる想定。
+  describe("monsterLevels のテーマ名前空間対応（Issue #93）", () => {
+    it("有料テーマ(buddha)でstage3到達時、monsterLevelsが'buddha:'名前空間付きキーで保存されること", async () => {
+      vi.spyOn(Math, "random").mockReturnValue(0); // STUDY が選ばれる
+      const yesterday = new Date("2026-03-28");
+      mockPrisma.streak.upsert.mockResolvedValue(
+        streak({ loginCurrentStreak: 9, loginBestStreak: 9, lastLoginDate: yesterday }),
+      );
+      mockPrisma.streak.update.mockResolvedValue(streak());
+      // stage2、29pt蓄積中。ボーナス1ptで total=30 → 30以上なので進化する
+      mockPrisma.user.findUnique.mockResolvedValue(
+        childUser({
+          monsterSetId: "buddha",
+          evolutionStage: 2,
+          evolutionPath: "STUDY_STUDY",
+          studyPt: 29, staminaPt: 0, lifePt: 0,
+          collectedPaths: '["STUDY","STUDY_STUDY"]',
+          // 旧形式の裸キーに既存値7がある（buddha は有料テーマなので引き継いではならない）
+          monsterLevels: '{"STUDY_STUDY_STUDY":7}',
+        }),
+      );
+      mockPrisma.user.update.mockResolvedValue(childUser());
+
+      await recordLoginActivity("child-1", today);
+
+      const updateData = mockPrisma.user.update.mock.calls[0][0].data;
+      expect(updateData.evolutionStage).toBe(3);
+      const levels = JSON.parse(updateData.monsterLevels as string) as Record<string, number>;
+      expect(levels["buddha:STUDY_STUDY_STUDY"]).toBe(1);
+
+      vi.restoreAllMocks();
+    });
+
+    it("無料テーマ(dark)は旧形式（裸のパス）の既存値を引き継いで+1すること", async () => {
+      vi.spyOn(Math, "random").mockReturnValue(0); // STUDY が選ばれる
+      const yesterday = new Date("2026-03-28");
+      mockPrisma.streak.upsert.mockResolvedValue(
+        streak({ loginCurrentStreak: 9, loginBestStreak: 9, lastLoginDate: yesterday }),
+      );
+      mockPrisma.streak.update.mockResolvedValue(streak());
+      mockPrisma.user.findUnique.mockResolvedValue(
+        childUser({
+          monsterSetId: "dark",
+          evolutionStage: 2,
+          evolutionPath: "STUDY_STUDY",
+          studyPt: 29, staminaPt: 0, lifePt: 0,
+          collectedPaths: '["STUDY","STUDY_STUDY"]',
+          monsterLevels: '{"STUDY_STUDY_STUDY":3}',
+        }),
+      );
+      mockPrisma.user.update.mockResolvedValue(childUser());
+
+      await recordLoginActivity("child-1", today);
+
+      const updateData = mockPrisma.user.update.mock.calls[0][0].data;
+      const levels = JSON.parse(updateData.monsterLevels as string) as Record<string, number>;
+      expect(levels["dark:STUDY_STUDY_STUDY"]).toBe(4);
+
+      vi.restoreAllMocks();
+    });
+  });
 });

--- a/src/__tests__/lib/monsterThemes/monsterLevels.test.ts
+++ b/src/__tests__/lib/monsterThemes/monsterLevels.test.ts
@@ -1,0 +1,148 @@
+// Issue #93: monsterLevels（進化Stage3到達カウント）のテーマ名前空間対応の互換ヘルパーテスト。
+// 対象: src/lib/monsterThemes/monsterLevels.ts (未実装。実装は implementer が行う)
+//
+// 仕様（Issue #93 記載分の解釈。@/lib/monsterThemes/collectedPaths.ts と同じ設計思想）:
+//  - 新形式は "{themeId}:{path}" 形式（例: "buddha:STUDY_STUDY_STUDY"）で保存する。
+//  - 旧形式（裸のパス文字列、例: "STUDY_STUDY_STUDY"）は
+//    無料テーマ（dark/light）の記録として引き続き読める後方互換を維持する。
+//  - 有料テーマ（例: buddha）は旧形式（裸のパス文字列）を自分の記録として読まない
+//    （無料テーマ専用の互換レイヤーであるため）。
+//
+// getMonsterLevel(monsterLevels, themeId, path): number
+// incrementMonsterLevel(monsterLevels, themeId, path): Record<string, number>
+//   ※ イミュータブル。新形式キーへ +1（旧形式の値があれば引き継ぐ）。
+
+import { describe, it, expect } from "vitest";
+import { getMonsterLevel, incrementMonsterLevel } from "@/lib/monsterThemes/monsterLevels";
+
+const FREE_THEMES = ["dark", "light"] as const;
+
+describe("getMonsterLevel", () => {
+  it("空オブジェクトは常に 0 を返すこと", () => {
+    expect(getMonsterLevel({}, "dark", "STUDY_STUDY_STUDY")).toBe(0);
+    expect(getMonsterLevel({}, "buddha", "STUDY_STUDY_STUDY")).toBe(0);
+  });
+
+  describe("新形式（テーマ名前空間付き）のみの場合", () => {
+    const levels = { "buddha:STUDY_STUDY_STUDY": 3, "buddha:STAMINA_STAMINA_STAMINA": 1 };
+
+    it("該当テーマなら新形式の値を読めること", () => {
+      expect(getMonsterLevel(levels, "buddha", "STUDY_STUDY_STUDY")).toBe(3);
+      expect(getMonsterLevel(levels, "buddha", "STAMINA_STAMINA_STAMINA")).toBe(1);
+    });
+
+    it("別テーマの名前空間付き記録は 0 を返すこと", () => {
+      expect(getMonsterLevel(levels, "dark", "STUDY_STUDY_STUDY")).toBe(0);
+      expect(getMonsterLevel(levels, "light", "STUDY_STUDY_STUDY")).toBe(0);
+    });
+
+    it("記録されていない path は 0 を返すこと", () => {
+      expect(getMonsterLevel(levels, "buddha", "LIFE_LIFE_LIFE")).toBe(0);
+    });
+  });
+
+  describe("旧形式（裸のパス文字列）のみの場合", () => {
+    const levels = { "STUDY_STUDY_STUDY": 5, "STAMINA_STAMINA_STAMINA": 2 };
+
+    it.each(FREE_THEMES)("無料テーマ(%s)は旧形式を自分の記録として読めること", (themeId) => {
+      expect(getMonsterLevel(levels, themeId, "STUDY_STUDY_STUDY")).toBe(5);
+      expect(getMonsterLevel(levels, themeId, "STAMINA_STAMINA_STAMINA")).toBe(2);
+    });
+
+    it("有料テーマ(buddha)は旧形式を自分の記録として読まず 0 を返すこと", () => {
+      expect(getMonsterLevel(levels, "buddha", "STUDY_STUDY_STUDY")).toBe(0);
+    });
+
+    it("記録されていない path は 0 を返すこと", () => {
+      expect(getMonsterLevel(levels, "dark", "LIFE_LIFE_LIFE")).toBe(0);
+    });
+  });
+
+  describe("旧形式・新形式が混在する場合", () => {
+    const levels = { "STUDY_STUDY_STUDY": 4, "buddha:STAMINA_STAMINA_STAMINA": 6 };
+
+    it("dark: 旧形式の STUDY_STUDY_STUDY は 4、新形式の STAMINA_STAMINA_STAMINA は 0", () => {
+      expect(getMonsterLevel(levels, "dark", "STUDY_STUDY_STUDY")).toBe(4);
+      expect(getMonsterLevel(levels, "dark", "STAMINA_STAMINA_STAMINA")).toBe(0);
+    });
+
+    it("buddha: 新形式の STAMINA_STAMINA_STAMINA は 6、旧形式の STUDY_STUDY_STUDY は 0", () => {
+      expect(getMonsterLevel(levels, "buddha", "STAMINA_STAMINA_STAMINA")).toBe(6);
+      expect(getMonsterLevel(levels, "buddha", "STUDY_STUDY_STUDY")).toBe(0);
+    });
+
+    it("新形式キーが存在する場合は旧形式より新形式が優先されること", () => {
+      const mixed = { "STUDY_STUDY_STUDY": 1, "dark:STUDY_STUDY_STUDY": 9 };
+      expect(getMonsterLevel(mixed, "dark", "STUDY_STUDY_STUDY")).toBe(9);
+    });
+  });
+});
+
+describe("incrementMonsterLevel", () => {
+  it("境界値: 空オブジェクトに対する increment は名前空間付きキーで1になること", () => {
+    const result = incrementMonsterLevel({}, "buddha", "STUDY_STUDY_STUDY");
+    expect(result).toEqual({ "buddha:STUDY_STUDY_STUDY": 1 });
+  });
+
+  it("境界値: 空オブジェクトに dark で increment しても 'dark:' 名前空間付きで1になること", () => {
+    const result = incrementMonsterLevel({}, "dark", "STUDY_STUDY_STUDY");
+    expect(result).toEqual({ "dark:STUDY_STUDY_STUDY": 1 });
+  });
+
+  it("新形式キーが既にある場合は単純に+1すること", () => {
+    const result = incrementMonsterLevel(
+      { "buddha:STUDY_STUDY_STUDY": 2 },
+      "buddha",
+      "STUDY_STUDY_STUDY",
+    );
+    expect(result).toEqual({ "buddha:STUDY_STUDY_STUDY": 3 });
+  });
+
+  it("新形式キーが無く旧形式キーがある場合（無料テーマ）、旧形式の値を引き継いで+1すること", () => {
+    const result = incrementMonsterLevel(
+      { "STUDY_STUDY_STUDY": 3 },
+      "dark",
+      "STUDY_STUDY_STUDY",
+    );
+    // 旧形式キー自体は残ってよい。新形式キーが 3+1=4 で追加される。
+    expect(result).toEqual({ "STUDY_STUDY_STUDY": 3, "dark:STUDY_STUDY_STUDY": 4 });
+  });
+
+  it("旧形式キーがあっても有料テーマ(buddha)では引き継がず1から始まること", () => {
+    const result = incrementMonsterLevel(
+      { "STUDY_STUDY_STUDY": 7 },
+      "buddha",
+      "STUDY_STUDY_STUDY",
+    );
+    expect(result).toEqual({ "STUDY_STUDY_STUDY": 7, "buddha:STUDY_STUDY_STUDY": 1 });
+  });
+
+  it("別パスのincrementは既存のキーに影響しないこと", () => {
+    const result = incrementMonsterLevel(
+      { "buddha:STUDY_STUDY_STUDY": 2 },
+      "buddha",
+      "STAMINA_STAMINA_STAMINA",
+    );
+    expect(result).toEqual({
+      "buddha:STUDY_STUDY_STUDY": 2,
+      "buddha:STAMINA_STAMINA_STAMINA": 1,
+    });
+  });
+
+  it("イミュータブル（元のオブジェクトを変更しない）であること", () => {
+    const original = { "STUDY_STUDY_STUDY": 1 };
+    incrementMonsterLevel(original, "buddha", "STAMINA_STAMINA_STAMINA");
+    expect(original).toEqual({ "STUDY_STUDY_STUDY": 1 });
+  });
+
+  it("複数回のincrementで正しく積み上がること", () => {
+    let levels: Record<string, number> = {};
+    levels = incrementMonsterLevel(levels, "buddha", "STUDY_STUDY_STUDY");
+    levels = incrementMonsterLevel(levels, "buddha", "STUDY_STUDY_STUDY");
+    levels = incrementMonsterLevel(levels, "dark", "STUDY_STUDY_STUDY");
+    expect(levels).toEqual({
+      "buddha:STUDY_STUDY_STUDY": 2,
+      "dark:STUDY_STUDY_STUDY": 1,
+    });
+  });
+});

--- a/src/__tests__/lib/streak.test.ts
+++ b/src/__tests__/lib/streak.test.ts
@@ -315,3 +315,72 @@ describe("recordDailyAchievement", () => {
     expect(mockTriggerMonsterEvolvedLog).not.toHaveBeenCalled();
   });
 });
+
+// ─── Issue #93: monsterLevels のテーマ名前空間対応 ─────────────────────
+// マイルストーンボーナスで stage3 に到達した際、monsterLevels が
+// "{monsterSetId}:{path}" 形式で保存されることを検証する。
+// 現状の streak.ts は `monsterLevels[evolution.newPath] = ... + 1` と
+// 生キーで直書きしているため、これらのテストは Red（失敗）になる想定。
+describe("monsterLevels のテーマ名前空間対応（Issue #93）", () => {
+  const today = new Date("2026-03-13");
+
+  it("有料テーマ(buddha)でstage3到達時、monsterLevelsが'buddha:'名前空間付きキーで保存されること", async () => {
+    vi.spyOn(Math, "random").mockReturnValue(0); // STUDY が選ばれる
+    const yesterday = new Date("2026-03-12");
+    mockPrisma.user.findUnique
+      .mockResolvedValueOnce(childUser({ minTasksForStreak: 1 }))
+      .mockResolvedValueOnce(childUser({
+        monsterSetId: "buddha",
+        studyPt: 26, staminaPt: 2, lifePt: 1,
+        evolutionStage: 2,
+        evolutionPath: "STUDY_STUDY",
+        collectedPaths: '["STUDY","STUDY_STUDY"]',
+        // 旧形式の裸キーに既存値7がある（buddha は有料テーマなので引き継いではならない）
+        monsterLevels: '{"STUDY_STUDY_STUDY":7}',
+      }));
+    mockCounts(1, 3);
+    mockPrisma.streak.upsert.mockResolvedValue(
+      streak({ currentStreak: 2, bestStreak: 2, lastAchievedDate: yesterday }),
+    );
+    mockPrisma.streak.update.mockResolvedValue(streak());
+    mockPrisma.user.update.mockResolvedValue(childUser());
+
+    await recordDailyAchievement("child-1", today);
+
+    const updateData = mockPrisma.user.update.mock.calls[0][0].data;
+    expect(updateData.evolutionStage).toBe(3);
+    const levels = JSON.parse(updateData.monsterLevels as string) as Record<string, number>;
+    expect(levels["buddha:STUDY_STUDY_STUDY"]).toBe(1);
+
+    vi.restoreAllMocks();
+  });
+
+  it("無料テーマ(dark)は旧形式（裸のパス）の既存値を引き継いで+1すること", async () => {
+    vi.spyOn(Math, "random").mockReturnValue(0); // STUDY が選ばれる
+    const yesterday = new Date("2026-03-12");
+    mockPrisma.user.findUnique
+      .mockResolvedValueOnce(childUser({ minTasksForStreak: 1 }))
+      .mockResolvedValueOnce(childUser({
+        monsterSetId: "dark",
+        studyPt: 26, staminaPt: 2, lifePt: 1,
+        evolutionStage: 2,
+        evolutionPath: "STUDY_STUDY",
+        collectedPaths: '["STUDY","STUDY_STUDY"]',
+        monsterLevels: '{"STUDY_STUDY_STUDY":3}',
+      }));
+    mockCounts(1, 3);
+    mockPrisma.streak.upsert.mockResolvedValue(
+      streak({ currentStreak: 2, bestStreak: 2, lastAchievedDate: yesterday }),
+    );
+    mockPrisma.streak.update.mockResolvedValue(streak());
+    mockPrisma.user.update.mockResolvedValue(childUser());
+
+    await recordDailyAchievement("child-1", today);
+
+    const updateData = mockPrisma.user.update.mock.calls[0][0].data;
+    const levels = JSON.parse(updateData.monsterLevels as string) as Record<string, number>;
+    expect(levels["dark:STUDY_STUDY_STUDY"]).toBe(4);
+
+    vi.restoreAllMocks();
+  });
+});

--- a/src/components/child/ZukanContent.tsx
+++ b/src/components/child/ZukanContent.tsx
@@ -177,6 +177,7 @@ export default function ZukanContent({
             collected={collected}
             monsterLevels={monsterLevels}
             monsterTable={monsterTable}
+            themeId={activeTheme}
             openModal={openModal}
           />
         ))}

--- a/src/components/child/ZukanEvolutionBranch.tsx
+++ b/src/components/child/ZukanEvolutionBranch.tsx
@@ -5,6 +5,7 @@ import { getEvolutionChildren } from "@/lib/monsters";
 import { CATEGORY_LABEL } from "@/lib/categories";
 import type { Category } from "@/types";
 import { getS3Aura } from "@/lib/s3Aura";
+import { getMonsterLevel } from "@/lib/monsterThemes/monsterLevels";
 import PathChips from "./PathChips";
 
 function shadowPath(imagePath: string): string {
@@ -24,6 +25,7 @@ interface ZukanEvolutionBranchProps {
   collected: Set<string>;
   monsterLevels: Record<string, number>;
   monsterTable: Record<string, MonsterEntry>;
+  themeId: string;
   openModal: (image: string, name: string, path: string) => void;
 }
 
@@ -32,6 +34,7 @@ export default function ZukanEvolutionBranch({
   collected,
   monsterLevels,
   monsterTable,
+  themeId,
   openModal,
 }: ZukanEvolutionBranchProps) {
   const s1Color = CATEGORY_COLORS[s1] ?? { r: 154, g: 140, b: 110 };
@@ -142,8 +145,10 @@ export default function ZukanEvolutionBranch({
                 {s3Keys.map((s3) => {
                   const m3 = monsterTable[s3];
                   const isS3Collected = collected.has(s3);
-                  // Lv: monsterLevels に記録があればその値、収集済みだが記録なし（旧データ）は 1
-                  const lv = monsterLevels[s3] ?? (isS3Collected ? 1 : 0);
+                  // Lv: monsterLevels に記録があればその値（テーマ名前空間対応）、
+                  // 収集済みだが記録なし（旧データ）は 1
+                  const recordedLv = getMonsterLevel(monsterLevels, themeId, s3);
+                  const lv = recordedLv > 0 ? recordedLv : isS3Collected ? 1 : 0;
                   const aura = isS3Collected ? getS3Aura(lv) : null;
                   return (
                     <div

--- a/src/lib/approve.ts
+++ b/src/lib/approve.ts
@@ -7,6 +7,7 @@ import { log } from "@/lib/logger";
 import { calculateQuestXP } from "@/lib/xp";
 import { getMonsterStage } from "@/lib/monsters";
 import { addCollectedPath } from "@/lib/monsterThemes/collectedPaths";
+import { incrementMonsterLevel } from "@/lib/monsterThemes/monsterLevels";
 import { triggerMonsterEvolvedLog, triggerBadgeLog } from "@/lib/bulletinLog";
 import { DECLARATION_BONUS_XP } from "@/lib/declaration";
 import { todayJST, jstDateOf } from "@/lib/date";
@@ -136,7 +137,7 @@ export async function approveQuestInstance(quest: QuestWithRelations, stamp?: st
     );
 
     let collectedPaths = JSON.parse(child.collectedPaths) as string[];
-    const monsterLevels = JSON.parse(child.monsterLevels ?? "{}") as Record<string, number>;
+    let monsterLevels = JSON.parse(child.monsterLevels ?? "{}") as Record<string, number>;
 
     if (evolution.reborn) {
       // 転生閾値到達: pendingフラグをセット（実際のリセットはユーザー操作後）
@@ -154,7 +155,7 @@ export async function approveQuestInstance(quest: QuestWithRelations, stamp?: st
       if (evolution.evolved) {
         collectedPaths = addCollectedPath(collectedPaths, child.monsterSetId, evolution.newPath);
         if (evolution.newStage === 3) {
-          monsterLevels[evolution.newPath] = (monsterLevels[evolution.newPath] ?? 0) + 1;
+          monsterLevels = incrementMonsterLevel(monsterLevels, child.monsterSetId, evolution.newPath);
         }
         log.info("Monster evolved", {
           childId: quest.childId,

--- a/src/lib/loginStreak.ts
+++ b/src/lib/loginStreak.ts
@@ -3,6 +3,7 @@ import { prisma } from "@/lib/prisma";
 import { checkEvolution } from "@/lib/evolution";
 import { getMonsterStage } from "@/lib/monsters";
 import { addCollectedPath } from "@/lib/monsterThemes/collectedPaths";
+import { incrementMonsterLevel } from "@/lib/monsterThemes/monsterLevels";
 import { triggerMonsterEvolvedLog } from "@/lib/bulletinLog";
 import { log } from "@/lib/logger";
 
@@ -99,7 +100,7 @@ async function applyLoginBonus(childId: string, bonus: number): Promise<void> {
 
   const collectedPaths = JSON.parse(child.collectedPaths) as string[];
   const isReborn = collectedPaths.length > 0;
-  const monsterLevels = JSON.parse(child.monsterLevels ?? "{}") as Record<string, number>;
+  let monsterLevels = JSON.parse(child.monsterLevels ?? "{}") as Record<string, number>;
 
   const evolution = checkEvolution(
     child.evolutionStage,
@@ -126,7 +127,7 @@ async function applyLoginBonus(childId: string, bonus: number): Promise<void> {
     if (evolution.evolved) {
       newCollectedPaths = addCollectedPath(collectedPaths, child.monsterSetId, evolution.newPath);
       if (evolution.newStage === 3) {
-        monsterLevels[evolution.newPath] = (monsterLevels[evolution.newPath] ?? 0) + 1;
+        monsterLevels = incrementMonsterLevel(monsterLevels, child.monsterSetId, evolution.newPath);
       }
       const evolvedMonster = getMonsterStage(evolution.newStage, evolution.newPath, child.monsterSetId);
       const evolvedName = evolvedMonster?.name ?? evolution.newPath;

--- a/src/lib/monsterThemes/monsterLevels.ts
+++ b/src/lib/monsterThemes/monsterLevels.ts
@@ -1,0 +1,43 @@
+// monsterLevels (User.monsterLevels, JSON文字列 {path: count} 形式) のテーマ名前空間対応ヘルパー。
+//
+// 新形式: "{themeId}:{path}" (例: "buddha:STUDY_STUDY_STUDY")
+// 旧形式: 裸のパス文字列 (例: "STUDY_STUDY_STUDY")。既存ユーザーのデータ互換のため、
+//         無料テーマ (dark/light) の記録として引き続き読める。
+//         有料テーマ (buddha 等) は旧形式を自分の記録として読まない。
+//
+// @/lib/monsterThemes/collectedPaths.ts と同じ設計思想。
+
+const FREE_THEME_IDS = new Set(["dark", "light"]);
+
+function namespacedKey(themeId: string, path: string): string {
+  return `${themeId}:${path}`;
+}
+
+/** monsterLevels から指定テーマ・パスの stage3 到達カウントを取得する。 */
+export function getMonsterLevel(
+  monsterLevels: Record<string, number>,
+  themeId: string,
+  path: string,
+): number {
+  const namespaced = namespacedKey(themeId, path);
+  if (namespaced in monsterLevels) return monsterLevels[namespaced];
+  // 旧形式（裸のパス文字列）は無料テーマ（dark/light）の記録としてのみ読む
+  if (FREE_THEME_IDS.has(themeId) && path in monsterLevels) return monsterLevels[path];
+  return 0;
+}
+
+/**
+ * monsterLevels に指定テーマ・パスの stage3 到達カウントを +1 する（イミュータブル）。
+ * 新形式キーが既にあればその値に+1。無ければ getMonsterLevel で読める既存値
+ * （旧形式含む）を引き継いで+1した値を新形式キーとして保存する。
+ * 旧形式キーはそのまま残す。
+ */
+export function incrementMonsterLevel(
+  monsterLevels: Record<string, number>,
+  themeId: string,
+  path: string,
+): Record<string, number> {
+  const namespaced = namespacedKey(themeId, path);
+  const current = getMonsterLevel(monsterLevels, themeId, path);
+  return { ...monsterLevels, [namespaced]: current + 1 };
+}

--- a/src/lib/streak.ts
+++ b/src/lib/streak.ts
@@ -3,6 +3,7 @@ import { prisma } from "@/lib/prisma";
 import { checkEvolution } from "@/lib/evolution";
 import { getMonsterStage } from "@/lib/monsters";
 import { addCollectedPath } from "@/lib/monsterThemes/collectedPaths";
+import { incrementMonsterLevel } from "@/lib/monsterThemes/monsterLevels";
 import { getNewMilestoneBonus, distributeBonus, STREAK_MILESTONES } from "@/lib/streakMilestones";
 import { log } from "@/lib/logger";
 import { triggerStreakTitleLog, triggerMonsterEvolvedLog } from "@/lib/bulletinLog";
@@ -95,7 +96,7 @@ export async function recordDailyAchievement(childId: string, questDate: Date) {
       } else {
         const collectedPaths = JSON.parse(latestChild.collectedPaths) as string[];
         const isReborn = collectedPaths.length > 0;
-        const monsterLevels = JSON.parse(latestChild.monsterLevels ?? "{}") as Record<string, number>;
+        let monsterLevels = JSON.parse(latestChild.monsterLevels ?? "{}") as Record<string, number>;
 
         const evolution = checkEvolution(
           latestChild.evolutionStage,
@@ -122,7 +123,7 @@ export async function recordDailyAchievement(childId: string, questDate: Date) {
           if (evolution.evolved) {
             newCollectedPaths = addCollectedPath(collectedPaths, latestChild.monsterSetId, evolution.newPath);
             if (evolution.newStage === 3) {
-              monsterLevels[evolution.newPath] = (monsterLevels[evolution.newPath] ?? 0) + 1;
+              monsterLevels = incrementMonsterLevel(monsterLevels, latestChild.monsterSetId, evolution.newPath);
             }
             const evolvedMonster = getMonsterStage(evolution.newStage, evolution.newPath, latestChild.monsterSetId);
             const evolvedName = evolvedMonster?.name ?? evolution.newPath;


### PR DESCRIPTION
## Summary
- `monsterLevels`（進化Stage3到達カウント）がテーマ名前空間未対応（`collectedPaths`はIssue #73で対応済み）だった問題を修正し、`getMonsterLevel`/`incrementMonsterLevel`（`src/lib/monsterThemes/monsterLevels.ts`）に統一
- `approve.ts`/`streak.ts`/`loginStreak.ts`の`monsterLevels`直書き箇所を名前空間対応の呼び出しに置換（進化規約チェックリストは維持）
- `ZukanEvolutionBranch`/`ZukanContent`に`themeId`を配線し、図鑑のLv表示を名前空間対応にする
- 既存DBの`collectedPaths`/`monsterLevels`にある旧形式（名前空間なし）エントリを、各ユーザーの`side`から導出したテーマで一括変換する冪等マイグレーションを追加

## Test plan
- [x] `npm test` パス（196 test files / 2742 tests, green）
- [x] `npm run lint` パス
- [x] `tsc` パス
- [x] `prisma validate` パス
- [ ] マイグレーションSQLは実DB未検証。**Vercelプレビュービルドの`prisma migrate deploy`実行結果（Vercelチェックの成否）で最終検証すること**

## Related decision
- `docs/decisions.md#2026-08-20`

Closes #93

🤖 Generated with [Claude Code](https://claude.com/claude-code)
