### PR TITLE
fix(monster): モンスター表示の残り4箇所がbuddhaテーマを無視する不具合を修正

### DIFF
--- a/src/__tests__/components/child-monster-page-theme.test.tsx
+++ b/src/__tests__/components/child-monster-page-theme.test.tsx
@@ -1,0 +1,136 @@
+// @vitest-environment jsdom
+//
+// Issue #100: themeIdFromSide(side) のみに頼ると dark/light の2択にしか解決できず、
+// monsterSetId（buddha等）が無視されるバグの残存箇所1
+// 対象: src/app/app/child/monster/page.tsx
+//
+// useMonsterStatus() が返す data.monsterSetId を getMonsterStage の第3引数に渡すべきだが、
+// 現状は themeIdFromSide(data.side) のみを渡しているため、
+// monsterSetId==="buddha" でも dark/light テーブルの画像が表示されてしまう。
+
+import { render, screen, waitFor } from "@testing-library/react";
+import { describe, it, expect, vi, afterEach } from "vitest";
+import React from "react";
+
+vi.mock("next/image", () => ({
+  __esModule: true,
+  default: ({ src, alt }: { src: string; alt: string }) => (
+    <img src={src} alt={alt} />
+  ),
+}));
+
+vi.mock("@/components/LoadingSpinner", () => ({
+  default: () => <div data-testid="spinner" />,
+}));
+
+vi.mock("@/components/child/EggSelectionModal", () => ({
+  default: () => <div data-testid="egg-selection-modal" />,
+}));
+
+vi.mock("@/components/child/CutsceneOverlay", () => ({
+  default: () => <div data-testid="cutscene-overlay" />,
+}));
+
+vi.mock("@/components/child/EvolutionProgressCard", () => ({
+  default: () => <div data-testid="evolution-progress-card" />,
+}));
+
+vi.mock("@/components/child/StreakCard", () => ({
+  default: () => <div data-testid="streak-card" />,
+}));
+
+vi.mock("@/components/child/ParameterCardList", () => ({
+  default: () => <div data-testid="parameter-card-list" />,
+}));
+
+import type { MonsterData, StreakData } from "@/hooks/useMonsterStatus";
+
+const mockUseMonsterStatus = vi.fn();
+vi.mock("@/hooks/useMonsterStatus", () => ({
+  useMonsterStatus: () => mockUseMonsterStatus(),
+}));
+
+import MonsterPage from "@/app/app/child/monster/page";
+
+function makeData(overrides: Partial<MonsterData> = {}): MonsterData {
+  return {
+    name: "たろうのモンスター",
+    side: "DARK",
+    monsterSetId: "dark",
+    evolutionStage: 1,
+    evolutionPath: "STUDY",
+    collectedPaths: "[]",
+    studyPt: 3,
+    staminaPt: 0,
+    lifePt: 0,
+    pendingStudyPt: 0,
+    pendingStaminaPt: 0,
+    pendingLifePt: 0,
+    rebirthPending: false,
+    rebirthEggBonus: null,
+    ...overrides,
+  };
+}
+
+const streak: StreakData = {
+  currentStreak: 0,
+  bestStreak: 0,
+  monthlyDays: 0,
+  lastAchievedDate: null,
+  currentTitle: null,
+};
+
+function setupHook(data: MonsterData, hookOverrides: Record<string, unknown> = {}) {
+  mockUseMonsterStatus.mockReturnValue({
+    data,
+    streak,
+    loading: false,
+    reborn: false,
+    setReborn: vi.fn(),
+    unlockedAchievement: null,
+    setUnlockedAchievement: vi.fn(),
+    setData: vi.fn(),
+    fetchStatus: vi.fn(),
+    ...hookOverrides,
+  });
+}
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("子 育成ページ: モンスターテーマ解決（Issue #100）", () => {
+  it("monsterSetId が buddha のとき、buddhaテーマの画像が表示される（side は無視される）", async () => {
+    // side は DARK のままだが monsterSetId が buddha を優先するべき
+    setupHook(makeData({ side: "DARK", monsterSetId: "buddha", evolutionStage: 1, evolutionPath: "STUDY" }));
+
+    render(<MonsterPage />);
+
+    await waitFor(() => {
+      const img = screen.getByAltText("文殊丸");
+      expect((img as HTMLImageElement).src).toContain("/monsters/buddha/STUDY_");
+    });
+  });
+
+  it("monsterSetId が dark のとき、darkテーマの画像が表示される（回帰確認）", async () => {
+    setupHook(makeData({ side: "DARK", monsterSetId: "dark", evolutionStage: 1, evolutionPath: "STUDY" }));
+
+    render(<MonsterPage />);
+
+    await waitFor(() => {
+      const img = screen.getByAltText("ラーン");
+      expect((img as HTMLImageElement).src).toContain("/monsters/dark/STUDY_");
+    });
+  });
+
+  it("境界値: monsterSetId が buddha かつ evolutionStage===0（卵）のとき buddha の卵画像が表示される", async () => {
+    setupHook(makeData({ side: "LIGHT", monsterSetId: "buddha", evolutionStage: 0, evolutionPath: "", rebirthEggBonus: null }));
+
+    render(<MonsterPage />);
+
+    await waitFor(() => {
+      const img = screen.getByAltText("たまご");
+      expect((img as HTMLImageElement).src).toContain("/monsters/buddha/egg.webp");
+    });
+  });
+});

