### PR TITLE
fix(child-view): 代理報告・スキップ後にモンスターEXP表示を更新

### DIFF
--- a/src/__tests__/components/child-view-quests-page.test.tsx
+++ b/src/__tests__/components/child-view-quests-page.test.tsx
@@ -274,3 +274,60 @@ describe("ChildViewQuestsPage: モンスターミニカード（キャラクタ�
     );
   });
 });
+
+describe("ChildViewQuestsPage: 代理報告後の EXP 再取得（Issue #96 回帰防止）", () => {
+  it("代理報告成功後に monster-status を再フェッチし、MonsterMiniCard の EXP 表示が更新される", async () => {
+    let monsterStatusCallCount = 0;
+    global.fetch = vi.fn().mockImplementation((url: string, init?: RequestInit) => {
+      if (url.includes("/api/parent/child-view/quests/today")) {
+        return Promise.resolve({ ok: true, json: () => Promise.resolve([baseQuest]) });
+      }
+      if (url.includes("/api/parent/child-view/monster-status")) {
+        monsterStatusCallCount++;
+        // 初回: studyPt=1（あと9ptで進化）/ 再取得後: studyPt=4（あと6ptで進化）
+        const studyPt = monsterStatusCallCount === 1 ? 1 : 4;
+        return Promise.resolve({
+          ok: true,
+          json: () =>
+            Promise.resolve({
+              name: "たろう",
+              side: null,
+              evolutionStage: 1,
+              evolutionPath: "",
+              collectedPaths: "[]",
+              studyPt,
+              staminaPt: 0,
+              lifePt: 0,
+              rebirthEggBonus: null,
+            }),
+        });
+      }
+      if (url.includes("/report-approve") && init?.method === "POST") {
+        return Promise.resolve({ ok: true, json: () => Promise.resolve({ ok: true, treasureIds: [] }) });
+      }
+      return Promise.resolve({ ok: false, json: () => Promise.resolve({}) });
+    }) as unknown as typeof fetch;
+
+    await act(async () => {
+      render(<ChildViewQuestsPage />);
+    });
+    await waitFor(() => expect(screen.getByText("宿題")).toBeTruthy());
+    // 初回ロード時点の EXP 表示
+    await waitFor(() => expect(screen.getByText(/あと 9 pt で進化/)).toBeTruthy());
+
+    await act(async () => {
+      fireEvent.click(screen.getByText("宿題"));
+    });
+    await waitFor(() => expect(screen.getByTestId("quest-sheet")).toBeTruthy());
+
+    await act(async () => {
+      fireEvent.click(screen.getByTestId("trigger-report"));
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    // monster-status が再フェッチされ、表示が更新後の値になっていること
+    await waitFor(() => expect(monsterStatusCallCount).toBeGreaterThanOrEqual(2));
+    await waitFor(() => expect(screen.getByText(/あと 6 pt で進化/)).toBeTruthy());
+  });
+});

--- a/src/__tests__/components/child-view-quests-skip-and-cutscene.test.tsx
+++ b/src/__tests__/components/child-view-quests-skip-and-cutscene.test.tsx
@@ -223,3 +223,42 @@ describe("ChildViewQuestsPage: 進化カットインのトリガー", () => {
     }
   });
 });
+
+describe("ChildViewQuestsPage: 代理スキップ後の EXP 再取得（Issue #96 回帰防止）", () => {
+  it("代理スキップ成功後に monster-status を再フェッチする", async () => {
+    let monsterStatusCallCount = 0;
+    global.fetch = vi.fn().mockImplementation((url: string, init?: RequestInit) => {
+      if (url.includes("/api/parent/child-view/quests/today")) {
+        return Promise.resolve({ ok: true, json: () => Promise.resolve([baseQuest]) });
+      }
+      if (url.includes("/api/parent/child-view/monster-status")) {
+        monsterStatusCallCount++;
+        return Promise.resolve({ ok: true, json: () => Promise.resolve({ name: "たろう" }) });
+      }
+      if (url.includes("/skip-approve") && init?.method === "POST") {
+        return Promise.resolve({ ok: true, json: () => Promise.resolve({ ok: true, treasureIds: [] }) });
+      }
+      return Promise.resolve({ ok: false, json: () => Promise.resolve({}) });
+    }) as unknown as typeof fetch;
+
+    await act(async () => {
+      render(<ChildViewQuestsPage />);
+    });
+    await waitFor(() => expect(screen.getByText("宿題")).toBeTruthy());
+    await waitFor(() => expect(monsterStatusCallCount).toBe(1));
+
+    await act(async () => {
+      fireEvent.click(screen.getByText("宿題"));
+    });
+    await waitFor(() => expect(screen.getByTestId("quest-sheet")).toBeTruthy());
+
+    await act(async () => {
+      fireEvent.click(screen.getByTestId("trigger-skip"));
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    // 代理スキップ後にも monster-status が再フェッチされ、EXP 表示更新のトリガーとなること
+    await waitFor(() => expect(monsterStatusCallCount).toBeGreaterThanOrEqual(2));
+  });
+});

--- a/src/app/app/parent/child-view/[childId]/quests/page.tsx
+++ b/src/app/app/parent/child-view/[childId]/quests/page.tsx
@@ -122,7 +122,8 @@ export default function ChildViewQuestsPage() {
     }
     // 代理操作で進化が走った可能性を ChildViewMonsterCutsceneListener に知らせる（Realtime 不使用のため明示通知）
     window.dispatchEvent(new CustomEvent("child-view-monster-refresh"));
-    await refreshQuests();
+    // クエスト一覧に加え、モンスターの EXP 表示（MonsterMiniCard）も再取得する（Issue #96）
+    await Promise.all([refreshQuests(), fetchChildName()]);
   }
 
   async function handleSkip(questId: string, reason: string) {
@@ -144,7 +145,8 @@ export default function ChildViewQuestsPage() {
       // ignore
     }
     window.dispatchEvent(new CustomEvent("child-view-monster-refresh"));
-    await refreshQuests();
+    // クエスト一覧に加え、モンスターの EXP 表示（MonsterMiniCard）も再取得する（Issue #96）
+    await Promise.all([refreshQuests(), fetchChildName()]);
   }
 
   const completedCount = computeCompletedCount(quests);


### PR DESCRIPTION
## Summary
- 親代理画面（`/app/parent/child-view/[childId]/quests`）でタスクを完了/スキップ承認しても、モンスターの EXP 表示（`MonsterMiniCard`）が更新されない不具合を修正
- `handleReport`/`handleSkip` の成功後処理を `await refreshQuests();` から `await Promise.all([refreshQuests(), fetchChildName()]);` に変更し、クエスト一覧とモンスター情報を同時に再取得するようにした

## Test plan
- [x] `npm test` パス（2744 tests passed）
- [ ] `npm run lint` パス
- [x] 該当機能のテスト追加（`src/__tests__/components/child-view-quests-page.test.tsx`, `src/__tests__/components/child-view-quests-skip-and-cutscene.test.tsx`）

Closes #96

🤖 Generated with [Claude Code](https://claude.com/claude-code)
