### PR TITLE
fix(monster): ミニカードがbuddhaテーマを無視する不具合を修正

### DIFF
--- a/src/__tests__/lib/monster-mini.test.ts
+++ b/src/__tests__/lib/monster-mini.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from "vitest";
 import { getMonsterMiniData } from "@/lib/monster-mini";
 import { REBIRTH_THRESHOLD } from "@/lib/evolution";
+import { getMonsterStage } from "@/lib/monsters";
 
 const base = {
   evolutionStage: 1,
@@ -120,5 +121,34 @@ describe("getMonsterMiniData", () => {
       rebirthEggBonus: "STUDY",
     });
     expect(result.image).toBe("/monsters/dark/STUDY_ラーン.webp");
+  });
+
+  it("monsterSetId='buddha' を渡すと side に関わらず buddha テーマの画像を返す", () => {
+    const expected = getMonsterStage(base.evolutionStage, base.evolutionPath, "buddha");
+    const result = getMonsterMiniData({
+      ...base,
+      side: "LIGHT", // side は無視され monsterSetId が優先されるはず
+      monsterSetId: "buddha",
+    });
+    expect(result.image).toBe(expected.image);
+    expect(result.monsterName).toBe(expected.name);
+    // buddha は dark/light とは異なる画像パスであることの確認（回帰防止）
+    expect(result.image).not.toBe("/monsters/dark/STUDY_ラーン.webp");
+    expect(result.image).not.toBe("/monsters/light/STUDY_ルミナ.webp");
+  });
+
+  it("monsterSetId を渡さない場合は従来通り side によるフォールバック(dark)になる", () => {
+    const result = getMonsterMiniData(base); // monsterSetId 省略, side=null
+    expect(result.image).toBe("/monsters/dark/STUDY_ラーン.webp");
+  });
+
+  it("monsterSetId が null の場合も side によるフォールバックになる（境界値）", () => {
+    const result = getMonsterMiniData({
+      ...base,
+      side: "LIGHT",
+      monsterSetId: null,
+    });
+    expect(result.image).toBe("/monsters/light/STUDY_ルミナ.webp");
+    expect(result.monsterName).toBe("ルミナ");
   });
 });

--- a/src/app/api/parent/child-view/children/route.ts
+++ b/src/app/api/parent/child-view/children/route.ts
@@ -25,6 +25,7 @@ export async function GET() {
       lifePt: true,
       collectedPaths: true,
       rebirthEggBonus: true,
+      monsterSetId: true,
     },
     orderBy: { name: "asc" },
   });

--- a/src/app/api/parent/child-view/monster-status/route.ts
+++ b/src/app/api/parent/child-view/monster-status/route.ts
@@ -70,6 +70,7 @@ export async function GET(request: Request) {
     pendingLifePt,
     rebirthPending: child.rebirthPending,
     rebirthEggBonus: child.rebirthEggBonus,
+    monsterSetId: child.monsterSetId,
     currentStreak: streakRecord?.currentStreak ?? 0,
     bestStreak: streakRecord?.bestStreak ?? 0,
     monthlyDays: monthlyQuests.length,

--- a/src/app/app/child/quests/page.tsx
+++ b/src/app/app/child/quests/page.tsx
@@ -95,6 +95,7 @@ export default function QuestsPage() {
         lifePt: d.lifePt,
         collectedPaths: d.collectedPaths ?? "[]",
         rebirthEggBonus: d.rebirthEggBonus ?? null,
+        monsterSetId: d.monsterSetId ?? null,
       }),
     );
   }

