### PR TITLE
refactor(monster-theme): テーマ所持記録を子供単位から家族単位へ移行

### DIFF
--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -2792,3 +2792,28 @@
 - `src/components/child/TreasureStock.tsx` — `variant?: "pill" | "card"` を追加、連打防止の同期ガード（`useRef`）を追加
 - `src/app/app/child/quests/page.tsx` — レイアウト組み替え（`CheckinPill` → ヘッダー → 締切バナー → `QuestStatusCard` → `MonsterMiniCard` → 報告ヒント → クエストリスト）
 
+## 2026-08-21: モンスターテーマ所持記録を子供単位（`ChildMonsterTheme`）から家族単位（`FamilyMonsterTheme`）へ移行する（2026-08-18決定の補足、Issue #111）
+
+### 決定内容
+- 2026-08-18決定（モンスターテーマセット機能 Stage 1）で導入した所持記録テーブルを、`ChildMonsterTheme`（`childId` + `themeId` 一意）から `FamilyMonsterTheme`（`familyId` + `themeId` 一意）へ置き換えた
+- `activateChildTheme(childId, ...)` を廃止し `activateFamilyTheme(familyId, ...)` に統一。呼び出し元（`src/app/api/family/members/[id]/monster-theme/route.ts`・`src/app/api/rebirth/route.ts`）は childId ではなく親/子供が所属する家族の `familyId` を渡すように変更した
+- 有料テーマの所持チェック（`familyMonsterTheme.findUnique`）・図鑑の `ownedThemes` 算出（`familyMonsterTheme.findMany`）も同様に家族単位のクエリに置き換えた。`familyId` が null のユーザーは所持クエリ自体を呼ばず空配列にフォールバックする（`familyId: undefined` を where に渡すと条件が無視され全家族横断で漏洩するため、必ず早期ガードする）
+- 表示中テーマ（`monsterSetId`）の仕組み・**転生時のみ切替可能**というルールは変更しない。変わるのは「所持」の母集団が子供単位から家族単位になった点のみ
+- 旧 `ChildMonsterTheme` テーブルは新規マイグレーション（`prisma/migrations/20260821000001_move_monster_theme_ownership_to_family/`）でデータ移送（兄弟重複は `activatedAt` 最古を採用しつつ `ON CONFLICT DO NOTHING` で吸収）後に DROP した
+
+### 理由
+- 親が購入したテーマは家族の子供全員が使えるべきであり、子供を追加するたびに個別付与が必要な現行設計（子供単位所持）はユーザー体験・運用コストの両面で問題があった
+- 本番の `ChildMonsterTheme` は移行時点で0件であることを確認済みのため実データ移行のリスクは無いが、将来同様の移行が発生した場合に備えてデータ移送ロジック自体は正しく実装した
+
+### やってはいけないこと
+- 所持チェック・所持一覧取得を `childId` 基準のクエリに戻す（兄弟間でテーマ所持が共有されなくなる）
+- `familyId` が undefined/null の可能性があるユーザーに対して、null ガードせず `familyMonsterTheme` の where に渡す（全家族横断の漏洩に繋がる）
+- 表示中テーマの切り替えタイミング（転生時のみ）や `monsterSetId`/`pendingMonsterSetId` の仕組み自体を今回の移行のついでに変更する
+
+### 該当箇所
+- `prisma/schema.prisma` — `FamilyMonsterTheme` モデル（`ChildMonsterTheme` は削除済み）
+- `prisma/migrations/20260821000001_move_monster_theme_ownership_to_family/` — テーブル作成・データ移送・旧テーブルDROP
+- `src/lib/monsterThemes.ts` — `activateFamilyTheme()`
+- `src/lib/monsterThemes/ownedThemes.ts` — `resolveOwnedThemes()`（ロジック自体は不変、呼び出し元が渡すレコードの母集団のみ変更）
+- `src/app/api/family/members/[id]/monster-theme/route.ts` / `src/app/api/family/code/route.ts` / `src/app/api/monster/route.ts` / `src/app/api/parent/child-view/monster/route.ts` / `src/app/api/rebirth/route.ts` — 呼び出し元の更新
+