--- a/src/__tests__/components/child-view-monster-cutscene-listener.test.tsx
+++ b/src/__tests__/components/child-view-monster-cutscene-listener.test.tsx
@@ -18,6 +18,7 @@ type Status = {
   evolutionStage: number;
   evolutionPath: string;
   side: string | null;
+  monsterSetId?: string;
 };
 
 function setupFetch(initial: Status, ...subsequent: Status[]) {
@@ -142,6 +143,27 @@ describe("ChildViewMonsterCutsceneListener — 親モード代理操作後の進
     await new Promise((r) => setTimeout(r, 50));
     expect(screen.queryByText("進化した！")).toBeNull();
     expect(screen.queryByText("うまれた！")).toBeNull();
+  });
+
+  it("Issue #100: monsterSetId が buddha のとき、カットインに buddha テーマの画像が表示される（side は無視される）", async () => {
+    // side は null（未設定）だが monsterSetId が buddha を優先するべき
+    setupFetch(
+      { evolutionStage: 0, evolutionPath: "", side: null, monsterSetId: "buddha" },
+      { evolutionStage: 1, evolutionPath: "STUDY", side: null, monsterSetId: "buddha" },
+    );
+
+    await act(async () => {
+      render(<ChildViewMonsterCutsceneListener childId="child-1" />);
+    });
+
+    await act(async () => {
+      window.dispatchEvent(new CustomEvent("child-view-monster-refresh"));
+    });
+
+    await waitFor(() => {
+      const img = screen.getByAltText("文殊丸");
+      expect((img as HTMLImageElement).src).toContain("/monsters/buddha/STUDY_");
+    });
   });
 
   it("初回マウント時、localStorage の child 別キーに保存された lastSeen より stage が進んでいればカットインを出す（クロスセッション検知）", async () => {

--- a/src/__tests__/components/monster-cutscene-listener.test.tsx
+++ b/src/__tests__/components/monster-cutscene-listener.test.tsx
@@ -39,6 +39,7 @@ type Status = {
   evolutionStage: number;
   evolutionPath: string;
   side: string | null;
+  monsterSetId?: string;
 };
 
 function setupFetch(initial: Status, ...subsequent: Status[]) {
@@ -168,6 +169,28 @@ describe("MonsterCutsceneListener — 子レイアウト常駐の進化カット
     expect(screen.queryByText("進化した！")).toBeNull();
     // 以降の差分検知のために lastSeen は記録される
     expect(localStorage.getItem("lastSeenEvolutionStage")).toBe("3");
+  });
+
+  it("Issue #100: monsterSetId が buddha のとき、カットインに buddha テーマの画像が表示される（side は無視される）", async () => {
+    // side は null（未設定）だが monsterSetId が buddha を優先するべき
+    setupFetch(
+      { evolutionStage: 0, evolutionPath: "", side: null, monsterSetId: "buddha" },
+      { evolutionStage: 1, evolutionPath: "STUDY", side: null, monsterSetId: "buddha" },
+    );
+
+    await act(async () => {
+      render(<MonsterCutsceneListener />);
+    });
+    await waitFor(() => expect(userUpdateCallback).not.toBeNull());
+
+    await act(async () => {
+      userUpdateCallback!();
+    });
+
+    await waitFor(() => {
+      const img = screen.getByAltText("文殊丸");
+      expect((img as HTMLImageElement).src).toContain("/monsters/buddha/STUDY_");
+    });
   });
 
   it("カットイン表示後、lastSeenEvolutionStage は新ステージで更新される", async () => {

--- a/src/__tests__/components/parent-family-member-icon-theme.test.tsx
+++ b/src/__tests__/components/parent-family-member-icon-theme.test.tsx
@@ -1,0 +1,146 @@
+// @vitest-environment jsdom
+//
+// Issue #100: themeIdFromSide(side) のみに頼ると dark/light の2択にしか解決できず、
+// monsterSetId（buddha等）が無視されるバグの残存箇所2
+// 対象: src/app/app/parent/(app)/family/page.tsx（メンバー一覧のモンスターアイコン部分）
+//
+// member.monsterSetId が既にレスポンスに含まれているにもかかわらず、
+// アイコン描画では themeIdFromSide(member.side) のみを getMonsterStage に渡しているため、
+// monsterSetId==="buddha" のメンバーでも dark/light テーブルの画像が表示されてしまう。
+
+import { render, screen, waitFor } from "@testing-library/react";
+import { describe, it, expect, vi, afterEach } from "vitest";
+import React from "react";
+
+vi.mock("@/lib/supabase/client", () => ({
+  createClient: () => ({
+    auth: { signOut: vi.fn().mockResolvedValue({}) },
+    channel: vi.fn(() => ({
+      on: vi.fn().mockReturnThis(),
+      subscribe: vi.fn(),
+    })),
+    removeChannel: vi.fn(),
+  }),
+}));
+
+vi.mock("next/image", () => ({
+  __esModule: true,
+  default: ({ src, alt }: { src: string; alt?: string }) => (
+    <img src={src} alt={alt} />
+  ),
+}));
+
+vi.mock("@/components/LoadingSpinner", () => ({
+  default: () => <div data-testid="spinner" />,
+}));
+
+import FamilyPage from "@/app/app/parent/(app)/family/page";
+
+type MockMember = {
+  id: string;
+  name: string;
+  role: "PARENT" | "CHILD";
+  side: string | null;
+  monsterName: string | null;
+  evolutionStage: number;
+  evolutionPath: string;
+  rebirthEggBonus: string | null;
+  rebirthPending: boolean;
+  childCode: string | null;
+  minTasksForStreak: number;
+  reportDeadlineTime: string | null;
+  checkinDeadlineTime: string | null;
+  questTimeNotifyEnabled: boolean;
+  studyPt: number;
+  staminaPt: number;
+  lifePt: number;
+  collectedPaths: string;
+  monsterSetId: string;
+  pendingMonsterSetId: string | null;
+  ownedThemes: string[];
+};
+
+function makeChild(overrides: Partial<MockMember> = {}): MockMember {
+  return {
+    id: "child-1",
+    name: "たろう",
+    role: "CHILD",
+    side: "DARK",
+    monsterName: "たろうのモンスター",
+    evolutionStage: 1,
+    evolutionPath: "STUDY",
+    rebirthEggBonus: null,
+    rebirthPending: false,
+    childCode: "1234",
+    minTasksForStreak: 1,
+    reportDeadlineTime: null,
+    checkinDeadlineTime: null,
+    questTimeNotifyEnabled: true,
+    studyPt: 0,
+    staminaPt: 0,
+    lifePt: 0,
+    collectedPaths: "[]",
+    monsterSetId: "dark",
+    pendingMonsterSetId: null,
+    ownedThemes: ["dark", "light", "buddha"],
+    ...overrides,
+  };
+}
+
+function mockFetchWithMembers(members: MockMember[]) {
+  global.fetch = vi.fn().mockImplementation((url: string) => {
+    if (url.includes("/api/family/code")) {
+      return Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve({ code: "ABC123", members }),
+      });
+    }
+    return Promise.resolve({ ok: true, json: () => Promise.resolve({}) });
+  }) as unknown as typeof fetch;
+}
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("親 ファミリーページ: メンバー一覧のモンスターアイコン テーマ解決（Issue #100）", () => {
+  it("monsterSetId が buddha のメンバーは、buddhaテーマの画像がアイコンに表示される（side は無視される）", async () => {
+    // side は DARK のままだが monsterSetId が buddha を優先するべき
+    mockFetchWithMembers([
+      makeChild({ side: "DARK", monsterSetId: "buddha", evolutionStage: 1, evolutionPath: "STUDY" }),
+    ]);
+
+    render(<FamilyPage />);
+
+    await waitFor(() => {
+      const img = screen.getByAltText("文殊丸");
+      expect((img as HTMLImageElement).src).toContain("/monsters/buddha/STUDY_");
+    });
+  });
+
+  it("monsterSetId が dark のメンバーは、darkテーマの画像がアイコンに表示される（回帰確認）", async () => {
+    mockFetchWithMembers([
+      makeChild({ side: "DARK", monsterSetId: "dark", evolutionStage: 1, evolutionPath: "STUDY" }),
+    ]);
+
+    render(<FamilyPage />);
+
+    await waitFor(() => {
+      const img = screen.getByAltText("ラーン");
+      expect((img as HTMLImageElement).src).toContain("/monsters/dark/STUDY_");
+    });
+  });
+
+  it("境界値: monsterSetId が buddha かつ evolutionStage===0（卵）のとき buddha の卵画像が表示される", async () => {
+    mockFetchWithMembers([
+      makeChild({ side: "LIGHT", monsterSetId: "buddha", evolutionStage: 0, evolutionPath: "", rebirthEggBonus: null }),
+    ]);
+
+    render(<FamilyPage />);
+
+    await waitFor(() => {
+      const img = screen.getByAltText("たまご");
+      expect((img as HTMLImageElement).src).toContain("/monsters/buddha/egg.webp");
+    });
+  });
+});

--- a/src/app/app/child/monster/page.tsx
+++ b/src/app/app/child/monster/page.tsx
@@ -73,7 +73,7 @@ export default function MonsterPage() {
   const pendingTotal = data.pendingStudyPt + data.pendingStaminaPt + data.pendingLifePt;
   const isReborn = (JSON.parse(data.collectedPaths) as string[]).length > 0;
   const xpInfo = getXpInfo(data.evolutionStage, data.evolutionPath, data.studyPt, data.staminaPt, data.lifePt, isReborn, data.rebirthEggBonus);
-  const monsterBase = getMonsterStage(data.evolutionStage, data.evolutionPath, themeIdFromSide(data.side));
+  const monsterBase = getMonsterStage(data.evolutionStage, data.evolutionPath, data.monsterSetId ?? themeIdFromSide(data.side));
   // 転生後の卵は選択した卵タイプの画像を表示する
   const monster = data.evolutionStage === 0 && data.rebirthEggBonus && EGG_BONUS_IMAGE[data.rebirthEggBonus]
     ? { ...monsterBase, image: EGG_BONUS_IMAGE[data.rebirthEggBonus] }
@@ -94,7 +94,7 @@ export default function MonsterPage() {
       {reborn && (() => {
         const eggImg = data.rebirthEggBonus && EGG_BONUS_IMAGE[data.rebirthEggBonus]
           ? EGG_BONUS_IMAGE[data.rebirthEggBonus]
-          : getMonsterStage(0, "", themeIdFromSide(data.side)).image;
+          : getMonsterStage(0, "", data.monsterSetId ?? themeIdFromSide(data.side)).image;
         return (
           <CutsceneOverlay
             onClose={() => setReborn(false)}

--- a/src/app/app/parent/(app)/family/page.tsx
+++ b/src/app/app/parent/(app)/family/page.tsx
@@ -346,7 +346,7 @@ export default function FamilyPage() {
             >
             <div className="flex items-center gap-3 p-3">
               <div className="w-10 h-10 rounded-full bg-quest-border flex items-center justify-center text-lg overflow-hidden">
-                {member.role === "PARENT" ? "👑" : (() => { const m = getMonsterStage(member.evolutionStage, member.evolutionPath ?? "", themeIdFromSide(member.side)); const img = member.evolutionStage === 0 && member.rebirthEggBonus && EGG_BONUS_IMAGE[member.rebirthEggBonus] ? EGG_BONUS_IMAGE[member.rebirthEggBonus] : m.image; return <Image src={img} alt={m.name} width={40} height={40} className="w-full h-full object-contain" />; })()}
+                {member.role === "PARENT" ? "👑" : (() => { const m = getMonsterStage(member.evolutionStage, member.evolutionPath ?? "", member.monsterSetId ?? themeIdFromSide(member.side)); const img = member.evolutionStage === 0 && member.rebirthEggBonus && EGG_BONUS_IMAGE[member.rebirthEggBonus] ? EGG_BONUS_IMAGE[member.rebirthEggBonus] : m.image; return <Image src={img} alt={m.name} width={40} height={40} className="w-full h-full object-contain" />; })()}
               </div>
               <div className="flex-1">
                 <p className="text-sm font-medium">

--- a/src/components/child/MonsterCutsceneListener.tsx
+++ b/src/components/child/MonsterCutsceneListener.tsx
@@ -9,6 +9,7 @@ type MonsterStatus = {
   evolutionStage: number;
   evolutionPath: string;
   side: string | null;
+  monsterSetId?: string | null;
 };
 
 type CutsceneState = {
@@ -37,7 +38,7 @@ export default function MonsterCutsceneListener() {
     let cancelled = false;
 
     function buildCutscene(d: MonsterStatus, kind: "hatched" | "evolved"): CutsceneState {
-      const monster = getMonsterStage(d.evolutionStage, d.evolutionPath, themeIdFromSide(d.side));
+      const monster = getMonsterStage(d.evolutionStage, d.evolutionPath, d.monsterSetId ?? themeIdFromSide(d.side));
       return {
         kind,
         imageSrc: monster.image,

--- a/src/components/parent/ChildViewMonsterCutsceneListener.tsx
+++ b/src/components/parent/ChildViewMonsterCutsceneListener.tsx
@@ -8,6 +8,7 @@ type MonsterStatus = {
   evolutionStage: number;
   evolutionPath: string;
   side: string | null;
+  monsterSetId?: string | null;
 };
 
 type CutsceneState = {
@@ -36,7 +37,7 @@ export default function ChildViewMonsterCutsceneListener({ childId }: { childId:
     const storageKey = `lastSeenEvolutionStage:${childId}`;
 
     function buildCutscene(d: MonsterStatus, kind: "hatched" | "evolved"): CutsceneState {
-      const monster = getMonsterStage(d.evolutionStage, d.evolutionPath, themeIdFromSide(d.side));
+      const monster = getMonsterStage(d.evolutionStage, d.evolutionPath, d.monsterSetId ?? themeIdFromSide(d.side));
       return {
         kind,
         imageSrc: monster.image,


### PR DESCRIPTION
## Summary
- Issue #98/PR #99 で修正した「`themeIdFromSide(side)` のみに頼り buddha 等の `monsterSetId` ベースのテーマを無視する」バグと同じクラスの残り4箇所を修正
- 対象: `src/app/app/child/monster/page.tsx`（子供本人のモンスター育成ページ本体・転生カットイン）、`src/app/app/parent/(app)/family/page.tsx`（親の家族画面メンバーアイコン）、`src/components/child/MonsterCutsceneListener.tsx`（子供本人の進化/孵化カットイン）、`src/components/parent/ChildViewMonsterCutsceneListener.tsx`（親代理の進化/孵化カットイン）
- いずれも `xxx.monsterSetId ?? themeIdFromSide(xxx.side)` のパターンに統一し、既存2ファイルへのテスト追記＋新規2ファイルの計4テストを追加

Closes #100

## Test plan
- [x] `npm test` パス（198 files / 2755 tests passed）
- [ ] `npm run lint` パス
- [ ] buddhaテーマ選択中の子で、育成ページ・親の家族画面アイコン・進化/孵化カットインが正しくbuddha画像で表示されることを手動確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)