--- a/src/app/app/parent/child-view/[childId]/monster/page.tsx
+++ b/src/app/app/parent/child-view/[childId]/monster/page.tsx
@@ -24,6 +24,7 @@ type MonsterStatus = {
   pendingLifePt: number;
   rebirthPending: boolean;
   rebirthEggBonus: string | null;
+  monsterSetId: string;
   currentStreak: number;
   bestStreak: number;
   monthlyDays: number;
@@ -85,6 +86,7 @@ export default function ChildViewMonsterPage() {
     lifePt: status.lifePt,
     collectedPaths: status.collectedPaths,
     rebirthEggBonus: status.rebirthEggBonus,
+    monsterSetId: status.monsterSetId,
   });
 
   const progressPct = mini.isRebirth

--- a/src/app/app/parent/child-view/[childId]/quests/page.tsx
+++ b/src/app/app/parent/child-view/[childId]/quests/page.tsx
@@ -88,6 +88,7 @@ export default function ChildViewQuestsPage() {
             lifePt: d.lifePt,
             collectedPaths: d.collectedPaths ?? "[]",
             rebirthEggBonus: d.rebirthEggBonus ?? null,
+            monsterSetId: d.monsterSetId ?? null,
           }),
         );
       }

--- a/src/app/app/parent/child-view/page.tsx
+++ b/src/app/app/parent/child-view/page.tsx
@@ -19,6 +19,7 @@ type Child = {
   lifePt: number;
   collectedPaths: string;
   rebirthEggBonus: string | null;
+  monsterSetId: string;
 };
 
 export default function ChildViewSelectorPage() {
@@ -86,6 +87,7 @@ export default function ChildViewSelectorPage() {
                 lifePt: c.lifePt,
                 collectedPaths: c.collectedPaths,
                 rebirthEggBonus: c.rebirthEggBonus,
+                monsterSetId: c.monsterSetId,
               });
               const xpMax = mini.isRebirth ? mini.rebirthThreshold : mini.ptToEvolve ?? 0;
               const xpPct = xpMax > 0 ? Math.min(100, (mini.ptCurrent / xpMax) * 100) : 0;

--- a/src/lib/monster-mini.ts
+++ b/src/lib/monster-mini.ts
@@ -27,10 +27,11 @@ export function getMonsterMiniData(params: {
   lifePt: number;
   collectedPaths: string;
   rebirthEggBonus?: string | null;
+  monsterSetId?: string | null;
 }): MonsterMiniData {
-  const { evolutionStage, evolutionPath, side, studyPt, staminaPt, lifePt, collectedPaths, rebirthEggBonus } = params;
+  const { evolutionStage, evolutionPath, side, studyPt, staminaPt, lifePt, collectedPaths, rebirthEggBonus, monsterSetId } = params;
   const isReborn = (JSON.parse(collectedPaths) as string[]).length > 0;
-  const monster = getMonsterStage(evolutionStage, evolutionPath, themeIdFromSide(side));
+  const monster = getMonsterStage(evolutionStage, evolutionPath, monsterSetId ? monsterSetId : themeIdFromSide(side));
   const xpInfo = getXpInfo(evolutionStage, evolutionPath, studyPt, staminaPt, lifePt, isReborn, rebirthEggBonus);
   
   // 転生後の卵は選択した卵タイプの画像を表示する


### PR DESCRIPTION
## Summary
- `getMonsterMiniData()`（`src/lib/monster-mini.ts`）が `monsterSetId` を受け取れず、`side` からdark/lightしか解決できなかったためbuddhaテーマがミニカード表示に反映されない不具合を修正
- `/api/parent/child-view/children`・`/api/parent/child-view/monster-status` のレスポンスに `monsterSetId` を追加
- 呼び出し元4画面（子供本人のクエスト画面、親の子選択一覧、親代理クエスト画面、親代理モンスター詳細画面）すべてで `monsterSetId` を渡すよう修正

## Test plan
- [x] `npm test` パス（196 files / 2747 tests）
- [ ] `npm run lint` パス
- [x] `src/__tests__/lib/monster-mini.test.ts` に monsterSetId 優先ロジックのテストを追加

Closes #98

🤖 Generated with [Claude Code](https://claude.com/claude-code)