--- a/prisma/migrations/20260821000001_move_monster_theme_ownership_to_family/migration.sql
+++ b/prisma/migrations/20260821000001_move_monster_theme_ownership_to_family/migration.sql
@@ -1,0 +1,42 @@
+-- Issue #111: モンスターテーマ所持記録を子供単位(ChildMonsterTheme)から
+-- 家族単位(FamilyMonsterTheme)へ移行する。
+--
+-- 背景: 親が購入したテーマは家族の子供全員が使えるべきであり、子供を追加するたびに
+-- 個別付与が必要な現行設計はユーザー体験・運用コストの両面で問題があった
+-- (docs/decisions.md 2026-08-18 決定の補足)。
+
+-- 1. FamilyMonsterTheme テーブルを作成する。
+CREATE TABLE "FamilyMonsterTheme" (
+    "id" TEXT NOT NULL,
+    "familyId" TEXT NOT NULL,
+    "themeId" TEXT NOT NULL,
+    "activatedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "grantReason" TEXT NOT NULL,
+
+    CONSTRAINT "FamilyMonsterTheme_pkey" PRIMARY KEY ("id")
+);
+
+CREATE UNIQUE INDEX "FamilyMonsterTheme_familyId_themeId_key" ON "FamilyMonsterTheme"("familyId", "themeId");
+CREATE INDEX "FamilyMonsterTheme_familyId_idx" ON "FamilyMonsterTheme"("familyId");
+
+ALTER TABLE "FamilyMonsterTheme" ADD CONSTRAINT "FamilyMonsterTheme_familyId_fkey"
+    FOREIGN KEY ("familyId") REFERENCES "Family"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- 2. データ移送: ChildMonsterTheme を User.familyId で JOIN して FamilyMonsterTheme へ INSERT する。
+--    兄弟間で同じ themeId の複数レコードがある場合は DISTINCT ON (familyId, themeId) +
+--    activatedAt ASC（最古のレコード）を採用し、ON CONFLICT DO NOTHING で重複作成を防ぐ。
+--    familyId が NULL のユーザーに紐づくレコード（INNER JOIN で自然に除外される）は対象外。
+--
+-- NOTE: 本番の ChildMonsterTheme は 0 件であることを確認済みのため実データへの影響は無いが、
+-- 将来の安全策としてロジック自体は正しく実装する。
+INSERT INTO "FamilyMonsterTheme" ("id", "familyId", "themeId", "activatedAt", "grantReason")
+SELECT DISTINCT ON (u."familyId", c."themeId")
+       gen_random_uuid()::text, u."familyId", c."themeId", c."activatedAt", c."grantReason"
+FROM "ChildMonsterTheme" c
+JOIN "User" u ON u."id" = c."childId"
+WHERE u."familyId" IS NOT NULL
+ORDER BY u."familyId", c."themeId", c."activatedAt" ASC
+ON CONFLICT ("familyId", "themeId") DO NOTHING;
+
+-- 3. 旧テーブルを削除する。
+DROP TABLE "ChildMonsterTheme";

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -38,12 +38,13 @@ enum SubscriptionPlan {
 }
 
 model Family {
-  id              String         @id @default(cuid())
-  code            String         @unique
-  createdAt       DateTime       @default(now())
-  autoApproveTime String         @default("24:00")
+  id              String               @id @default(cuid())
+  code            String               @unique
+  createdAt       DateTime             @default(now())
+  autoApproveTime String               @default("24:00")
   users           User[]
   tasks           TaskTemplate[]
+  monsterThemes   FamilyMonsterTheme[]
 }
 
 model User {
@@ -94,7 +95,6 @@ model User {
   collectionItems        UserCollectionItem[]
   checkinLogs            CheckinLog[]
   subscription           Subscription?
-  monsterThemes          ChildMonsterTheme[]
   createdAt              DateTime           @default(now())
 
   @@unique([familyId, childCode])
@@ -119,21 +119,22 @@ model Subscription {
   updatedAt        DateTime         @updatedAt
 }
 
-/// 子供が有効化した／解禁済みのモンスターテーマセット記録。
-/// 有料テーマ（例: buddha）の購入・付与履歴を管理する（Issue #73 モンスターテーマセット基盤）。
-/// childId + themeId で一意。dark/light は無料のため付与レコードが無くても常に選択可能
-/// （選択可否の判定は @/lib/monsterThemes/index の isFree と組み合わせて行う）。
-model ChildMonsterTheme {
+/// 家族が有効化した／解禁済みのモンスターテーマセット記録（Issue #111）。
+/// 有料テーマ（例: buddha）の購入・付与履歴を家族単位で管理する。
+/// 旧 ChildMonsterTheme（子供単位）からの移行先。兄弟間でテーマの所持を共有するため、
+/// familyId + themeId で一意とする。dark/light は無料のため付与レコードが無くても
+/// 常に選択可能（選択可否の判定は @/lib/monsterThemes/index の isFree と組み合わせて行う）。
+model FamilyMonsterTheme {
   id           String   @id @default(cuid())
-  childId      String
-  child        User     @relation(fields: [childId], references: [id], onDelete: Cascade)
+  familyId     String
+  family       Family   @relation(fields: [familyId], references: [id], onDelete: Cascade)
   themeId      String
   activatedAt  DateTime @default(now())
-  /// 有効化理由（例: "purchase", "default"）。将来の付与経路追加に備えた自由文字列。
+  /// 有効化理由（例: "purchase", "default", "manual"）。将来の付与経路追加に備えた自由文字列。
   grantReason  String
 
-  @@unique([childId, themeId])
-  @@index([childId])
+  @@unique([familyId, themeId])
+  @@index([familyId])
 }
 
 model TaskTemplate {

--- a/src/__tests__/api/family/code.test.ts
+++ b/src/__tests__/api/family/code.test.ts
@@ -9,10 +9,12 @@ const mockGetCurrentUser = vi.mocked(getCurrentUser);
 
 /**
  * `prisma.family.findUnique` は
- * `include: { users: { include: { streak: { select: ... }, monsterThemes: { select: { themeId: true } } } } }`
- * 付きで呼ばれる想定（Issue #90: ownedThemes をレスポンスに含めるため）が、DeepMockProxy の
- * `mockResolvedValue` は関係（リレーション）を含まないベースの `Family` 型しか受け付けない
- * （`users` プロパティ自体が型エラーになる）。
+ * `include: { users: { include: { streak: { select: ... } } } }` 付きで呼ばれる想定
+ * （Issue #111: ownedThemes はもはや子供単位の `monsterThemes` include ではなく、
+ * `prisma.familyMonsterTheme.findMany({ where: { familyId } })` の家族単位クエリで
+ * 別途取得し、全メンバーに共通適用する）。
+ * DeepMockProxy の `mockResolvedValue` は関係（リレーション）を含まないベースの `Family` 型
+ * しか受け付けない（`users` プロパティ自体が型エラーになる）ため、
  * `Prisma.FamilyGetPayload<{ include: ... }>` で実際のクエリ形状の値を組み立てたうえで、
  * モック関数の戻り値型へ `as unknown as` でキャストする。
  */
@@ -21,7 +23,6 @@ type FamilyWithUsersAndStreak = Prisma.FamilyGetPayload<{
     users: {
       include: {
         streak: { select: { lastLoginDate: true } };
-        monsterThemes: { select: { themeId: true } };
       };
     };
   };
@@ -49,6 +50,8 @@ function legacyMemberRow(
 
 beforeEach(() => {
   vi.clearAllMocks();
+  // ownedThemes 計算用の家族単位所持レコード取得。デフォルトは「所持なし」。
+  mockPrisma.familyMonsterTheme.findMany.mockResolvedValue([]);
 });
 
 describe("GET /api/family/code", () => {
@@ -142,74 +145,141 @@ describe("GET /api/family/code", () => {
     expect(json.members[0].lifePt).toBe(2);
   });
 
-  it("usersをcreatedAt昇順で取得すること", async () => {
+  it("usersをcreatedAt昇順で取得し、familyMonsterThemeを自ファミリーのfamilyIdで取得すること", async () => {
     mockGetCurrentUser.mockResolvedValue(parentUserWithFamily());
     mockFamilyFindUnique({ ...family(), users: [] });
 
     await GET();
 
-    expect(mockPrisma.family.findUnique).toHaveBeenCalledWith({
-      where: { id: "fam-1" },
-      include: {
-        users: {
-          orderBy: { createdAt: "asc" },
-          include: {
-            streak: { select: { lastLoginDate: true } },
-            monsterThemes: { select: { themeId: true } },
-          },
-        },
-      },
+    expect(mockPrisma.family.findUnique).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { id: "fam-1" },
+        include: expect.objectContaining({
+          users: expect.objectContaining({
+            orderBy: { createdAt: "asc" },
+          }),
+        }),
+      }),
+    );
+    // ownedThemes はもはや子供単位の include (monsterThemes) ではなく、
+    // 家族単位の FamilyMonsterTheme を別クエリで取得する
+    expect(mockPrisma.familyMonsterTheme.findMany).toHaveBeenCalledWith({
+      where: { familyId: "fam-1" },
     });
   });
 
-  describe("ownedThemes（Issue #90: ChildMonsterThemeレコードの手動付与を反映）", () => {
-    it("buddhaのChildMonsterThemeレコードがある子はownedThemesにbuddhaが含まれること", async () => {
+  describe("ownedThemes（Issue #111: 家族単位所持への移行、兄弟共有）", () => {
+    it("家族がbuddhaを所持している場合、子供2人の両方のmembers[].ownedThemesにbuddhaが含まれること", async () => {
       mockGetCurrentUser.mockResolvedValue(parentUserWithFamily());
+      mockPrisma.familyMonsterTheme.findMany.mockResolvedValue([
+        { id: "fmt-1", familyId: "fam-1", themeId: "buddha", activatedAt: new Date("2026-02-01"), grantReason: "purchase" },
+      ]);
       mockFamilyFindUnique({
         ...family(),
         users: [
           legacyMemberRow({
-            id: "u2",
+            id: "child-a",
             name: "太郎",
             role: "CHILD",
             monsterName: "ドラゴン",
             side: "DARK",
-            childCode: "1234",
+            childCode: "1111",
             monsterSetId: "dark",
-            monsterThemes: [{ themeId: "buddha" }],
-          } as unknown as FamilyWithUsersAndStreak["users"][number]),
-        ],
-      });
-
-      const res = await GET();
-      const json = await res.json();
-
-      expect(json.members[0].ownedThemes).toContain("buddha");
-    });
-
-    it("buddhaのChildMonsterThemeレコードが無い子はownedThemesにbuddhaが含まれないこと", async () => {
-      mockGetCurrentUser.mockResolvedValue(parentUserWithFamily());
-      mockFamilyFindUnique({
-        ...family(),
-        users: [
+          }),
           legacyMemberRow({
-            id: "u3",
+            id: "child-b",
             name: "次郎",
             role: "CHILD",
             monsterName: "スライム",
             side: "LIGHT",
-            childCode: "5678",
+            childCode: "2222",
             monsterSetId: "light",
-            monsterThemes: [],
-          } as unknown as FamilyWithUsersAndStreak["users"][number]),
+          }),
         ],
       });
 
       const res = await GET();
       const json = await res.json();
 
+      expect(json.members).toHaveLength(2);
+      expect(json.members[0].ownedThemes).toContain("buddha");
+      expect(json.members[1].ownedThemes).toContain("buddha");
+    });
+
+    it("家族の所持レコードが無い場合、各memberのownedThemesは無料テーマ+自身のmonsterSetIdのみになること", async () => {
+      mockGetCurrentUser.mockResolvedValue(parentUserWithFamily());
+      mockPrisma.familyMonsterTheme.findMany.mockResolvedValue([]);
+      mockFamilyFindUnique({
+        ...family(),
+        users: [
+          legacyMemberRow({
+            id: "child-a",
+            name: "太郎",
+            role: "CHILD",
+            monsterName: "ドラゴン",
+            side: "DARK",
+            childCode: "1111",
+            monsterSetId: "dark",
+          }),
+          legacyMemberRow({
+            id: "child-b",
+            name: "次郎",
+            role: "CHILD",
+            monsterName: "スライム",
+            side: "LIGHT",
+            childCode: "2222",
+            monsterSetId: "light",
+          }),
+        ],
+      });
+
+      const res = await GET();
+      const json = await res.json();
+
+      expect(json.members[0].ownedThemes.slice().sort()).toEqual(["dark", "light"]);
       expect(json.members[0].ownedThemes).not.toContain("buddha");
-      expect(json.members[0].ownedThemes).toEqual(["dark", "light"]);
+      expect(json.members[1].ownedThemes.slice().sort()).toEqual(["dark", "light"]);
+      expect(json.members[1].ownedThemes).not.toContain("buddha");
+    });
+
+    it("子供ごとに異なるmonsterSetIdを持つ場合、ownedThemesの母集団は共通だが各memberのmonsterSetIdは個別に返ること", async () => {
+      mockGetCurrentUser.mockResolvedValue(parentUserWithFamily());
+      mockPrisma.familyMonsterTheme.findMany.mockResolvedValue([
+        { id: "fmt-1", familyId: "fam-1", themeId: "buddha", activatedAt: new Date("2026-02-01"), grantReason: "purchase" },
+      ]);
+      mockFamilyFindUnique({
+        ...family(),
+        users: [
+          legacyMemberRow({
+            id: "child-a",
+            name: "太郎",
+            role: "CHILD",
+            monsterName: "ドラゴン",
+            side: "DARK",
+            childCode: "1111",
+            monsterSetId: "buddha",
+          }),
+          legacyMemberRow({
+            id: "child-b",
+            name: "次郎",
+            role: "CHILD",
+            monsterName: "スライム",
+            side: "LIGHT",
+            childCode: "2222",
+            monsterSetId: "light",
+          }),
+        ],
+      });
+
+      const res = await GET();
+      const json = await res.json();
+
+      // 母集団（buddha を含む所持テーマ一覧）は共通
+      expect(json.members[0].ownedThemes.slice().sort()).toEqual(["buddha", "dark", "light"]);
+      expect(json.members[1].ownedThemes.slice().sort()).toEqual(["buddha", "dark", "light"]);
+      // 現在有効なテーマ (monsterSetId) は個別に返る
+      expect(json.members[0].monsterSetId).toBe("buddha");
+      expect(json.members[1].monsterSetId).toBe("light");
     });
   });
 

--- a/src/__tests__/api/family/members-id-monster-theme.test.ts
+++ b/src/__tests__/api/family/members-id-monster-theme.test.ts
@@ -1,43 +1,44 @@
-// Issue #85 / #90: 親画面からモンスターテーマの付与・切替を行う（モンスターテーマセット Stage2/3）
-// 対象: src/app/api/family/members/[id]/monster-theme/route.ts の PATCH (所持チェックは未実装。実装は implementer が行う)
+// Issue #85 / #90 / #111: 親画面からモンスターテーマの付与・切替を行う（モンスターテーマセット Stage2/3、家族単位所持へ移行）
+// 対象: src/app/api/family/members/[id]/monster-theme/route.ts の PATCH (家族単位の所持チェックは未実装。実装は implementer が行う)
 //
-// 仕様:
+// 仕様（Issue #111 更新後）:
 //  - PARENT 認証必須。対象 child が自ファミリーであることを確認する（他ファミリーなら403）
 //  - themeId が @/lib/monsterThemes/index の MONSTER_THEMES に存在しない場合400
 //  - themeId が存在していても isFree: false（現状 buddha）の場合:
-//    prisma.childMonsterTheme.findUnique({ where: { childId_themeId: { childId: id, themeId } } })
-//    でレコードの有無を確認する
+//    prisma.familyMonsterTheme.findUnique({ where: { familyId_themeId: { familyId: user.familyId, themeId } } })
+//    で「家族単位」のレコードの有無を確認する（childId ではなく親の familyId で判定する）
 //      - レコードが無ければ400（決済導線は未実装だが、開発者による手動DB挿入で
-//        「購入済み」として付与された子は選択できる。Issue #90）
+//        「購入済み」として付与された家族は選択できる。Issue #90 / #111）
 //      - レコードがあれば、以降は isFree:true のテーマと同じ即時反映/予約ロジックに進む
+//      - 同一家族内の兄弟間でテーマ所持は共有される（どちらの子IDを指定しても同じ判定になる）
 //  - isFree: true のテーマは所持レコードの有無に関わらず選択できる
-//    （childMonsterTheme.findUnique は呼ばれない）
+//    （familyMonsterTheme.findUnique は呼ばれない）
 //  - 即時反映条件（evolutionStage === 0 または rebirthPending === true）を満たす場合:
-//    monsterSetId を更新し、activateChildTheme(childId, themeId, "manual") を呼ぶ
-//    （pendingMonsterSetId は変更しない）
-//  - 満たさない場合: pendingMonsterSetId にのみ保存する（activateChildTheme は呼ばない、
+//    monsterSetId を更新し、activateFamilyTheme(user.familyId, themeId, "manual") を呼ぶ
+//    （pendingMonsterSetId は変更しない。childId ではなく親の familyId を渡す）
+//  - 満たさない場合: pendingMonsterSetId にのみ保存する（activateFamilyTheme は呼ばない、
 //    monsterSetId 自体も変更しない）
 
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { PATCH } from "@/app/api/family/members/[id]/monster-theme/route";
 import { getCurrentUser } from "@/lib/auth";
-import { activateChildTheme } from "@/lib/monsterThemes";
+import { activateFamilyTheme } from "@/lib/monsterThemes";
 import { prismaMock as mockPrisma } from "../../helpers/prisma-mock";
 import { makeParams, makeRequest } from "../../helpers/request";
 import { parentUserWithFamily, childUserWithFamily, childUser } from "../../helpers/fixtures";
 
 vi.mock("@/lib/monsterThemes", () => ({
-  activateChildTheme: vi.fn().mockResolvedValue(undefined),
+  activateFamilyTheme: vi.fn().mockResolvedValue(undefined),
 }));
 
 const mockGetCurrentUser = vi.mocked(getCurrentUser);
-const mockActivateChildTheme = vi.mocked(activateChildTheme);
+const mockActivateFamilyTheme = vi.mocked(activateFamilyTheme);
 
-/** ChildMonsterTheme の所持レコード（購入済み扱い）を模したフィクスチャ */
-function ownedThemeRecord(overrides?: { childId?: string; themeId?: string }) {
+/** FamilyMonsterTheme の所持レコード（購入済み扱い）を模したフィクスチャ */
+function ownedThemeRecord(overrides?: { familyId?: string; themeId?: string }) {
   return {
-    id: "cmt-1",
-    childId: overrides?.childId ?? "child-1",
+    id: "fmt-1",
+    familyId: overrides?.familyId ?? "fam-1",
     themeId: overrides?.themeId ?? "buddha",
     activatedAt: new Date("2026-01-01T00:00:00Z"),
     grantReason: "purchase",
@@ -72,7 +73,7 @@ describe("PATCH /api/family/members/[id]/monster-theme", () => {
 
     const res = await PATCH(patchRequest("light"), makeParams("child-other-family"));
     expect(res.status).toBe(403);
-    expect(mockActivateChildTheme).not.toHaveBeenCalled();
+    expect(mockActivateFamilyTheme).not.toHaveBeenCalled();
   });
 
   it("存在しないテーマidの場合400を返すこと", async () => {
@@ -81,7 +82,7 @@ describe("PATCH /api/family/members/[id]/monster-theme", () => {
 
     const res = await PATCH(patchRequest("nonexistent-theme"), makeParams("child-1"));
     expect(res.status).toBe(400);
-    expect(mockActivateChildTheme).not.toHaveBeenCalled();
+    expect(mockActivateFamilyTheme).not.toHaveBeenCalled();
     expect(mockPrisma.user.update).not.toHaveBeenCalled();
   });
 
@@ -93,12 +94,12 @@ describe("PATCH /api/family/members/[id]/monster-theme", () => {
     expect(res.status).toBe(400);
   });
 
-  it("卵(evolutionStage===0)のとき即時切替: monsterSetIdが更新されactivateChildThemeが呼ばれること", async () => {
-    // NOTE: buddha は isFree:false のため PR #88 対応でここでは使えなくなった。
-    // 即時切替ロジック自体の検証が目的なので無料テーマ(light)で代替する。
-    mockGetCurrentUser.mockResolvedValue(parentUserWithFamily());
+  it("卵(evolutionStage===0)のとき即時切替: monsterSetIdが更新されactivateFamilyThemeが親のfamilyIdで呼ばれること", async () => {
+    // NOTE: buddha は isFree:false のため所持チェックが必要。即時切替ロジック自体の
+    // 検証が目的なので無料テーマ(light)で代替する。
+    mockGetCurrentUser.mockResolvedValue(parentUserWithFamily({ familyId: "fam-1" }));
     mockPrisma.user.findFirst.mockResolvedValue(
-      childUser({ id: "child-1", evolutionStage: 0, rebirthPending: false }),
+      childUser({ id: "child-1", evolutionStage: 0, rebirthPending: false, familyId: "fam-1" }),
     );
     mockPrisma.user.update.mockResolvedValue(childUser({ id: "child-1", monsterSetId: "light" }));
 
@@ -115,13 +116,14 @@ describe("PATCH /api/family/members/[id]/monster-theme", () => {
     const updateCall = mockPrisma.user.update.mock.calls[0][0] as { data: Record<string, unknown> };
     expect(updateCall.data).not.toHaveProperty("pendingMonsterSetId");
 
-    expect(mockActivateChildTheme).toHaveBeenCalledWith("child-1", "light", "manual");
+    // childId ではなく親の familyId が渡ること
+    expect(mockActivateFamilyTheme).toHaveBeenCalledWith("fam-1", "light", "manual");
   });
 
   it("rebirthPending===trueのとき即時切替されること", async () => {
-    mockGetCurrentUser.mockResolvedValue(parentUserWithFamily());
+    mockGetCurrentUser.mockResolvedValue(parentUserWithFamily({ familyId: "fam-1" }));
     mockPrisma.user.findFirst.mockResolvedValue(
-      childUser({ id: "child-1", evolutionStage: 3, rebirthPending: true }),
+      childUser({ id: "child-1", evolutionStage: 3, rebirthPending: true, familyId: "fam-1" }),
     );
     mockPrisma.user.update.mockResolvedValue(childUser({ id: "child-1", monsterSetId: "light" }));
 
@@ -134,12 +136,12 @@ describe("PATCH /api/family/members/[id]/monster-theme", () => {
         data: expect.objectContaining({ monsterSetId: "light" }),
       }),
     );
-    expect(mockActivateChildTheme).toHaveBeenCalledWith("child-1", "light", "manual");
+    expect(mockActivateFamilyTheme).toHaveBeenCalledWith("fam-1", "light", "manual");
   });
 
   it("育成途中(evolutionStage>0 かつ rebirthPending!==true)のときpendingMonsterSetIdにのみ保存されること", async () => {
-    // NOTE: buddha は isFree:false のため PR #88 対応でここでは使えなくなった。
-    // 予約ロジック自体の検証が目的なので無料テーマ(light)で代替する。
+    // NOTE: buddha は isFree:false のため所持チェックが必要。予約ロジック自体の
+    // 検証が目的なので無料テーマ(light)で代替する。
     mockGetCurrentUser.mockResolvedValue(parentUserWithFamily());
     mockPrisma.user.findFirst.mockResolvedValue(
       childUser({ id: "child-1", evolutionStage: 2, rebirthPending: false }),
@@ -155,16 +157,16 @@ describe("PATCH /api/family/members/[id]/monster-theme", () => {
       where: { id: "child-1" },
       data: { pendingMonsterSetId: "light" },
     });
-    expect(mockActivateChildTheme).not.toHaveBeenCalled();
+    expect(mockActivateFamilyTheme).not.toHaveBeenCalled();
   });
 
-  describe("有料テーマ（isFree: false）の所持チェック（Issue #90: 手動DB挿入による付与）", () => {
-    it("ChildMonsterThemeにbuddhaのレコードが無い場合、400を返すこと（即時反映条件を満たす卵状態でも拒否されること）", async () => {
-      mockGetCurrentUser.mockResolvedValue(parentUserWithFamily());
+  describe("有料テーマ（isFree: false）の家族単位所持チェック（Issue #111: 兄弟共有）", () => {
+    it("FamilyMonsterThemeにbuddhaのレコードが無い場合、400を返すこと（即時反映条件を満たす卵状態でも拒否されること）", async () => {
+      mockGetCurrentUser.mockResolvedValue(parentUserWithFamily({ familyId: "fam-1" }));
       mockPrisma.user.findFirst.mockResolvedValue(
-        childUser({ id: "child-1", evolutionStage: 0, rebirthPending: false }),
+        childUser({ id: "child-1", evolutionStage: 0, rebirthPending: false, familyId: "fam-1" }),
       );
-      mockPrisma.childMonsterTheme.findUnique.mockResolvedValue(null);
+      mockPrisma.familyMonsterTheme.findUnique.mockResolvedValue(null);
 
       const res = await PATCH(patchRequest("buddha"), makeParams("child-1"));
       expect(res.status).toBe(400);
@@ -172,30 +174,36 @@ describe("PATCH /api/family/members/[id]/monster-theme", () => {
       expect(body.error).toBeTruthy();
       expect(body.error).toBe("このテーマはまだ購入されていません");
 
-      expect(mockPrisma.childMonsterTheme.findUnique).toHaveBeenCalledWith({
-        where: { childId_themeId: { childId: "child-1", themeId: "buddha" } },
+      expect(mockPrisma.familyMonsterTheme.findUnique).toHaveBeenCalledWith({
+        where: { familyId_themeId: { familyId: "fam-1", themeId: "buddha" } },
       });
+      // childId ではなく親の familyId で判定すること
+      expect(mockPrisma.familyMonsterTheme.findUnique).not.toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: { childId_themeId: expect.anything() },
+        }),
+      );
     });
 
-    it("ChildMonsterThemeにbuddhaのレコードが無い場合、monsterSetId/pendingMonsterSetIdのいずれも変更されず、activateChildThemeも呼ばれないこと", async () => {
+    it("FamilyMonsterThemeにbuddhaのレコードが無い場合、monsterSetId/pendingMonsterSetIdのいずれも変更されず、activateFamilyThemeも呼ばれないこと", async () => {
       mockGetCurrentUser.mockResolvedValue(parentUserWithFamily());
       mockPrisma.user.findFirst.mockResolvedValue(
         childUser({ id: "child-1", evolutionStage: 2, rebirthPending: false }),
       );
-      mockPrisma.childMonsterTheme.findUnique.mockResolvedValue(null);
+      mockPrisma.familyMonsterTheme.findUnique.mockResolvedValue(null);
 
       const res = await PATCH(patchRequest("buddha"), makeParams("child-1"));
       expect(res.status).toBe(400);
       expect(mockPrisma.user.update).not.toHaveBeenCalled();
-      expect(mockActivateChildTheme).not.toHaveBeenCalled();
+      expect(mockActivateFamilyTheme).not.toHaveBeenCalled();
     });
 
-    it("ChildMonsterThemeにbuddhaのレコードがある場合、即時反映条件（卵）を満たすと切替が成功すること", async () => {
-      mockGetCurrentUser.mockResolvedValue(parentUserWithFamily());
+    it("FamilyMonsterThemeにbuddhaのレコードがある場合、即時反映条件（卵）を満たすと切替が成功すること", async () => {
+      mockGetCurrentUser.mockResolvedValue(parentUserWithFamily({ familyId: "fam-1" }));
       mockPrisma.user.findFirst.mockResolvedValue(
-        childUser({ id: "child-1", evolutionStage: 0, rebirthPending: false }),
+        childUser({ id: "child-1", evolutionStage: 0, rebirthPending: false, familyId: "fam-1" }),
       );
-      mockPrisma.childMonsterTheme.findUnique.mockResolvedValue(ownedThemeRecord());
+      mockPrisma.familyMonsterTheme.findUnique.mockResolvedValue(ownedThemeRecord());
       mockPrisma.user.update.mockResolvedValue(childUser({ id: "child-1", monsterSetId: "buddha" }));
 
       const res = await PATCH(patchRequest("buddha"), makeParams("child-1"));
@@ -209,15 +217,15 @@ describe("PATCH /api/family/members/[id]/monster-theme", () => {
           data: expect.objectContaining({ monsterSetId: "buddha" }),
         }),
       );
-      expect(mockActivateChildTheme).toHaveBeenCalledWith("child-1", "buddha", "manual");
+      expect(mockActivateFamilyTheme).toHaveBeenCalledWith("fam-1", "buddha", "manual");
     });
 
-    it("ChildMonsterThemeにbuddhaのレコードがある場合、育成途中(予約条件)ではpendingMonsterSetIdに保存されること", async () => {
+    it("FamilyMonsterThemeにbuddhaのレコードがある場合、育成途中(予約条件)ではpendingMonsterSetIdに保存されること", async () => {
       mockGetCurrentUser.mockResolvedValue(parentUserWithFamily());
       mockPrisma.user.findFirst.mockResolvedValue(
         childUser({ id: "child-1", evolutionStage: 2, rebirthPending: false }),
       );
-      mockPrisma.childMonsterTheme.findUnique.mockResolvedValue(ownedThemeRecord());
+      mockPrisma.familyMonsterTheme.findUnique.mockResolvedValue(ownedThemeRecord());
       mockPrisma.user.update.mockResolvedValue(
         childUser({ id: "child-1", pendingMonsterSetId: "buddha" }),
       );
@@ -231,7 +239,7 @@ describe("PATCH /api/family/members/[id]/monster-theme", () => {
         where: { id: "child-1" },
         data: { pendingMonsterSetId: "buddha" },
       });
-      expect(mockActivateChildTheme).not.toHaveBeenCalled();
+      expect(mockActivateFamilyTheme).not.toHaveBeenCalled();
     });
 
     it("境界値: isFree:trueのテーマ(dark/light)は所持レコード無しでも従来通り成功すること（回帰確認）", async () => {
@@ -243,9 +251,48 @@ describe("PATCH /api/family/members/[id]/monster-theme", () => {
 
       const res = await PATCH(patchRequest("dark"), makeParams("child-1"));
       expect(res.status).toBe(200);
-      expect(mockActivateChildTheme).toHaveBeenCalledWith("child-1", "dark", "manual");
+      expect(mockActivateFamilyTheme).toHaveBeenCalledWith("fam-1", "dark", "manual");
       // isFree:true のテーマでは所持チェックを行わない
-      expect(mockPrisma.childMonsterTheme.findUnique).not.toHaveBeenCalled();
+      expect(mockPrisma.familyMonsterTheme.findUnique).not.toHaveBeenCalled();
+    });
+
+    it("兄弟共有: 家族がbuddhaを所持していれば、子供Aを指定した場合も子供Bを指定した場合も200で切り替えられること", async () => {
+      mockGetCurrentUser.mockResolvedValue(parentUserWithFamily({ familyId: "fam-shared" }));
+      mockPrisma.familyMonsterTheme.findUnique.mockResolvedValue(
+        ownedThemeRecord({ familyId: "fam-shared" }),
+      );
+
+      // 子供A
+      mockPrisma.user.findFirst.mockResolvedValueOnce(
+        childUser({ id: "child-a", evolutionStage: 0, rebirthPending: false, familyId: "fam-shared" }),
+      );
+      mockPrisma.user.update.mockResolvedValueOnce(
+        childUser({ id: "child-a", monsterSetId: "buddha" }),
+      );
+      const resA = await PATCH(patchRequest("buddha"), makeParams("child-a"));
+      expect(resA.status).toBe(200);
+
+      // 子供B（別の子供IDだが同じ家族。所持チェックは家族単位なので同じレコードで通ること）
+      mockPrisma.user.findFirst.mockResolvedValueOnce(
+        childUser({ id: "child-b", evolutionStage: 0, rebirthPending: false, familyId: "fam-shared" }),
+      );
+      mockPrisma.user.update.mockResolvedValueOnce(
+        childUser({ id: "child-b", monsterSetId: "buddha" }),
+      );
+      const resB = await PATCH(
+        makeRequest("/api/family/members/child-b/monster-theme", { themeId: "buddha" }, "PATCH"),
+        makeParams("child-b"),
+      );
+      expect(resB.status).toBe(200);
+
+      expect(mockActivateFamilyTheme).toHaveBeenCalledWith("fam-shared", "buddha", "manual");
+      expect(mockActivateFamilyTheme).toHaveBeenCalledTimes(2);
+      // 所持チェックは常に family 単位の同じ where で呼ばれる（子供IDに依存しない）
+      for (const call of mockPrisma.familyMonsterTheme.findUnique.mock.calls) {
+        expect(call[0]).toEqual({
+          where: { familyId_themeId: { familyId: "fam-shared", themeId: "buddha" } },
+        });
+      }
     });
   });
 
@@ -265,6 +312,6 @@ describe("PATCH /api/family/members/[id]/monster-theme", () => {
       where: { id: "child-1" },
       data: { pendingMonsterSetId: "dark" },
     });
-    expect(mockActivateChildTheme).not.toHaveBeenCalled();
+    expect(mockActivateFamilyTheme).not.toHaveBeenCalled();
   });
 });

--- a/src/__tests__/api/monster/monster.test.ts
+++ b/src/__tests__/api/monster/monster.test.ts
@@ -121,20 +121,21 @@ describe("GET /api/monster", () => {
     });
   });
 
-  // ─── Issue #86: 図鑑（Zukan）のテーマ別タブ対応 ──────────────────────
-  // レスポンスに以下の2フィールドを追加する（未実装）。
+  // ─── Issue #86 → #111: 図鑑（Zukan）のテーマ別タブ対応（家族単位所持へ移行） ──────
+  // レスポンスに以下の2フィールドを追加する。
   //   - monsterSetId: string        … 現在有効なテーマ（User.monsterSetId をそのまま返す）
-  //   - ownedThemes: string[]       … ChildMonsterTheme に記録がある themeId の一覧
-  //     （monsterSetId 単体では判定しない。過去に切り替えた履歴があるテーマは全て含む）
-  describe("モンスターテーマ（Issue #86: 図鑑のテーマ別タブ対応）", () => {
+  //   - ownedThemes: string[]       … FamilyMonsterTheme（家族単位）に記録がある themeId の一覧
+  //     （monsterSetId 単体では判定しない。過去に家族が切り替えた履歴があるテーマは全て含む。
+  //     兄弟間で所持を共有するため、家族の familyId で絞り込む）
+  describe("モンスターテーマ（Issue #111: 家族単位所持への移行）", () => {
     it("現在のmonsterSetIdと所持テーマ一覧(ownedThemes)を返すこと", async () => {
       mockGetCurrentUser.mockResolvedValue(
-        childUserWithFamily({ monsterSetId: "light" }),
+        childUserWithFamily({ monsterSetId: "light", familyId: "fam-1" }),
       );
       mockPrisma.questInstance.findMany.mockResolvedValue([]);
-      mockPrisma.childMonsterTheme.findMany.mockResolvedValue([
-        { id: "cmt-1", childId: "child-1", themeId: "dark", activatedAt: new Date("2026-01-01"), grantReason: "default" },
-        { id: "cmt-2", childId: "child-1", themeId: "light", activatedAt: new Date("2026-02-01"), grantReason: "default" },
+      mockPrisma.familyMonsterTheme.findMany.mockResolvedValue([
+        { id: "fmt-1", familyId: "fam-1", themeId: "dark", activatedAt: new Date("2026-01-01"), grantReason: "default" },
+        { id: "fmt-2", familyId: "fam-1", themeId: "light", activatedAt: new Date("2026-02-01"), grantReason: "default" },
       ]);
 
       const res = await GET();
@@ -144,17 +145,15 @@ describe("GET /api/monster", () => {
       expect(json.ownedThemes.slice().sort()).toEqual(["dark", "light"]);
     });
 
-    it("複数テーマを過去に切り替えた履歴がある場合、現在のmonsterSetIdに関わらず全テーマがownedThemesに含まれること", async () => {
-      // dark → buddha → light と切り替えた履歴を想定。現在は light だが、
-      // ownedThemes は monsterSetId 単体ではなく ChildMonsterTheme の記録で決まる。
+    it("家族が所持している有料テーマ(buddha)がownedThemesに含まれること", async () => {
       mockGetCurrentUser.mockResolvedValue(
-        childUserWithFamily({ monsterSetId: "light" }),
+        childUserWithFamily({ monsterSetId: "light", familyId: "fam-1" }),
       );
       mockPrisma.questInstance.findMany.mockResolvedValue([]);
-      mockPrisma.childMonsterTheme.findMany.mockResolvedValue([
-        { id: "cmt-1", childId: "child-1", themeId: "dark", activatedAt: new Date("2026-01-01"), grantReason: "default" },
-        { id: "cmt-2", childId: "child-1", themeId: "buddha", activatedAt: new Date("2026-02-01"), grantReason: "purchase" },
-        { id: "cmt-3", childId: "child-1", themeId: "light", activatedAt: new Date("2026-03-01"), grantReason: "switch" },
+      mockPrisma.familyMonsterTheme.findMany.mockResolvedValue([
+        { id: "fmt-1", familyId: "fam-1", themeId: "dark", activatedAt: new Date("2026-01-01"), grantReason: "default" },
+        { id: "fmt-2", familyId: "fam-1", themeId: "buddha", activatedAt: new Date("2026-02-01"), grantReason: "purchase" },
+        { id: "fmt-3", familyId: "fam-1", themeId: "light", activatedAt: new Date("2026-03-01"), grantReason: "switch" },
       ]);
 
       const res = await GET();
@@ -164,13 +163,13 @@ describe("GET /api/monster", () => {
       expect(json.ownedThemes).toHaveLength(3);
     });
 
-    it("isFree:falseのテーマ（buddha）は、ChildMonsterThemeにレコードが無く現在テーマでもない場合はownedThemesに含まれないこと（回帰確認）", async () => {
+    it("isFree:falseのテーマ（buddha）は、FamilyMonsterThemeにレコードが無く現在テーマでもない場合はownedThemesに含まれないこと（回帰確認）", async () => {
       mockGetCurrentUser.mockResolvedValue(
-        childUserWithFamily({ monsterSetId: "dark" }),
+        childUserWithFamily({ monsterSetId: "dark", familyId: "fam-1" }),
       );
       mockPrisma.questInstance.findMany.mockResolvedValue([]);
-      mockPrisma.childMonsterTheme.findMany.mockResolvedValue([
-        { id: "cmt-1", childId: "child-1", themeId: "dark", activatedAt: new Date("2026-01-01"), grantReason: "default" },
+      mockPrisma.familyMonsterTheme.findMany.mockResolvedValue([
+        { id: "fmt-1", familyId: "fam-1", themeId: "dark", activatedAt: new Date("2026-01-01"), grantReason: "default" },
       ]);
 
       const res = await GET();
@@ -179,12 +178,12 @@ describe("GET /api/monster", () => {
       expect(json.ownedThemes).not.toContain("buddha");
     });
 
-    it("isFree:trueのテーマ（dark, light）はChildMonsterThemeにレコードが無くてもownedThemesに含まれること", async () => {
+    it("isFree:trueのテーマ（dark, light）はFamilyMonsterThemeにレコードが無くてもownedThemesに含まれること", async () => {
       mockGetCurrentUser.mockResolvedValue(
-        childUserWithFamily({ monsterSetId: "dark" }),
+        childUserWithFamily({ monsterSetId: "dark", familyId: "fam-1" }),
       );
       mockPrisma.questInstance.findMany.mockResolvedValue([]);
-      mockPrisma.childMonsterTheme.findMany.mockResolvedValue([]);
+      mockPrisma.familyMonsterTheme.findMany.mockResolvedValue([]);
 
       const res = await GET();
       const json = await res.json();
@@ -194,13 +193,13 @@ describe("GET /api/monster", () => {
     });
 
     it("現在のmonsterSetId（レコードがまだ無いケース）はisFree:falseのテーマでもownedThemesに含まれること", async () => {
-      // 移行直後など、monsterSetId は buddha だが ChildMonsterTheme レコードがまだ
+      // 移行直後など、monsterSetId は buddha だが FamilyMonsterTheme レコードがまだ
       // 作成されていないケースを想定。
       mockGetCurrentUser.mockResolvedValue(
-        childUserWithFamily({ monsterSetId: "buddha" }),
+        childUserWithFamily({ monsterSetId: "buddha", familyId: "fam-1" }),
       );
       mockPrisma.questInstance.findMany.mockResolvedValue([]);
-      mockPrisma.childMonsterTheme.findMany.mockResolvedValue([]);
+      mockPrisma.familyMonsterTheme.findMany.mockResolvedValue([]);
 
       const res = await GET();
       const json = await res.json();
@@ -209,37 +208,32 @@ describe("GET /api/monster", () => {
       expect(json.ownedThemes.slice().sort()).toEqual(["buddha", "dark", "light"]);
     });
 
-    it("境界値: dark→light切替済みでChildMonsterThemeにlightのレコードのみある場合でも、dark（無料テーマ）とlightの両方がownedThemesに含まれること", async () => {
+    it("FamilyMonsterThemeの検索はログイン中ユーザのfamilyIdで絞り込むこと", async () => {
       mockGetCurrentUser.mockResolvedValue(
-        childUserWithFamily({ monsterSetId: "light" }),
+        childUserWithFamily({ id: "child-99", monsterSetId: "dark", familyId: "fam-99" }),
       );
       mockPrisma.questInstance.findMany.mockResolvedValue([]);
-      mockPrisma.childMonsterTheme.findMany.mockResolvedValue([
-        { id: "cmt-1", childId: "child-1", themeId: "light", activatedAt: new Date("2026-03-01"), grantReason: "switch" },
-      ]);
+      mockPrisma.familyMonsterTheme.findMany.mockResolvedValue([]);
+
+      await GET();
+
+      expect(mockPrisma.familyMonsterTheme.findMany).toHaveBeenCalledWith({
+        where: { familyId: "fam-99" },
+      });
+    });
+
+    it("境界値: user.familyIdがnullの場合、familyMonsterTheme.findManyを呼ばず、ownedThemesは無料テーマ+monsterSetIdのみになること", async () => {
+      mockGetCurrentUser.mockResolvedValue(
+        childUserWithFamily({ monsterSetId: "dark", familyId: null }),
+      );
+      mockPrisma.questInstance.findMany.mockResolvedValue([]);
 
       const res = await GET();
       const json = await res.json();
 
-      expect(json.ownedThemes).toContain("dark");
-      expect(json.ownedThemes).toContain("light");
+      expect(mockPrisma.familyMonsterTheme.findMany).not.toHaveBeenCalled();
       expect(json.ownedThemes.slice().sort()).toEqual(["dark", "light"]);
-    });
-
-    it("ChildMonsterThemeの検索はログイン中の子供のchildIdで絞り込むこと", async () => {
-      mockGetCurrentUser.mockResolvedValue(
-        childUserWithFamily({ id: "child-99", monsterSetId: "dark" }),
-      );
-      mockPrisma.questInstance.findMany.mockResolvedValue([]);
-      mockPrisma.childMonsterTheme.findMany.mockResolvedValue([]);
-
-      await GET();
-
-      expect(mockPrisma.childMonsterTheme.findMany).toHaveBeenCalledWith(
-        expect.objectContaining({
-          where: expect.objectContaining({ childId: "child-99" }),
-        }),
-      );
+      expect(json.ownedThemes).not.toContain("buddha");
     });
   });
 });

--- a/src/__tests__/api/parent/child-view/monster.test.ts
+++ b/src/__tests__/api/parent/child-view/monster.test.ts
@@ -67,19 +67,20 @@ describe("GET /api/parent/child-view/monster", () => {
     expect(json.usedEggBonuses).toBe('["STUDY"]');
   });
 
-  // ─── Issue #86: 図鑑（Zukan）のテーマ別タブ対応 ──────────────────────
+  // ─── Issue #86 → #111: 図鑑（Zukan）のテーマ別タブ対応（家族単位所持へ移行） ──────
   // 親代理ビューの ZukanContent 再利用に monsterSetId / ownedThemes が必要。
-  // /api/monster（子供本人用）に追加済みの5件のテストと同水準のカバレッジを移植する。
-  describe("モンスターテーマ（Issue #86: 図鑑のテーマ別タブ対応）", () => {
+  // /api/monster（子供本人用）に追加済みのカバレッジを移植する。所持判定は対象の子供が
+  // 所属する家族の familyId で行う（兄弟間で共有される）。
+  describe("モンスターテーマ（Issue #111: 家族単位所持への移行）", () => {
     it("現在のmonsterSetIdと所持テーマ一覧(ownedThemes)を返すこと", async () => {
       mockGetCurrentUser.mockResolvedValue(parentUserWithFamily());
       mockPrisma.user.findFirst.mockResolvedValue(
-        childUser({ id: "child-1", monsterSetId: "light" }),
+        childUser({ id: "child-1", monsterSetId: "light", familyId: "fam-1" }),
       );
       mockPrisma.questInstance.findMany.mockResolvedValue([]);
-      mockPrisma.childMonsterTheme.findMany.mockResolvedValue([
-        { id: "cmt-1", childId: "child-1", themeId: "dark", activatedAt: new Date("2026-01-01"), grantReason: "default" },
-        { id: "cmt-2", childId: "child-1", themeId: "light", activatedAt: new Date("2026-02-01"), grantReason: "default" },
+      mockPrisma.familyMonsterTheme.findMany.mockResolvedValue([
+        { id: "fmt-1", familyId: "fam-1", themeId: "dark", activatedAt: new Date("2026-01-01"), grantReason: "default" },
+        { id: "fmt-2", familyId: "fam-1", themeId: "light", activatedAt: new Date("2026-02-01"), grantReason: "default" },
       ]);
 
       const res = await GET(makeReq("child-1"));
@@ -89,16 +90,16 @@ describe("GET /api/parent/child-view/monster", () => {
       expect(json.ownedThemes.slice().sort()).toEqual(["dark", "light"]);
     });
 
-    it("複数テーマを過去に切り替えた履歴がある場合、現在のmonsterSetIdに関わらず全テーマがownedThemesに含まれること", async () => {
+    it("家族が所持している有料テーマ(buddha)がownedThemesに含まれること", async () => {
       mockGetCurrentUser.mockResolvedValue(parentUserWithFamily());
       mockPrisma.user.findFirst.mockResolvedValue(
-        childUser({ id: "child-1", monsterSetId: "light" }),
+        childUser({ id: "child-1", monsterSetId: "light", familyId: "fam-1" }),
       );
       mockPrisma.questInstance.findMany.mockResolvedValue([]);
-      mockPrisma.childMonsterTheme.findMany.mockResolvedValue([
-        { id: "cmt-1", childId: "child-1", themeId: "dark", activatedAt: new Date("2026-01-01"), grantReason: "default" },
-        { id: "cmt-2", childId: "child-1", themeId: "buddha", activatedAt: new Date("2026-02-01"), grantReason: "purchase" },
-        { id: "cmt-3", childId: "child-1", themeId: "light", activatedAt: new Date("2026-03-01"), grantReason: "switch" },
+      mockPrisma.familyMonsterTheme.findMany.mockResolvedValue([
+        { id: "fmt-1", familyId: "fam-1", themeId: "dark", activatedAt: new Date("2026-01-01"), grantReason: "default" },
+        { id: "fmt-2", familyId: "fam-1", themeId: "buddha", activatedAt: new Date("2026-02-01"), grantReason: "purchase" },
+        { id: "fmt-3", familyId: "fam-1", themeId: "light", activatedAt: new Date("2026-03-01"), grantReason: "switch" },
       ]);
 
       const res = await GET(makeReq("child-1"));
@@ -108,14 +109,14 @@ describe("GET /api/parent/child-view/monster", () => {
       expect(json.ownedThemes).toHaveLength(3);
     });
 
-    it("isFree:falseのテーマ（buddha）は、ChildMonsterThemeにレコードが無く現在テーマでもない場合はownedThemesに含まれないこと（回帰確認）", async () => {
+    it("isFree:falseのテーマ（buddha）は、FamilyMonsterThemeにレコードが無く現在テーマでもない場合はownedThemesに含まれないこと（回帰確認）", async () => {
       mockGetCurrentUser.mockResolvedValue(parentUserWithFamily());
       mockPrisma.user.findFirst.mockResolvedValue(
-        childUser({ id: "child-1", monsterSetId: "dark" }),
+        childUser({ id: "child-1", monsterSetId: "dark", familyId: "fam-1" }),
       );
       mockPrisma.questInstance.findMany.mockResolvedValue([]);
-      mockPrisma.childMonsterTheme.findMany.mockResolvedValue([
-        { id: "cmt-1", childId: "child-1", themeId: "dark", activatedAt: new Date("2026-01-01"), grantReason: "default" },
+      mockPrisma.familyMonsterTheme.findMany.mockResolvedValue([
+        { id: "fmt-1", familyId: "fam-1", themeId: "dark", activatedAt: new Date("2026-01-01"), grantReason: "default" },
       ]);
 
       const res = await GET(makeReq("child-1"));
@@ -124,13 +125,13 @@ describe("GET /api/parent/child-view/monster", () => {
       expect(json.ownedThemes).not.toContain("buddha");
     });
 
-    it("isFree:trueのテーマ（dark, light）はChildMonsterThemeにレコードが無くてもownedThemesに含まれること", async () => {
+    it("isFree:trueのテーマ（dark, light）はFamilyMonsterThemeにレコードが無くてもownedThemesに含まれること", async () => {
       mockGetCurrentUser.mockResolvedValue(parentUserWithFamily());
       mockPrisma.user.findFirst.mockResolvedValue(
-        childUser({ id: "child-1", monsterSetId: "dark" }),
+        childUser({ id: "child-1", monsterSetId: "dark", familyId: "fam-1" }),
       );
       mockPrisma.questInstance.findMany.mockResolvedValue([]);
-      mockPrisma.childMonsterTheme.findMany.mockResolvedValue([]);
+      mockPrisma.familyMonsterTheme.findMany.mockResolvedValue([]);
 
       const res = await GET(makeReq("child-1"));
       const json = await res.json();
@@ -142,10 +143,10 @@ describe("GET /api/parent/child-view/monster", () => {
     it("現在のmonsterSetId（レコードがまだ無いケース）はisFree:falseのテーマでもownedThemesに含まれること", async () => {
       mockGetCurrentUser.mockResolvedValue(parentUserWithFamily());
       mockPrisma.user.findFirst.mockResolvedValue(
-        childUser({ id: "child-1", monsterSetId: "buddha" }),
+        childUser({ id: "child-1", monsterSetId: "buddha", familyId: "fam-1" }),
       );
       mockPrisma.questInstance.findMany.mockResolvedValue([]);
-      mockPrisma.childMonsterTheme.findMany.mockResolvedValue([]);
+      mockPrisma.familyMonsterTheme.findMany.mockResolvedValue([]);
 
       const res = await GET(makeReq("child-1"));
       const json = await res.json();
@@ -154,39 +155,34 @@ describe("GET /api/parent/child-view/monster", () => {
       expect(json.ownedThemes.slice().sort()).toEqual(["buddha", "dark", "light"]);
     });
 
-    it("境界値: dark→light切替済みでChildMonsterThemeにlightのレコードのみある場合でも、dark（無料テーマ）とlightの両方がownedThemesに含まれること", async () => {
+    it("FamilyMonsterThemeの検索は対象の子供が所属する家族のfamilyIdで絞り込むこと", async () => {
       mockGetCurrentUser.mockResolvedValue(parentUserWithFamily());
       mockPrisma.user.findFirst.mockResolvedValue(
-        childUser({ id: "child-1", monsterSetId: "light" }),
+        childUser({ id: "child-99", monsterSetId: "dark", familyId: "fam-99" }),
       );
       mockPrisma.questInstance.findMany.mockResolvedValue([]);
-      mockPrisma.childMonsterTheme.findMany.mockResolvedValue([
-        { id: "cmt-1", childId: "child-1", themeId: "light", activatedAt: new Date("2026-03-01"), grantReason: "switch" },
-      ]);
+      mockPrisma.familyMonsterTheme.findMany.mockResolvedValue([]);
+
+      await GET(makeReq("child-99"));
+
+      expect(mockPrisma.familyMonsterTheme.findMany).toHaveBeenCalledWith({
+        where: { familyId: "fam-99" },
+      });
+    });
+
+    it("境界値: 対象の子供のfamilyIdがnullの場合、familyMonsterTheme.findManyを呼ばず、ownedThemesは無料テーマ+monsterSetIdのみになること", async () => {
+      mockGetCurrentUser.mockResolvedValue(parentUserWithFamily());
+      mockPrisma.user.findFirst.mockResolvedValue(
+        childUser({ id: "child-1", monsterSetId: "dark", familyId: null }),
+      );
+      mockPrisma.questInstance.findMany.mockResolvedValue([]);
 
       const res = await GET(makeReq("child-1"));
       const json = await res.json();
 
-      expect(json.ownedThemes).toContain("dark");
-      expect(json.ownedThemes).toContain("light");
+      expect(mockPrisma.familyMonsterTheme.findMany).not.toHaveBeenCalled();
       expect(json.ownedThemes.slice().sort()).toEqual(["dark", "light"]);
-    });
-
-    it("ChildMonsterThemeの検索は対象の子供のchildIdで絞り込むこと", async () => {
-      mockGetCurrentUser.mockResolvedValue(parentUserWithFamily());
-      mockPrisma.user.findFirst.mockResolvedValue(
-        childUser({ id: "child-99", monsterSetId: "dark" }),
-      );
-      mockPrisma.questInstance.findMany.mockResolvedValue([]);
-      mockPrisma.childMonsterTheme.findMany.mockResolvedValue([]);
-
-      await GET(makeReq("child-99"));
-
-      expect(mockPrisma.childMonsterTheme.findMany).toHaveBeenCalledWith(
-        expect.objectContaining({
-          where: expect.objectContaining({ childId: "child-99" }),
-        }),
-      );
+      expect(json.ownedThemes).not.toContain("buddha");
     });
   });
 });

--- a/src/__tests__/api/rebirth/rebirth.test.ts
+++ b/src/__tests__/api/rebirth/rebirth.test.ts
@@ -3,7 +3,7 @@ import { POST } from "@/app/api/rebirth/route";
 import { getCurrentUser } from "@/lib/auth";
 import { checkAndUnlockBadges } from "@/lib/badges";
 import { triggerBadgeLog } from "@/lib/bulletinLog";
-import { activateChildTheme } from "@/lib/monsterThemes";
+import { activateFamilyTheme } from "@/lib/monsterThemes";
 import { prismaMock as mockPrisma } from "../../helpers/prisma-mock";
 import { childUser, childUserWithFamily, parentUserWithFamily } from "../../helpers/fixtures";
 import { makeRequest } from "../../helpers/request";
@@ -25,13 +25,13 @@ vi.mock("@/lib/bulletinLog", async () => {
 });
 
 vi.mock("@/lib/monsterThemes", () => ({
-  activateChildTheme: vi.fn().mockResolvedValue(undefined),
+  activateFamilyTheme: vi.fn().mockResolvedValue(undefined),
 }));
 
 const mockGetCurrentUser = vi.mocked(getCurrentUser);
 const mockCheckAndUnlockBadges = vi.mocked(checkAndUnlockBadges);
 const mockTriggerBadgeLog = vi.mocked(triggerBadgeLog);
-const mockActivateChildTheme = vi.mocked(activateChildTheme);
+const mockActivateFamilyTheme = vi.mocked(activateFamilyTheme);
 
 beforeEach(() => {
   vi.clearAllMocks();
@@ -246,13 +246,16 @@ describe("POST /api/rebirth", () => {
     expect(mockTriggerBadgeLog).toHaveBeenCalledWith("child-1", "卵えらびマスター");
   });
 
-  // Issue #85: 転生実行時に pendingMonsterSetId を monsterSetId へ反映する
-  describe("pendingMonsterSetId の反映（モンスターテーマセット Stage2）", () => {
+  // Issue #85 / #111: 転生実行時に pendingMonsterSetId を monsterSetId へ反映する。
+  // モンスターテーマの所持記録は家族単位（FamilyMonsterTheme）で行うため、
+  // activateFamilyTheme は childId ではなく子供が所属する家族の familyId で呼ばれる。
+  describe("pendingMonsterSetId の反映（モンスターテーマセット Stage2、家族単位所持へ移行）", () => {
     it("pendingMonsterSetIdが設定されている場合、monsterSetIdに反映されpendingMonsterSetIdがクリアされること", async () => {
       mockGetCurrentUser.mockResolvedValue(childUserWithFamily({ id: "child-1" }));
       mockPrisma.user.findUnique.mockResolvedValue(
         childUser({
           id: "child-1",
+          familyId: "fam-1",
           rebirthPending: true,
           usedEggBonuses: "[]",
           pendingMonsterSetId: "buddha",
@@ -275,11 +278,12 @@ describe("POST /api/rebirth", () => {
       );
     });
 
-    it("pendingMonsterSetIdが設定されている場合、activateChildThemeが呼ばれること", async () => {
+    it("pendingMonsterSetIdが設定されている場合、activateFamilyThemeが子供の所属するfamilyIdで呼ばれること", async () => {
       mockGetCurrentUser.mockResolvedValue(childUserWithFamily({ id: "child-1" }));
       mockPrisma.user.findUnique.mockResolvedValue(
         childUser({
           id: "child-1",
+          familyId: "fam-1",
           rebirthPending: true,
           usedEggBonuses: "[]",
           pendingMonsterSetId: "buddha",
@@ -292,7 +296,8 @@ describe("POST /api/rebirth", () => {
       expect(res.status).toBe(200);
       await new Promise(r => setImmediate(r));
 
-      expect(mockActivateChildTheme).toHaveBeenCalledWith("child-1", "buddha", "manual");
+      // childId ("child-1") ではなく familyId ("fam-1") が渡ること
+      expect(mockActivateFamilyTheme).toHaveBeenCalledWith("fam-1", "buddha", "manual");
     });
 
     it("pendingMonsterSetIdが未設定(null)の場合、monsterSetId/pendingMonsterSetIdを変更しないこと", async () => {
@@ -300,6 +305,7 @@ describe("POST /api/rebirth", () => {
       mockPrisma.user.findUnique.mockResolvedValue(
         childUser({
           id: "child-1",
+          familyId: "fam-1",
           rebirthPending: true,
           usedEggBonuses: "[]",
           pendingMonsterSetId: null,
@@ -316,11 +322,12 @@ describe("POST /api/rebirth", () => {
       expect(updateCall.data).not.toHaveProperty("pendingMonsterSetId");
     });
 
-    it("pendingMonsterSetIdが未設定(null)の場合、activateChildThemeが呼ばれないこと", async () => {
+    it("pendingMonsterSetIdが未設定(null)の場合、activateFamilyThemeが呼ばれないこと", async () => {
       mockGetCurrentUser.mockResolvedValue(childUserWithFamily({ id: "child-1" }));
       mockPrisma.user.findUnique.mockResolvedValue(
         childUser({
           id: "child-1",
+          familyId: "fam-1",
           rebirthPending: true,
           usedEggBonuses: "[]",
           pendingMonsterSetId: null,
@@ -333,7 +340,30 @@ describe("POST /api/rebirth", () => {
       expect(res.status).toBe(200);
       await new Promise(r => setImmediate(r));
 
-      expect(mockActivateChildTheme).not.toHaveBeenCalled();
+      expect(mockActivateFamilyTheme).not.toHaveBeenCalled();
+    });
+
+    it("境界値: familyIdがnullの子供の場合、activateFamilyThemeを呼ばず、転生処理自体は成功すること（after()内で例外を出さない）", async () => {
+      mockGetCurrentUser.mockResolvedValue(childUserWithFamily({ id: "child-1" }));
+      mockPrisma.user.findUnique.mockResolvedValue(
+        childUser({
+          id: "child-1",
+          familyId: null,
+          rebirthPending: true,
+          usedEggBonuses: "[]",
+          pendingMonsterSetId: "buddha",
+        }),
+      );
+      mockPrisma.user.updateMany.mockResolvedValue({ count: 1 });
+
+      const req = makeRequest("/api/rebirth", { eggType: "STUDY" });
+      const res = await POST(req);
+      expect(res.status).toBe(200);
+      const json = await res.json();
+      expect(json).toEqual({ ok: true });
+      await new Promise(r => setImmediate(r));
+
+      expect(mockActivateFamilyTheme).not.toHaveBeenCalled();
     });
   });
 });

--- a/src/__tests__/lib/monsterThemes-activate.test.ts
+++ b/src/__tests__/lib/monsterThemes-activate.test.ts
@@ -1,15 +1,17 @@
-// Issue #73: モンスターテーマセット Stage1 — テーマ有効化記録の DB 操作層テスト。
-// 対象: src/lib/monsterThemes.ts の activateChildTheme (未実装。実装は implementer が行う)
+// Issue #111: モンスターテーマ所持記録を子供単位から家族単位へ移行。
+// 対象: src/lib/monsterThemes.ts の activateFamilyTheme (未実装。実装は implementer が行う)
 //
-// NOTE: このファイルは `src/lib/monsterThemes.ts`（DB操作層、新規ファイル）を対象とする。
+// NOTE: このファイルは `src/lib/monsterThemes.ts`（DB操作層）を対象とする。
 // データ定義層の `src/lib/monsterThemes/` ディレクトリ（buddha.ts / index.ts 等）とは別物。
 //
-// 想定シグネチャ: activateChildTheme(childId: string, themeId: string, grantReason: string, now?: Date): Promise<void>
-//  - ChildMonsterTheme テーブルへ upsert する (@@unique([childId, themeId]) を前提)
+// 想定シグネチャ: activateFamilyTheme(familyId: string, themeId: string, grantReason: string, now?: Date): Promise<void>
+//  - FamilyMonsterTheme テーブルへ upsert する (@@unique([familyId, themeId]) を前提)
 //  - 新規有効化なら1レコード作成、既存テーマの再有効化では重複作成しない
+//  - 旧 activateChildTheme(childId, ...) の家族単位版。兄弟間でテーマの所持を共有するため
+//    childId ではなく familyId で upsert する。
 
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { activateChildTheme } from "@/lib/monsterThemes";
+import { activateFamilyTheme } from "@/lib/monsterThemes";
 import { prismaMock as mockPrisma } from "../helpers/prisma-mock";
 
 beforeEach(() => {
@@ -18,23 +20,23 @@ beforeEach(() => {
 
 const FIXED_NOW = new Date("2026-08-15T03:00:00Z");
 
-describe("activateChildTheme", () => {
+describe("activateFamilyTheme", () => {
   it("新規テーマ有効化 → upsert で1レコード作成されること", async () => {
-    mockPrisma.childMonsterTheme.upsert.mockResolvedValue({
-      id: "cmt-1",
-      childId: "child-1",
+    mockPrisma.familyMonsterTheme.upsert.mockResolvedValue({
+      id: "fmt-1",
+      familyId: "fam-1",
       themeId: "buddha",
       activatedAt: FIXED_NOW,
       grantReason: "purchase",
     });
 
-    await activateChildTheme("child-1", "buddha", "purchase", FIXED_NOW);
+    await activateFamilyTheme("fam-1", "buddha", "purchase", FIXED_NOW);
 
-    expect(mockPrisma.childMonsterTheme.upsert).toHaveBeenCalledTimes(1);
-    expect(mockPrisma.childMonsterTheme.upsert).toHaveBeenCalledWith({
-      where: { childId_themeId: { childId: "child-1", themeId: "buddha" } },
+    expect(mockPrisma.familyMonsterTheme.upsert).toHaveBeenCalledTimes(1);
+    expect(mockPrisma.familyMonsterTheme.upsert).toHaveBeenCalledWith({
+      where: { familyId_themeId: { familyId: "fam-1", themeId: "buddha" } },
       create: {
-        childId: "child-1",
+        familyId: "fam-1",
         themeId: "buddha",
         activatedAt: FIXED_NOW,
         grantReason: "purchase",
@@ -43,49 +45,49 @@ describe("activateChildTheme", () => {
     });
   });
 
-  it("既存テーマの再有効化 → 同じ unique where で upsert が呼ばれ、重複作成が起きない設計であること", async () => {
-    mockPrisma.childMonsterTheme.upsert.mockResolvedValue({
-      id: "cmt-1",
-      childId: "child-1",
+  it("同一family+同一themeを2回有効化 → 常に同じunique whereでupsertされ重複作成されないこと", async () => {
+    mockPrisma.familyMonsterTheme.upsert.mockResolvedValue({
+      id: "fmt-1",
+      familyId: "fam-1",
       themeId: "buddha",
       activatedAt: FIXED_NOW,
       grantReason: "purchase",
     });
 
-    await activateChildTheme("child-1", "buddha", "purchase", FIXED_NOW);
-    await activateChildTheme("child-1", "buddha", "purchase", FIXED_NOW);
+    await activateFamilyTheme("fam-1", "buddha", "purchase", FIXED_NOW);
+    await activateFamilyTheme("fam-1", "buddha", "purchase", FIXED_NOW);
 
-    expect(mockPrisma.childMonsterTheme.upsert).toHaveBeenCalledTimes(2);
-    for (const call of mockPrisma.childMonsterTheme.upsert.mock.calls) {
+    expect(mockPrisma.familyMonsterTheme.upsert).toHaveBeenCalledTimes(2);
+    for (const call of mockPrisma.familyMonsterTheme.upsert.mock.calls) {
       expect(call[0].where).toEqual({
-        childId_themeId: { childId: "child-1", themeId: "buddha" },
+        familyId_themeId: { familyId: "fam-1", themeId: "buddha" },
       });
     }
   });
 
-  it("childId が空文字の場合はエラーを投げること", async () => {
-    await expect(activateChildTheme("", "buddha", "purchase")).rejects.toThrow();
+  it("familyId が空文字の場合はエラーを投げること", async () => {
+    await expect(activateFamilyTheme("", "buddha", "purchase")).rejects.toThrow();
   });
 
   it("themeId が空文字の場合はエラーを投げること", async () => {
-    await expect(activateChildTheme("child-1", "", "purchase")).rejects.toThrow();
+    await expect(activateFamilyTheme("fam-1", "", "purchase")).rejects.toThrow();
   });
 
   it("now を省略した場合は現在時刻でレコードが作成されること", async () => {
-    mockPrisma.childMonsterTheme.upsert.mockResolvedValue({
-      id: "cmt-1",
-      childId: "child-1",
+    mockPrisma.familyMonsterTheme.upsert.mockResolvedValue({
+      id: "fmt-1",
+      familyId: "fam-1",
       themeId: "dark",
       activatedAt: new Date(),
       grantReason: "default",
     });
 
-    await activateChildTheme("child-1", "dark", "default");
+    await activateFamilyTheme("fam-1", "dark", "default");
 
-    expect(mockPrisma.childMonsterTheme.upsert).toHaveBeenCalledWith(
+    expect(mockPrisma.familyMonsterTheme.upsert).toHaveBeenCalledWith(
       expect.objectContaining({
         create: expect.objectContaining({
-          childId: "child-1",
+          familyId: "fam-1",
           themeId: "dark",
           grantReason: "default",
           activatedAt: expect.any(Date),

--- a/src/app/api/family/code/route.ts
+++ b/src/app/api/family/code/route.ts
@@ -12,18 +12,20 @@ export async function GET() {
       return NextResponse.json({ code: null, members: [] });
     }
 
-    const family = await prisma.family.findUnique({
-      where: { id: user.familyId },
-      include: {
-        users: {
-          orderBy: { createdAt: "asc" },
-          include: {
-            streak: { select: { lastLoginDate: true } },
-            monsterThemes: { select: { themeId: true } },
+    const [family, ownedThemeRecords] = await Promise.all([
+      prisma.family.findUnique({
+        where: { id: user.familyId },
+        include: {
+          users: {
+            orderBy: { createdAt: "asc" },
+            include: {
+              streak: { select: { lastLoginDate: true } },
+            },
           },
         },
-      },
-    });
+      }),
+      prisma.familyMonsterTheme.findMany({ where: { familyId: user.familyId } }),
+    ]);
 
     const members = (family?.users || []).map((u: Record<string, unknown>) => ({
       id: u.id,
@@ -50,7 +52,7 @@ export async function GET() {
         ? String((u.streak as { lastLoginDate: Date | null }).lastLoginDate)
         : null,
       ownedThemes: resolveOwnedThemes(
-        u.monsterThemes as { themeId: string }[] | undefined,
+        ownedThemeRecords,
         (u.monsterSetId as string | null) ?? null,
       ),
     }));

--- a/src/app/api/family/members/[id]/monster-theme/route.ts
+++ b/src/app/api/family/members/[id]/monster-theme/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from "next/server";
 import { prisma } from "@/lib/prisma";
 import { getCurrentUser } from "@/lib/auth";
-import { activateChildTheme } from "@/lib/monsterThemes";
+import { activateFamilyTheme } from "@/lib/monsterThemes";
 import { MONSTER_THEMES } from "@/lib/monsterThemes/index";
 import { routeLogger } from "@/lib/logger";
 
@@ -34,9 +34,10 @@ export async function PATCH(
   }
   if (MONSTER_THEMES[themeId].isFree === false) {
     // 決済導線は未実装だが、開発者による手動DB挿入で「購入済み」として付与された
-    // 子は選択できる（Issue #90）。ChildMonsterTheme の所持レコードで判定する。
-    const owned = await prisma.childMonsterTheme.findUnique({
-      where: { childId_themeId: { childId: id, themeId } },
+    // 家族は選択できる（Issue #90 / #111）。FamilyMonsterTheme の所持レコードで
+    // 家族単位に判定する（childId ではなく親の familyId。兄弟間で所持を共有する）。
+    const owned = await prisma.familyMonsterTheme.findUnique({
+      where: { familyId_themeId: { familyId: user.familyId, themeId } },
     });
     if (!owned) {
       return NextResponse.json({ error: "このテーマはまだ購入されていません" }, { status: 400 });
@@ -51,7 +52,7 @@ export async function PATCH(
       where: { id },
       data: { monsterSetId: themeId },
     });
-    await activateChildTheme(id, themeId, "manual");
+    await activateFamilyTheme(user.familyId, themeId, "manual");
     rlog.info("Monster theme changed immediately", { childId: id, themeId });
     return NextResponse.json({ immediate: true, monsterSetId: themeId });
   }

--- a/src/app/api/monster/route.ts
+++ b/src/app/api/monster/route.ts
@@ -10,13 +10,17 @@ export async function GET() {
     return NextResponse.json({ error: "認証が必要です" }, { status: 401 });
   }
 
-  // 承認待ち（REPORTED）クエストのXPをカテゴリ別に集計 と 所持テーマ一覧（Issue #86）を並列取得
+  // 承認待ち（REPORTED）クエストのXPをカテゴリ別に集計 と 所持テーマ一覧（Issue #86 → #111:
+  // 家族単位所持）を並列取得。familyId が無いユーザーは familyMonsterTheme を問い合わせず
+  // 空配列にフォールバックする（undefined を where に渡すと全家族横断で漏洩するため）。
   const [pendingQuests, ownedThemeRecords] = await Promise.all([
     prisma.questInstance.findMany({
       where: { childId: user.id, status: "REPORTED" },
       include: { template: true },
     }),
-    prisma.childMonsterTheme.findMany({ where: { childId: user.id } }),
+    user.familyId
+      ? prisma.familyMonsterTheme.findMany({ where: { familyId: user.familyId } })
+      : Promise.resolve([]),
   ]);
   const ownedThemes = resolveOwnedThemes(ownedThemeRecords, user.monsterSetId);
 

--- a/src/app/api/parent/child-view/monster/route.ts
+++ b/src/app/api/parent/child-view/monster/route.ts
@@ -24,12 +24,17 @@ export async function GET(request: Request) {
   }
   const child = resolved.child;
 
+  // 所持テーマ一覧（Issue #86 → #111: 家族単位所持）。familyId が無い子供は
+  // familyMonsterTheme を問い合わせず空配列にフォールバックする（undefined を where に
+  // 渡すと全家族横断で漏洩するため、必ず早期ガードする）。
   const [pendingQuests, ownedThemeRecords] = await Promise.all([
     prisma.questInstance.findMany({
       where: { childId: child.id, status: "REPORTED" },
       include: { template: true },
     }),
-    prisma.childMonsterTheme.findMany({ where: { childId: child.id } }),
+    child.familyId
+      ? prisma.familyMonsterTheme.findMany({ where: { familyId: child.familyId } })
+      : Promise.resolve([]),
   ]);
   const ownedThemes = resolveOwnedThemes(ownedThemeRecords, child.monsterSetId);
 

--- a/src/app/api/rebirth/route.ts
+++ b/src/app/api/rebirth/route.ts
@@ -3,7 +3,7 @@ import { getCurrentUser } from "@/lib/auth";
 import { prisma } from "@/lib/prisma";
 import { triggerMonsterRebornLog, triggerBadgeLog } from "@/lib/bulletinLog";
 import { checkAndUnlockBadges } from "@/lib/badges";
-import { activateChildTheme } from "@/lib/monsterThemes";
+import { activateFamilyTheme } from "@/lib/monsterThemes";
 
 const VALID_EGG_TYPES = ["NORMAL", "STUDY", "STAMINA", "LIFE"] as const;
 
@@ -25,7 +25,7 @@ export async function POST(request: Request) {
 
   const child = await prisma.user.findUnique({
     where: { id: user.id },
-    select: { rebirthPending: true, usedEggBonuses: true, pendingMonsterSetId: true },
+    select: { rebirthPending: true, usedEggBonuses: true, pendingMonsterSetId: true, familyId: true },
   });
 
   if (!child?.rebirthPending) {
@@ -63,8 +63,9 @@ export async function POST(request: Request) {
     return NextResponse.json({ error: "転生の準備ができていません" }, { status: 400 });
   }
 
-  if (pendingThemeId) {
-    after(() => activateChildTheme(user.id, pendingThemeId, "manual").catch(() => {}));
+  if (pendingThemeId && child.familyId) {
+    const familyId = child.familyId;
+    after(() => activateFamilyTheme(familyId, pendingThemeId, "manual").catch(() => {}));
   }
 
   // 転生ログ — after() でレスポンス送信後に実行（サーバレスで取りこぼさないため）

--- a/src/lib/monsterThemes.ts
+++ b/src/lib/monsterThemes.ts
@@ -1,26 +1,27 @@
-// モンスターテーマセットの DB 操作層（ChildMonsterTheme テーブル）。
+// モンスターテーマセットの DB 操作層（FamilyMonsterTheme テーブル）。
 // データ定義層 (@/lib/monsterThemes/index, @/lib/monsterThemes/buddha) とは別ファイル。
 
 import { prisma } from "@/lib/prisma";
 
 /**
- * 子供にモンスターテーマの有効化を記録する（購入・付与など）。
- * childId + themeId で upsert するため、同じテーマを複数回有効化しても
- * レコードが重複作成されることはない。
+ * 家族にモンスターテーマの有効化を記録する（購入・付与など）。
+ * familyId + themeId で upsert するため、同じテーマを複数回有効化しても
+ * レコードが重複作成されることはない。兄弟間でテーマの所持を共有するため
+ * childId ではなく familyId を単位とする（Issue #111）。
  */
-export async function activateChildTheme(
-  childId: string,
+export async function activateFamilyTheme(
+  familyId: string,
   themeId: string,
   grantReason: string,
   now: Date = new Date(),
 ): Promise<void> {
-  if (!childId) throw new Error("childId is required");
+  if (!familyId) throw new Error("familyId is required");
   if (!themeId) throw new Error("themeId is required");
 
-  await prisma.childMonsterTheme.upsert({
-    where: { childId_themeId: { childId, themeId } },
+  await prisma.familyMonsterTheme.upsert({
+    where: { familyId_themeId: { familyId, themeId } },
     create: {
-      childId,
+      familyId,
       themeId,
       activatedAt: now,
       grantReason,

--- a/src/lib/monsterThemes/ownedThemes.ts
+++ b/src/lib/monsterThemes/ownedThemes.ts
@@ -1,14 +1,14 @@
 // 所持テーマ一覧（ownedThemes）を決定する純粋関数（ビジネスロジック層）。
 //
-// ChildMonsterTheme のレコードのみから ownedThemes を構築すると、以下が漏れる:
+// FamilyMonsterTheme のレコードのみから ownedThemes を構築すると、以下が漏れる:
 //   - isFree: true のテーマ（dark/light）は付与レコードが無くても所持しているはず
 //   - 現在有効な monsterSetId（移行直後などレコードがまだ無いケース）
 // このため、以下の3種類をマージした一覧を返す。
 //   - MONSTER_THEMES で isFree === true の全テーマID
 //   - 現在の monsterSetId
-//   - 既存の ChildMonsterTheme レコード由来の themeId
+//   - 既存の FamilyMonsterTheme レコード由来の themeId（Issue #111: 家族単位所持、兄弟間で共有）
 //
-// isFree: false のテーマ（buddha 等）は、ChildMonsterTheme にレコードが無い限り含めない
+// isFree: false のテーマ（buddha 等）は、FamilyMonsterTheme にレコードが無い限り含めない
 // （PR #89 Codexレビュー指摘2）。
 
 import { MONSTER_THEMES } from "@/lib/monsterThemes/index";


### PR DESCRIPTION
## Summary

モンスターテーマセット（買い切りコンテンツ）の所持記録を「子供ごと」から「家族ごと」に変更するリファクタ。親が1度テーマを購入すれば、同じ家族の子供全員が使えるようになる（子供を追加するたびの個別付与が不要になる）。

背景: 実際の決済導線（購入UI）はまだ未実装で、有料テーマの唯一の付与経路は開発者によるDB直接INSERTのみ。決済導線を実装した後にスキーマを変えると実課金レコードの移行が絡んでコストが跳ね上がるため、今が変更コストが最小のタイミング。また `getFamilyPlan(familyId)` がサブスクを家族単位で解決している既存実装とも整合する。

- `ChildMonsterTheme`（`childId`+`themeId`）を `FamilyMonsterTheme`（`familyId`+`themeId`）に置き換え（マイグレーション含む。データ移送は`DISTINCT ON`+`ON CONFLICT DO NOTHING`で兄弟重複を吸収、`familyId`がNULLの子供はスキップ）
- `activateChildTheme` → `activateFamilyTheme` に変更し、呼び出し元2箇所（親のテーマ切替API・転生API）を更新
- `/api/family/members/[id]/monster-theme` の所持チェックを `familyId` 基準に変更（兄弟共有が機能するように）
- `/api/family/code` のN+1クエリを解消（家族単位で1回のクエリに統合）
- `/api/monster`・`/api/parent/child-view/monster` も `familyId` 基準に変更、`familyId` が null の場合の横断漏洩防止ガードを追加
- 「現在表示中のテーマ」（`monsterSetId`、転生時のみ切替可能というルール）は変更なし。所持の母集団だけが家族単位になる
- `resolveOwnedThemes`（純粋関数）・クライアント側コンポーネント・APIレスポンス形状は無変更

Closes #111

## Test plan
- [x] `npm test` パス（201ファイル / 2793テスト全通過、既存テスト回帰なし）
- [x] 本番の `ChildMonsterTheme` は0件であることを確認済み（マイグレーションによるデータ損失リスクなし）
- [ ] `npm run lint` パス
- [ ] 手動確認: 家族の子供2人でテーマ選択UIが共有されること（兄弟共有）

## Related decision
- `docs/decisions.md#2026-08-21-モンスターテーマ所持記録を子供単位childmonstertheme-から家族単位familymonstertheme-へ移行する2026-08-18決定の補足issue-111`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
