### PR TITLE
fix(treasure): 開かずの宝箱バグの恒久修正 (#108)

### DIFF
--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -119,6 +119,10 @@
 - [2026-08-12: テストの `no-explicit-any` 解消（案B）— Prisma モックを `vitest-mock-extended` の `mockDeep` に置き換える（Issue #35, #23 の基盤1）](#2026-08-12-テストの-no-explicit-any-解消案b-prisma-モックを-vitest-mock-extended-の-mockdeep-に置き換えるissue-35-23-の基盤1)
 - [2026-08-14: PRごとのVercelプレビュー環境でPlaywright E2Eを自動実行する。UI関連パス変更時のみ・non-blocking運用で開始（Issue #74）](#2026-08-14-prごとのvercelプレビュー環境でplaywright-e2eを自動実行するui関連パス変更時のみ・non-blocking運用で開始issue-74)
 - [2026-08-18: モンスターテーマセット機能 Stage 1 — テーマ切り替え方式（解釈B）採用、転生時のみ切替可、図鑑は所持テーマのみ表示（Issue #73）](#2026-08-18-モンスターテーマセット機能-stage-1--テーマ切り替え方式解釈b採用転生時のみ切替可図鑑は所持テーマのみ表示issue-73)
+- [2026-08-20: monsterLevels のテーマ名前空間対応と既存DB移行（Issue #93）](#2026-08-20-monsterlevels-のテーマ名前空間対応と既存db移行issue-93)
+- [2026-08-21: quests画面1枚に限定してストリークを1行ピルとして条件付き再導入する（2026-06-29決定の部分上書き、Issue #106）](#2026-08-21-quests画面1枚に限定してストリークを1行ピルとして条件付き再導入する2026-06-29決定の部分上書きissue-106)
+- [2026-08-21: モンスターテーマ所持記録を子供単位（`ChildMonsterTheme`）から家族単位（`FamilyMonsterTheme`）へ移行する（2026-08-18決定の補足、Issue #111）](#2026-08-21-モンスターテーマ所持記録を子供単位childmonsterthemeから家族単位familymonsterthemeへ移行する2026-08-18決定の補足issue-111)
+- [2026-08-22: 「開かずの宝箱」バグの恒久修正 — 宝箱日付解決を resolveTreasureDate に一本化](#2026-08-22-開かずの宝箱バグの恒久修正--宝箱日付解決を-resolvetreasuredate-に一本化)
 
 <!-- TOC:END -->
 
@@ -2816,4 +2820,36 @@
 - `src/lib/monsterThemes.ts` — `activateFamilyTheme()`
 - `src/lib/monsterThemes/ownedThemes.ts` — `resolveOwnedThemes()`（ロジック自体は不変、呼び出し元が渡すレコードの母集団のみ変更）
 - `src/app/api/family/members/[id]/monster-theme/route.ts` / `src/app/api/family/code/route.ts` / `src/app/api/monster/route.ts` / `src/app/api/parent/child-view/monster/route.ts` / `src/app/api/rebirth/route.ts` — 呼び出し元の更新
+
+## 2026-08-22: 「開かずの宝箱」バグの恒久修正 — 宝箱日付解決を resolveTreasureDate に一本化
+
+### 決定内容
+- 2026-06-19 決定（宝箱集計を今日基準に切替）の追補・修正として、宝箱の日付解決ロジックを **`src/lib/treasureDate.ts` の `resolveTreasureDate(questDate, carryOver, at)` という単一の純粋関数** に一本化する
+  - `carryOver === true` かつ `questDate < jstDateOf(at)` の場合のみ `jstDateOf(at)` を返し、それ以外は `questDate` をそのまま返す
+- `src/lib/approve.ts` の private 関数 `effectiveTreasureDate`（`todayJST()` を内部で呼び直していた）を削除し、`resolveTreasureDate` に置き換える。`approveQuestInstance` / `approveSkipQuestInstance` は `at` に **`quest.reportedAt ?? new Date()`** を渡す（承認時刻ではなく報告時刻を基準にする）
+- `approveSkipQuestInstance` の引数型に `reportedAt` を追加。呼び出し元（`/api/approve/[id]`、`/api/parent/child-view/quests/[id]/skip-approve`）は手組みオブジェクトに `reportedAt` を含めるよう修正
+- `/api/quests/[id]/report`・`/api/quests/[id]/skip` は、生成時の集計基準日を `resolveTreasureDate(quest.date, carryOver, now)` から導出する（`now` と `todayJST()` を別々に呼ばない）
+- `/api/approve/[id]` の差し戻し（reject）経路も、`cancelTreasuresOnReject` の対象日付と直前の集計 `findMany` を `resolveTreasureDate(quest.date, carryOver, quest.reportedAt ?? new Date())` で統一する
+- `/api/parent/child-view/quests/[id]/report-approve` は `approveQuestInstance` に渡す `updatedQuest.reportedAt` を、実際に DB へ書き込んだ値（`quest.reportedAt ?? now`）と揃える
+
+### 理由
+- 生成時（report/skip ルート）と承認時（`approve.ts` の旧 `effectiveTreasureDate`）がそれぞれ独立して `todayJST()` を呼んで「今日」を再計算しており、`carryOver=true` のクエストで **報告日と承認日が別の暦日をまたぐ**とズレが生じていた
+- 例: 8/20 23:58 JST に報告（生成側は 8/20 基準で LOCKED 宝箱を作る）→ 8/21 に承認（承認側は `todayJST()`=8/21 で unlock を検索）→ 8/20 の LOCKED が一致せず見つからず、永久に開かずの宝箱として残る
+- 修正後は `reportedAt` という「生成時に確定した1つの事実」を承認・差し戻し時にも再利用することで、生成側・承認側で必ず同じ基準日を共有できる（再計算しない）
+
+### やってはいけないこと
+- `effectiveTreasureDate` のような private な日付再計算関数を復活させる（`resolveTreasureDate` に一本化した意味がなくなる）
+- 承認・差し戻し経路で `quest.reportedAt` を無視して `new Date()`（＝承認操作を行った時刻）だけを基準にする（reportedAt が取得できるにもかかわらずフォールバックだけ使うのは本バグの再発）
+- `approveSkipQuestInstance` へ手組みオブジェクトを渡す箇所で `reportedAt` を省略する（型上は許容されても、生成時の基準日とズレる）
+
+### 該当箇所
+- `src/lib/treasureDate.ts` — 新規。純粋関数 `resolveTreasureDate`
+- `src/lib/approve.ts` — `effectiveTreasureDate` 削除、`resolveTreasureDate` 呼び出しに統一。`approveSkipQuestInstance` の型に `reportedAt` 追加
+- `src/app/api/quests/[id]/report/route.ts` / `src/app/api/quests/[id]/skip/route.ts` — 単一の `now` から `resolveTreasureDate` 経由で集計基準日を導出
+- `src/app/api/approve/[id]/route.ts` — reject 経路（REPORTED / SKIP_REPORTED 両方）の集計・`cancelTreasuresOnReject` 呼び出しを統一
+- `src/app/api/parent/child-view/quests/[id]/report-approve/route.ts` / `src/app/api/parent/child-view/quests/[id]/skip-approve/route.ts` — `reportedAt` を DB 書き込み値と揃えて `approve.ts` に渡す
+- `src/__tests__/lib/treasureDate.test.ts` — 新規。境界値（等号・未来日・JST日付切り替わり前後）を含む単体テスト
+- `src/__tests__/lib/approve.test.ts` — `carryOver 過去日付タスクの承認 (resolveTreasureDate 経由)` セクション
+- `src/__tests__/api/approve/approve-id.test.ts` — 差し戻し経路の carryOver 過去日付テスト
+- `src/__tests__/api/cron/auto-approve-treasure-date.test.ts` — 新規。cron 経由で実装（モックなし）を通したリグレッションテスト
 

--- a/src/__tests__/api/approve/approve-id.test.ts
+++ b/src/__tests__/api/approve/approve-id.test.ts
@@ -810,5 +810,88 @@ describe("POST /api/approve/[id]", () => {
       const findManyCall = prismaMock.questInstance.findMany.mock.calls[0][0];
       expect(findManyCall?.where?.template).toEqual({ isActive: true, pausedAt: null });
     });
+
+    // Issue #108: carryOver=true の古い日付タスクを差し戻す場合、宝箱の CANCELLED 判定・
+    // 集計クエリは quest.date (スケジュール上の元日付) ではなく、報告日 (resolveTreasureDate で
+    // 解決した日付) を対象にしないと、報告日に生成された宝箱が誤った日付で検索されてしまう。
+    describe("carryOver 過去日付タスクの差し戻し (resolveTreasureDate 経由)", () => {
+      it("carryOver=true / quest.date が報告日より前 / 差し戻しは数日後 → cancelTreasuresOnReject は報告日で呼ばれること", async () => {
+        vi.useFakeTimers();
+        // 差し戻し時刻: 2026-08-22（報告日から2日後）
+        vi.setSystemTime(new Date("2026-08-22T03:00:00.000Z"));
+
+        const reportedAt = new Date("2026-08-20T05:00:00.000Z"); // JST 8/20 14:00
+        const reportDateJST = new Date("2026-08-20T00:00:00.000Z");
+        const quest = questWithTemplateAndChild(
+          {
+            id: "q-carry-rej",
+            status: "REPORTED",
+            childId: "child-1",
+            templateId: "tpl-1",
+            date: new Date("2026-08-19T00:00:00.000Z"), // スケジュール上の元日付
+            reportedAt,
+          },
+          { category: "STUDY", carryOver: true },
+          { id: "child-1", minTasksForStreak: 1, studyPt: 0, staminaPt: 0, lifePt: 0 },
+        );
+        prismaMock.questInstance.findUnique.mockResolvedValue(quest);
+        prismaMock.questInstance.update.mockResolvedValue(quest);
+        prismaMock.questInstance.findMany.mockResolvedValue([
+          questInstance({ status: "PENDING" }),
+          questInstance({ status: "REPORTED" }),
+        ]);
+
+        await POST(
+          makeRequest("/api/approve/q-carry-rej", { action: "reject", rejectionReason: "がんばろう" }),
+          makeParams("q-carry-rej"),
+        );
+
+        // findMany の集計クエリも報告日で行われること（現行実装は quest.date=8/19 で呼んでしまうため Red）
+        const findManyCall = prismaMock.questInstance.findMany.mock.calls[0][0];
+        expect(findManyCall?.where?.date).toEqual(reportDateJST);
+
+        expect(mockCancelTreasures).toHaveBeenCalledWith(
+          expect.objectContaining({ childId: "child-1", date: reportDateJST }),
+        );
+        vi.useRealTimers();
+      });
+
+      it("carryOver=false は差し戻しが何日後でも cancelTreasuresOnReject は常に quest.date のまま", async () => {
+        vi.useFakeTimers();
+        vi.setSystemTime(new Date("2026-08-28T03:00:00.000Z"));
+
+        const oldDate = new Date("2026-08-19T00:00:00.000Z");
+        const quest = questWithTemplateAndChild(
+          {
+            id: "q-noncarry-rej",
+            status: "REPORTED",
+            childId: "child-1",
+            templateId: "tpl-1",
+            date: oldDate,
+            reportedAt: new Date("2026-08-19T05:00:00.000Z"),
+          },
+          { category: "STUDY", carryOver: false },
+          { id: "child-1", minTasksForStreak: 1, studyPt: 0, staminaPt: 0, lifePt: 0 },
+        );
+        prismaMock.questInstance.findUnique.mockResolvedValue(quest);
+        prismaMock.questInstance.update.mockResolvedValue(quest);
+        prismaMock.questInstance.findMany.mockResolvedValue([
+          questInstance({ status: "PENDING" }),
+          questInstance({ status: "REPORTED" }),
+        ]);
+
+        await POST(
+          makeRequest("/api/approve/q-noncarry-rej", { action: "reject", rejectionReason: "がんばろう" }),
+          makeParams("q-noncarry-rej"),
+        );
+
+        const findManyCall = prismaMock.questInstance.findMany.mock.calls[0][0];
+        expect(findManyCall?.where?.date).toEqual(oldDate);
+        expect(mockCancelTreasures).toHaveBeenCalledWith(
+          expect.objectContaining({ childId: "child-1", date: oldDate }),
+        );
+        vi.useRealTimers();
+      });
+    });
   });
 });

--- a/src/__tests__/api/cron/auto-approve-treasure-date.test.ts
+++ b/src/__tests__/api/cron/auto-approve-treasure-date.test.ts
@@ -1,0 +1,148 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { GET } from "@/app/api/cron/auto-approve/route";
+import { prismaMock as mockPrisma } from "../../helpers/prisma-mock";
+import { questInstance, childUser } from "../../helpers/fixtures";
+
+// Issue #108: auto-approve cron 経由でも「開かずの宝箱」バグが再現することを確認する。
+// この describe ブロックは @/lib/approve / @/lib/treasureService を **モックしない**。
+// cron → approveQuestInstance / approveSkipQuestInstance → unlockTreasuresOnApprove
+// (実装) → prisma.treasureLog.updateMany まで実際に通し、carryOver 過去日付タスクが
+// 承認日ではなく報告日で unlock されることを検証する。
+vi.mock("@/lib/streak", () => ({
+  recordDailyAchievement: vi.fn().mockResolvedValue(undefined),
+  recordTaskStreak: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("@/lib/badges", () => ({
+  checkAndUnlockBadges: vi.fn().mockResolvedValue([]),
+}));
+
+function pendingQuest(overrides: {
+  id: string;
+  status: "REPORTED" | "SKIP_REPORTED";
+  date: Date;
+  reportedAt: Date | null;
+  childId: string;
+  templateId: string;
+  carryOver: boolean;
+}) {
+  return {
+    ...questInstance({
+      id: overrides.id,
+      status: overrides.status,
+      date: overrides.date,
+      reportedAt: overrides.reportedAt,
+      childId: overrides.childId,
+      templateId: overrides.templateId,
+    }),
+    template: {
+      id: overrides.templateId,
+      category: "STUDY" as const,
+      createdBy: "PARENT" as const,
+      isTemporary: false,
+      photoBonus: false,
+      repeatDays: [1, 2, 3, 4, 5],
+      carryOver: overrides.carryOver,
+    },
+    child: {
+      id: overrides.childId,
+      evolutionStage: 0,
+      evolutionPath: "",
+      collectedPaths: "[]",
+      studyPt: 0,
+      staminaPt: 0,
+      lifePt: 0,
+    },
+  };
+}
+
+function makeRequest(secret?: string) {
+  const headers: Record<string, string> = {};
+  if (secret !== undefined) {
+    headers["authorization"] = `Bearer ${secret}`;
+  }
+  return new Request("http://localhost/api/cron/auto-approve", {
+    method: "GET",
+    headers,
+  });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.stubEnv("CRON_SECRET", "test-secret");
+  mockPrisma.questDeclaration.findUnique.mockResolvedValue(null);
+  mockPrisma.user.findUnique.mockResolvedValue(childUser());
+  mockPrisma.questInstance.update.mockResolvedValue(questInstance());
+  mockPrisma.user.update.mockResolvedValue(childUser());
+  mockPrisma.treasureLog.updateMany.mockResolvedValue({ count: 1 });
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("GET /api/cron/auto-approve 経由の宝箱 unlock 日付解決 (resolveTreasureDate)", () => {
+  it("carryOver=true / 古いスケジュール日 / 報告日と承認日(cronの今日)が異なる → 宝箱は報告日で unlock されること", async () => {
+    // cron 実行時刻(承認時刻): 2026-08-21 JST 10:00 = UTC 2026-08-21 01:00
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-08-21T01:00:00.000Z"));
+
+    const reportedAt = new Date("2026-08-20T14:58:00.000Z"); // JST 8/20 23:58
+    const reportDateJST = new Date("2026-08-20T00:00:00.000Z");
+    const cronTodayJST = new Date("2026-08-21T00:00:00.000Z");
+
+    mockPrisma.questInstance.findMany.mockResolvedValue([
+      pendingQuest({
+        id: "q-cron-carry",
+        status: "REPORTED",
+        date: new Date("2026-08-10T00:00:00.000Z"), // スケジュール上のかなり古い元日付
+        reportedAt,
+        childId: "child-1",
+        templateId: "tpl-1",
+        carryOver: true,
+      }),
+    ] as never);
+
+    const res = await GET(makeRequest("test-secret"));
+    expect(res.status).toBe(200);
+
+    // 現行実装 (effectiveTreasureDate が todayJST() を使う) では cron の実行日 (8/21) で
+    // updateMany が呼ばれてしまうため、この期待値は Red になる。
+    expect(mockPrisma.treasureLog.updateMany).toHaveBeenCalledWith({
+      where: { childId: "child-1", date: reportDateJST, status: "LOCKED" },
+      data: { status: "UNLOCKED" },
+    });
+    expect(mockPrisma.treasureLog.updateMany).not.toHaveBeenCalledWith({
+      where: { childId: "child-1", date: cronTodayJST, status: "LOCKED" },
+      data: { status: "UNLOCKED" },
+    });
+  });
+
+  it("SKIP_REPORTED / carryOver=true でも同様に報告日で unlock されること", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-08-22T03:00:00.000Z")); // 承認(cron実行): 8/22
+
+    const reportedAt = new Date("2026-08-20T10:00:00.000Z"); // JST 8/20 19:00
+    const reportDateJST = new Date("2026-08-20T00:00:00.000Z");
+
+    mockPrisma.questInstance.findMany.mockResolvedValue([
+      pendingQuest({
+        id: "q-cron-skip-carry",
+        status: "SKIP_REPORTED",
+        date: new Date("2026-08-19T00:00:00.000Z"),
+        reportedAt,
+        childId: "child-1",
+        templateId: "tpl-1",
+        carryOver: true,
+      }),
+    ] as never);
+
+    const res = await GET(makeRequest("test-secret"));
+    expect(res.status).toBe(200);
+
+    expect(mockPrisma.treasureLog.updateMany).toHaveBeenCalledWith({
+      where: { childId: "child-1", date: reportDateJST, status: "LOCKED" },
+      data: { status: "UNLOCKED" },
+    });
+  });
+});

--- a/src/__tests__/lib/approve.test.ts
+++ b/src/__tests__/lib/approve.test.ts
@@ -595,78 +595,184 @@ describe("宝箱アンロック", () => {
     expect(mockUnlockTreasures).toHaveBeenCalledWith("child-1", skipQuest.date);
   });
 
-  // 2026-06-19 で carryOver 過去日付の宝箱生成は「今日基準」に切り替わったが、
-  // 承認時の unlock は quest.date (過去) で検索していたため LOCKED が永久に残る。
-  // unlock も carryOver-past のときは今日基準にする必要がある。
-  describe("carryOver 過去日付タスクの承認", () => {
-    beforeEach(() => {
-      vi.useFakeTimers();
-      vi.setSystemTime(new Date("2026-03-28T03:00:00Z")); // JST 12:00 → today=2026-03-28
-    });
+  // Issue #108: carryOver 過去日付の宝箱 unlock は「承認処理を呼び出した時刻(今)」ではなく
+  // 「報告時刻 (quest.reportedAt)」を基準日にしないと、報告と承認が別の暦日をまたいだ場合に
+  // 生成側 (report/skip 時点、reportedAt 基準) と承認側の date が食い違い、LOCKED が永久に残る。
+  // そのため各テストで reportedAt を quest.date / 承認時のシステム時刻とは独立にモックする。
+  describe("carryOver 過去日付タスクの承認 (resolveTreasureDate 経由)", () => {
     afterEach(() => {
       vi.useRealTimers();
     });
 
-    it("approveQuestInstance: carryOver=true かつ quest.date < today → unlock は today で呼ぶ", async () => {
+    it("【本バグの再現→修正確認】8/20 23:58 JST に報告 → 8/21 に承認 → unlock は報告日(8/20)で呼ばれること", async () => {
+      vi.useFakeTimers();
+      // 承認時刻: 2026-08-21 JST 10:00 = UTC 2026-08-21 01:00（報告日の翌日）
+      vi.setSystemTime(new Date("2026-08-21T01:00:00.000Z"));
+
       mockPrisma.user.findUnique.mockResolvedValue(childUser(baseQuest.child));
       mockPrisma.questInstance.update.mockResolvedValue(questInstance());
       mockPrisma.user.update.mockResolvedValue(childUser());
 
-      const today = new Date("2026-03-28T00:00:00.000Z");
-      const oldQuest = {
+      // reportedAt: 2026-08-20 23:58 JST = UTC 2026-08-20 14:58
+      const reportedAt = new Date("2026-08-20T14:58:00.000Z");
+      const reportDateJST = new Date("2026-08-20T00:00:00.000Z");
+      const approvalDateJST = new Date("2026-08-21T00:00:00.000Z");
+      const quest = {
         ...baseQuest,
-        date: new Date("2026-03-19T00:00:00.000Z"), // 9日前
+        date: reportDateJST,
+        reportedAt,
         template: { ...baseQuest.template, carryOver: true, photoBonus: false },
       };
-      await approveQuestInstance(oldQuest);
+      await approveQuestInstance(quest);
 
-      expect(mockUnlockTreasures).toHaveBeenCalledWith("child-1", today);
+      // 現行の effectiveTreasureDate (todayJST() で判定) だと承認日(8/21)で呼ばれてしまうため Red になる
+      expect(mockUnlockTreasures).toHaveBeenCalledWith("child-1", reportDateJST);
+      expect(mockUnlockTreasures).not.toHaveBeenCalledWith("child-1", approvalDateJST);
     });
 
-    it("approveSkipQuestInstance: carryOver=true かつ quest.date < today → unlock は today で呼ぶ", async () => {
-      mockPrisma.questInstance.update.mockResolvedValue(questInstance());
-      const today = new Date("2026-03-28T00:00:00.000Z");
-      const oldSkipQuest = {
-        ...baseQuest,
-        status: "SKIP_REPORTED" as const,
-        date: new Date("2026-03-19T00:00:00.000Z"),
-        template: { ...baseQuest.template, carryOver: true },
-      };
-      await approveSkipQuestInstance(oldSkipQuest);
+    it("carryOver=true / quest.date が報告日より前 / 承認が数日後 → unlock は報告日で呼ばれること", async () => {
+      vi.useFakeTimers();
+      // 承認時刻: 2026-08-22（報告日からさらに2日後）
+      vi.setSystemTime(new Date("2026-08-22T03:00:00.000Z"));
 
-      expect(mockUnlockTreasures).toHaveBeenCalledWith("child-1", today);
-    });
-
-    it("carryOver=false は quest.date < today でも unlock は quest.date のまま", async () => {
       mockPrisma.user.findUnique.mockResolvedValue(childUser(baseQuest.child));
       mockPrisma.questInstance.update.mockResolvedValue(questInstance());
       mockPrisma.user.update.mockResolvedValue(childUser());
 
-      const oldDate = new Date("2026-03-19T00:00:00.000Z");
-      const oldQuest = {
+      const reportedAt = new Date("2026-08-20T05:00:00.000Z"); // JST 8/20 14:00
+      const reportDateJST = new Date("2026-08-20T00:00:00.000Z");
+      const quest = {
+        ...baseQuest,
+        date: new Date("2026-08-19T00:00:00.000Z"), // スケジュール上の元日付（報告日より前）
+        reportedAt,
+        template: { ...baseQuest.template, carryOver: true, photoBonus: false },
+      };
+      await approveQuestInstance(quest);
+
+      expect(mockUnlockTreasures).toHaveBeenCalledWith("child-1", reportDateJST);
+    });
+
+    it("carryOver=true で報告と承認が同一日 → 従来どおり報告日で unlock される（リグレッション防止）", async () => {
+      vi.useFakeTimers();
+      vi.setSystemTime(new Date("2026-08-20T06:00:00.000Z")); // JST 8/20 15:00 に承認
+
+      mockPrisma.user.findUnique.mockResolvedValue(childUser(baseQuest.child));
+      mockPrisma.questInstance.update.mockResolvedValue(questInstance());
+      mockPrisma.user.update.mockResolvedValue(childUser());
+
+      const reportedAt = new Date("2026-08-20T02:00:00.000Z"); // JST 8/20 11:00
+      const sameDayJST = new Date("2026-08-20T00:00:00.000Z");
+      const quest = {
+        ...baseQuest,
+        date: sameDayJST,
+        reportedAt,
+        template: { ...baseQuest.template, carryOver: true, photoBonus: false },
+      };
+      await approveQuestInstance(quest);
+
+      expect(mockUnlockTreasures).toHaveBeenCalledWith("child-1", sameDayJST);
+    });
+
+    it("carryOver=false は承認が何日後でも unlock は常に quest.date のまま", async () => {
+      vi.useFakeTimers();
+      vi.setSystemTime(new Date("2026-08-28T03:00:00.000Z"));
+
+      mockPrisma.user.findUnique.mockResolvedValue(childUser(baseQuest.child));
+      mockPrisma.questInstance.update.mockResolvedValue(questInstance());
+      mockPrisma.user.update.mockResolvedValue(childUser());
+
+      const oldDate = new Date("2026-08-19T00:00:00.000Z");
+      const reportedAt = new Date("2026-08-19T05:00:00.000Z");
+      const quest = {
         ...baseQuest,
         date: oldDate,
+        reportedAt,
         template: { ...baseQuest.template, carryOver: false, photoBonus: false },
       };
-      await approveQuestInstance(oldQuest);
+      await approveQuestInstance(quest);
 
       expect(mockUnlockTreasures).toHaveBeenCalledWith("child-1", oldDate);
     });
 
-    it("carryOver=true でも quest.date === today なら unlock は quest.date (=today) のまま", async () => {
+    it("reportedAt=null（親代理PENDING即承認など）の場合、承認時刻基準にフォールバックすること", async () => {
+      vi.useFakeTimers();
+      // 承認時刻: 2026-08-25 JST 12:00 = UTC 2026-08-25 03:00
+      vi.setSystemTime(new Date("2026-08-25T03:00:00.000Z"));
+
       mockPrisma.user.findUnique.mockResolvedValue(childUser(baseQuest.child));
       mockPrisma.questInstance.update.mockResolvedValue(questInstance());
       mockPrisma.user.update.mockResolvedValue(childUser());
 
-      const today = new Date("2026-03-28T00:00:00.000Z");
-      const todayQuest = {
+      const approvalDateJST = new Date("2026-08-25T00:00:00.000Z");
+      const quest = {
         ...baseQuest,
-        date: today,
+        date: new Date("2026-08-19T00:00:00.000Z"), // 過去日
+        reportedAt: null,
         template: { ...baseQuest.template, carryOver: true, photoBonus: false },
       };
-      await approveQuestInstance(todayQuest);
+      await approveQuestInstance(quest);
 
-      expect(mockUnlockTreasures).toHaveBeenCalledWith("child-1", today);
+      expect(mockUnlockTreasures).toHaveBeenCalledWith("child-1", approvalDateJST);
+    });
+
+    it("古い carryOver クエストの承認で、今日分の別の LOCKED 宝箱（未承認）が UNLOCKED にならないこと", async () => {
+      vi.useFakeTimers();
+      // 承認時刻: 2026-08-21（報告日の翌日）
+      vi.setSystemTime(new Date("2026-08-21T01:00:00.000Z"));
+
+      mockPrisma.user.findUnique.mockResolvedValue(childUser(baseQuest.child));
+      mockPrisma.questInstance.update.mockResolvedValue(questInstance());
+      mockPrisma.user.update.mockResolvedValue(childUser());
+
+      const reportedAt = new Date("2026-08-20T14:58:00.000Z"); // JST 8/20 23:58
+      const todayDateJST = new Date("2026-08-21T00:00:00.000Z");
+      const quest = {
+        ...baseQuest,
+        date: new Date("2026-08-20T00:00:00.000Z"),
+        reportedAt,
+        template: { ...baseQuest.template, carryOver: true, photoBonus: false },
+      };
+      await approveQuestInstance(quest);
+
+      // 今日(承認日)の別クエスト用 LOCKED 宝箱を誤って巻き込んで unlock してはいけない
+      expect(mockUnlockTreasures).not.toHaveBeenCalledWith("child-1", todayDateJST);
+    });
+
+    it("approveSkipQuestInstance: 8/20 に報告 → 8/22 にスキップ承認 → unlock は報告日(8/20)で呼ばれること", async () => {
+      vi.useFakeTimers();
+      vi.setSystemTime(new Date("2026-08-22T03:00:00.000Z"));
+
+      mockPrisma.questInstance.update.mockResolvedValue(questInstance());
+      const reportedAt = new Date("2026-08-20T10:00:00.000Z"); // JST 8/20 19:00
+      const reportDateJST = new Date("2026-08-20T00:00:00.000Z");
+      const skipQuest = {
+        ...baseQuest,
+        status: "SKIP_REPORTED" as const,
+        date: new Date("2026-08-19T00:00:00.000Z"),
+        reportedAt,
+        template: { ...baseQuest.template, carryOver: true },
+      };
+      await approveSkipQuestInstance(skipQuest);
+
+      expect(mockUnlockTreasures).toHaveBeenCalledWith("child-1", reportDateJST);
+    });
+
+    it("approveSkipQuestInstance: carryOver=false は承認が何日後でも unlock は常に quest.date のまま", async () => {
+      vi.useFakeTimers();
+      vi.setSystemTime(new Date("2026-08-28T03:00:00.000Z"));
+
+      mockPrisma.questInstance.update.mockResolvedValue(questInstance());
+      const oldDate = new Date("2026-08-19T00:00:00.000Z");
+      const skipQuest = {
+        ...baseQuest,
+        status: "SKIP_REPORTED" as const,
+        date: oldDate,
+        reportedAt: new Date("2026-08-19T05:00:00.000Z"),
+        template: { ...baseQuest.template, carryOver: false },
+      };
+      await approveSkipQuestInstance(skipQuest);
+
+      expect(mockUnlockTreasures).toHaveBeenCalledWith("child-1", oldDate);
     });
   });
 });

--- a/src/__tests__/lib/treasureDate.test.ts
+++ b/src/__tests__/lib/treasureDate.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect } from "vitest";
+import { resolveTreasureDate } from "@/lib/treasureDate";
+import { jstDateOf } from "@/lib/date";
+
+// Issue #108: 「開かずの宝箱」バグの恒久修正。
+// unlockTreasuresOnApprove(childId, date) の date は、生成時 (report/skip) と
+// 承認時 (approve.ts) で別々に「今」を再計算していたため、carryOver=true のクエストで
+// 報告日と承認日が別の暦日をまたぐと不一致になり、宝箱が永久に LOCKED のまま残っていた。
+// resolveTreasureDate は「基準となる時刻 (at)」を呼び出し側が明示的に渡す純粋関数にすることで
+// 生成側・承認側で同じ「基準日」を共有できるようにする。
+describe("resolveTreasureDate", () => {
+  it("carryOver=false の場合、at が questDate よりどれだけ先でも questDate をそのまま返す", () => {
+    const questDate = new Date("2026-08-10T00:00:00.000Z");
+    const at = new Date("2026-08-20T03:00:00.000Z"); // JST 2026-08-20 12:00
+    expect(resolveTreasureDate(questDate, false, at)).toEqual(questDate);
+  });
+
+  it("carryOver=false の場合、at が questDate より過去でも questDate をそのまま返す（防御的）", () => {
+    const questDate = new Date("2026-08-20T00:00:00.000Z");
+    const at = new Date("2026-08-10T03:00:00.000Z");
+    expect(resolveTreasureDate(questDate, false, at)).toEqual(questDate);
+  });
+
+  it("carryOver=true かつ questDate < jstDateOf(at) の場合、jstDateOf(at) を返す", () => {
+    const questDate = new Date("2026-08-10T00:00:00.000Z");
+    const at = new Date("2026-08-20T03:00:00.000Z"); // JST 2026-08-20 12:00
+    expect(resolveTreasureDate(questDate, true, at)).toEqual(jstDateOf(at));
+    expect(resolveTreasureDate(questDate, true, at)).toEqual(new Date("2026-08-20T00:00:00.000Z"));
+  });
+
+  it("carryOver=true かつ questDate === jstDateOf(at)（境界: 等号）の場合、questDate を返す", () => {
+    const at = new Date("2026-08-20T03:00:00.000Z"); // JST 2026-08-20 12:00
+    const questDate = jstDateOf(at); // 2026-08-20T00:00:00.000Z
+    expect(resolveTreasureDate(questDate, true, at)).toEqual(questDate);
+  });
+
+  it("carryOver=true かつ questDate > jstDateOf(at)（未来日クエスト、通常起きないが防御的）の場合、questDate を返す", () => {
+    const at = new Date("2026-08-20T03:00:00.000Z"); // JST 2026-08-20
+    const questDate = new Date("2026-08-25T00:00:00.000Z"); // 未来日
+    expect(resolveTreasureDate(questDate, true, at)).toEqual(questDate);
+  });
+
+  it("at が JST 23:59:59.999（UTC 14:59:59.999、日付切り替わり直前）の場合、その JST 日付として解決されること", () => {
+    // JST 2026-08-20 23:59:59.999 = UTC 2026-08-20 14:59:59.999
+    const at = new Date("2026-08-20T14:59:59.999Z");
+    const questDate = new Date("2026-08-19T00:00:00.000Z"); // 過去日
+    const expected = new Date("2026-08-20T00:00:00.000Z");
+    expect(resolveTreasureDate(questDate, true, at)).toEqual(expected);
+  });
+
+  it("at が JST 0:00:00.000（UTC 15:00:00.000、日付切り替わり直後）の場合、その JST 日付として解決されること", () => {
+    // JST 2026-08-21 00:00:00.000 = UTC 2026-08-20 15:00:00.000
+    const at = new Date("2026-08-20T15:00:00.000Z");
+    const questDate = new Date("2026-08-19T00:00:00.000Z"); // 過去日
+    const expected = new Date("2026-08-21T00:00:00.000Z");
+    expect(resolveTreasureDate(questDate, true, at)).toEqual(expected);
+  });
+});

--- a/src/app/api/approve/[id]/route.ts
+++ b/src/app/api/approve/[id]/route.ts
@@ -5,6 +5,7 @@ import { approveQuestInstance, approveSkipQuestInstance } from "@/lib/approve";
 import { routeLogger } from "@/lib/logger";
 import { computeCompletedCount, computeSkippedCount } from "@/lib/questProgress";
 import { cancelTreasuresOnReject } from "@/lib/treasureService";
+import { resolveTreasureDate } from "@/lib/treasureDate";
 
 export async function POST(
   request: Request,
@@ -40,17 +41,23 @@ export async function POST(
       // - reportedCount が minTasks を割れば LOCKED 全部 CANCELLED
       // - 全完了でなくなれば ALL_COMPLETE のみ CANCELLED
       //   (再報告で生成し直されるので、最新の skippedCount に応じた boost で出る)
+      // carryOver 過去日付は生成側 (report/skip) が使った基準日 (reportedAt) と揃える。
+      const treasureDate = resolveTreasureDate(
+        quest.date,
+        quest.template.carryOver,
+        quest.reportedAt ?? new Date(),
+      );
       const todayQuests = await prisma.questInstance.findMany({
         where: {
           childId: quest.childId,
-          date: quest.date,
+          date: treasureDate,
           template: { isActive: true, pausedAt: null },
         },
         select: { status: true },
       });
       await cancelTreasuresOnReject({
         childId: quest.childId,
-        date: quest.date,
+        date: treasureDate,
         reportedCount: computeCompletedCount(todayQuests),
         totalCount: todayQuests.length,
         skippedCount: computeSkippedCount(todayQuests),
@@ -86,17 +93,23 @@ export async function POST(
     });
 
     // 差し戻し後の当日進捗を集計して、条件を割った LOCKED 宝箱を CANCELLED に
+    // carryOver 過去日付は生成側 (report/skip) が使った基準日 (reportedAt) と揃える。
+    const treasureDate = resolveTreasureDate(
+      quest.date,
+      quest.template.carryOver,
+      quest.reportedAt ?? new Date(),
+    );
     const todayQuests = await prisma.questInstance.findMany({
       where: {
         childId: quest.childId,
-        date: quest.date,
+        date: treasureDate,
         template: { isActive: true, pausedAt: null },
       },
       select: { status: true },
     });
     await cancelTreasuresOnReject({
       childId: quest.childId,
-      date: quest.date,
+      date: treasureDate,
       reportedCount: computeCompletedCount(todayQuests),
       totalCount: todayQuests.length,
       skippedCount: computeSkippedCount(todayQuests),

--- a/src/app/api/parent/child-view/quests/[id]/report-approve/route.ts
+++ b/src/app/api/parent/child-view/quests/[id]/report-approve/route.ts
@@ -1,13 +1,14 @@
 import { NextResponse, after } from "next/server";
 import { prisma } from "@/lib/prisma";
 import { getCurrentUser } from "@/lib/auth";
-import { isBeforeDeadline, todayJST } from "@/lib/date";
+import { isBeforeDeadline } from "@/lib/date";
 import { approveQuestInstance } from "@/lib/approve";
 import { resolveTargetChild } from "@/lib/parentChildView";
 import { triggerTaskProgressLog } from "@/lib/bulletinLog";
 import { routeLogger } from "@/lib/logger";
 import { computeCompletedCount, computeSkippedCount } from "@/lib/questProgress";
 import { generateProxyTreasure } from "@/lib/treasureService";
+import { resolveTreasureDate } from "@/lib/treasureDate";
 
 export async function POST(
   request: Request,
@@ -72,11 +73,14 @@ export async function POST(
   });
 
   // 既に書き込み済みの値を反映した quest オブジェクトを approveQuestInstance に渡す
+  // reportedAt も実際に DB へ書き込んだ値（既存値優先、なければ now）と揃える。
+  // approveQuestInstance 内の resolveTreasureDate が quest.reportedAt を基準にするため。
   const updatedQuest = {
     ...quest,
     deadlineBonusEarned:
       deadlineBonusEarned !== undefined ? deadlineBonusEarned : quest.deadlineBonusEarned,
     photoUrl: photoUrl ?? quest.photoUrl,
+    reportedAt: quest.reportedAt ?? now,
   };
 
   // approveQuestInstance が status=APPROVED への更新・XP付与・進化・バッジ・掲示板ログ（EVOLVED/BADGE）を一気に処理する
@@ -87,10 +91,8 @@ export async function POST(
   // carryOver 過去日付は子セルフ report/skip と同じく集計を今日基準に切り替える
   // (quest.date=昨日 のまま集計すると今日のタスクが載らず ALL_COMPLETE 判定が壊れる)
   const minTasks = (child as unknown as { minTasksForStreak?: number }).minTasksForStreak ?? 1;
-  const today = todayJST();
-  const isCarryOverPast =
-    !!quest.template?.carryOver && quest.date.getTime() < today.getTime();
-  const aggregationDate = isCarryOverPast ? today : quest.date;
+  const aggregationDate = resolveTreasureDate(quest.date, !!quest.template?.carryOver, now);
+  const isCarryOverPast = aggregationDate.getTime() !== quest.date.getTime();
   const sameDateQuests = await prisma.questInstance.findMany({
     where: {
       childId: child.id,

--- a/src/app/api/parent/child-view/quests/[id]/skip-approve/route.ts
+++ b/src/app/api/parent/child-view/quests/[id]/skip-approve/route.ts
@@ -1,13 +1,13 @@
 import { NextResponse, after } from "next/server";
 import { prisma } from "@/lib/prisma";
 import { getCurrentUser } from "@/lib/auth";
-import { todayJST } from "@/lib/date";
 import { approveSkipQuestInstance } from "@/lib/approve";
 import { resolveTargetChild } from "@/lib/parentChildView";
 import { triggerTaskProgressLog } from "@/lib/bulletinLog";
 import { routeLogger } from "@/lib/logger";
 import { computeCompletedCount, computeSkippedCount } from "@/lib/questProgress";
 import { generateProxyTreasure } from "@/lib/treasureService";
+import { resolveTreasureDate } from "@/lib/treasureDate";
 
 export async function POST(
   request: Request,
@@ -49,31 +49,35 @@ export async function POST(
     return NextResponse.json({ error: "このクエストはスキップできません" }, { status: 400 });
   }
 
+  const now = new Date();
+  // reportedAt: SKIP_REPORTED から来た場合は既存値を保つ。PENDING からの即時スキップは now。
+  const reportedAt = quest.reportedAt ?? now;
+
   // 報告フィールドを書き込む。子供本人のスキップ申請と同じく comment（理由）と reportedAt を埋める。
-  // SKIP_REPORTED から来た場合は reportedAt 既存値を保つ。
   await prisma.questInstance.update({
     where: { id },
     data: {
       comment: commentText,
-      reportedAt: quest.reportedAt ?? new Date(),
+      reportedAt,
     },
   });
 
   // 親代理「即 SKIPPED」: SKIP_REPORTED を経由せず一気に SKIPPED まで確定（report-approve と同じ思想）
+  // reportedAt も実際に DB へ書き込んだ値と揃える（approveSkipQuestInstance 内の
+  // resolveTreasureDate が quest.reportedAt を基準にするため）。
   await approveSkipQuestInstance({
     id: quest.id,
     childId: child.id,
     date: quest.date,
+    reportedAt,
     template: { carryOver: !!quest.template?.carryOver },
   });
 
   // PROXY / ALL_COMPLETE 宝箱: minTasks 到達 or 全完了で即 UNLOCKED 生成（report-approve と同規約）
   // carryOver 過去日付は集計を今日基準に切り替える（子セルフ skip 経路と同じ扱い）
   const minTasks = (child as unknown as { minTasksForStreak?: number }).minTasksForStreak ?? 1;
-  const today = todayJST();
-  const isCarryOverPast =
-    !!quest.template?.carryOver && quest.date.getTime() < today.getTime();
-  const aggregationDate = isCarryOverPast ? today : quest.date;
+  const aggregationDate = resolveTreasureDate(quest.date, !!quest.template?.carryOver, now);
+  const isCarryOverPast = aggregationDate.getTime() !== quest.date.getTime();
   const sameDateQuests = await prisma.questInstance.findMany({
     where: {
       childId: child.id,

--- a/src/app/api/quests/[id]/report/route.ts
+++ b/src/app/api/quests/[id]/report/route.ts
@@ -1,12 +1,13 @@
 import { NextResponse, after } from "next/server";
 import { prisma } from "@/lib/prisma";
 import { getCurrentUser } from "@/lib/auth";
-import { isBeforeDeadline, todayJST } from "@/lib/date";
+import { isBeforeDeadline } from "@/lib/date";
 import { sendPushToParent } from "@/lib/push";
 import { routeLogger } from "@/lib/logger";
 import { triggerTaskProgressLog } from "@/lib/bulletinLog";
 import { computeCompletedCount, computeSkippedCount } from "@/lib/questProgress";
 import { generateTreasuresOnReport } from "@/lib/treasureService";
+import { resolveTreasureDate } from "@/lib/treasureDate";
 
 export async function POST(
   request: Request,
@@ -86,10 +87,10 @@ export async function POST(
   // ALL_COMPLETE が古日付で生成される」というバグになる。古日付 carryOver 報告は今日の
   // 行動として扱い、宝箱の date と集計も今日基準に切替える。carryOver 自身は別日付に
   // 紐づくため findMany には含まれず、別途 1件として加算する。
-  const today = todayJST();
-  const isCarryOverPastReport =
-    !!quest.template?.carryOver && quest.date.getTime() < today.getTime();
-  const aggregationDate = isCarryOverPastReport ? today : quest.date;
+  // 単一の now から基準日を導出する（JST 深夜0時をまたぐ理論上のズレを防ぐため、
+  // 別途 todayJST() を呼び直さない。承認時 (approve.ts) と同じ resolveTreasureDate を使う）。
+  const aggregationDate = resolveTreasureDate(quest.date, !!quest.template?.carryOver, now);
+  const isCarryOverPastReport = aggregationDate.getTime() !== quest.date.getTime();
   // template.isActive / pausedAt でフィルタして「子供画面 (/api/quests/today) に映る
   // タスク集合」と揃える。親がテンプレを pause / 無効化した後もインスタンスは残るため、
   // フィルタしないと「見えない幽霊タスク」で totalCount が水増しされ ALL_COMPLETE が

--- a/src/app/api/quests/[id]/skip/route.ts
+++ b/src/app/api/quests/[id]/skip/route.ts
@@ -1,12 +1,12 @@
 import { NextResponse, after } from "next/server";
 import { prisma } from "@/lib/prisma";
 import { getCurrentUser } from "@/lib/auth";
-import { todayJST } from "@/lib/date";
 import { sendPushToParent } from "@/lib/push";
 import { routeLogger } from "@/lib/logger";
 import { triggerTaskProgressLog } from "@/lib/bulletinLog";
 import { computeCompletedCount, computeSkippedCount } from "@/lib/questProgress";
 import { generateTreasuresOnReport } from "@/lib/treasureService";
+import { resolveTreasureDate } from "@/lib/treasureDate";
 
 export async function POST(
   request: Request,
@@ -42,12 +42,14 @@ export async function POST(
     return NextResponse.json({ error: "PENDINGまたはREJECTEDのクエストのみスキップできます" }, { status: 400 });
   }
 
+  const now = new Date();
+
   await prisma.questInstance.update({
     where: { id },
     data: {
       status: "SKIP_REPORTED",
       comment: commentText,
-      reportedAt: new Date(),
+      reportedAt: now,
       rejectionReason: null,
     },
   });
@@ -70,10 +72,8 @@ export async function POST(
 
   // 宝箱生成: スキップ申請も SKIP_REPORTED として完了扱いに含まれる。
   // carryOver の古日付スキップは今日基準に切替（report と同じ理由。詳細は report ルート参照）。
-  const today = todayJST();
-  const isCarryOverPastSkip =
-    !!quest.template?.carryOver && quest.date.getTime() < today.getTime();
-  const aggregationDate = isCarryOverPastSkip ? today : quest.date;
+  const aggregationDate = resolveTreasureDate(quest.date, !!quest.template?.carryOver, now);
+  const isCarryOverPastSkip = aggregationDate.getTime() !== quest.date.getTime();
   // template.isActive / pausedAt でフィルタして子供画面のタスク集合と揃える
   // (詳細は report ルートのコメント参照)
   const sameDateQuests = await prisma.questInstance.findMany({

--- a/src/lib/approve.ts
+++ b/src/lib/approve.ts
@@ -12,6 +12,7 @@ import { triggerMonsterEvolvedLog, triggerBadgeLog } from "@/lib/bulletinLog";
 import { DECLARATION_BONUS_XP } from "@/lib/declaration";
 import { todayJST, jstDateOf } from "@/lib/date";
 import { unlockTreasuresOnApprove } from "@/lib/treasureService";
+import { resolveTreasureDate } from "@/lib/treasureDate";
 
 export type QuestWithRelations = {
   id: string;
@@ -194,8 +195,12 @@ export async function approveQuestInstance(quest: QuestWithRelations, stamp?: st
   }
 
   // 同日の LOCKED 宝箱を UNLOCKED に。0個でも安全 (updateMany)
-  // carryOver 過去日付は生成側 (2026-06-19) に合わせて今日基準で検索する。
-  await unlockTreasuresOnApprove(quest.childId, effectiveTreasureDate(quest.date, quest.template.carryOver));
+  // carryOver 過去日付は生成側 (report/skip) が使った基準日 (reportedAt) と揃える。
+  // reportedAt が無い場合（親代理の即承認など）は承認時刻にフォールバックする。
+  await unlockTreasuresOnApprove(
+    quest.childId,
+    resolveTreasureDate(quest.date, quest.template.carryOver, quest.reportedAt ?? new Date()),
+  );
 
   // バッジ解除チェック + 掲示板ログ — レスポンス送信後に after() で実行
   after(() =>
@@ -210,7 +215,7 @@ export async function approveQuestInstance(quest: QuestWithRelations, stamp?: st
 }
 
 export async function approveSkipQuestInstance(
-  quest: Pick<QuestWithRelations, "id" | "childId" | "date"> & {
+  quest: Pick<QuestWithRelations, "id" | "childId" | "date" | "reportedAt"> & {
     template: Pick<QuestWithRelations["template"], "carryOver">;
   },
 ): Promise<void> {
@@ -221,17 +226,6 @@ export async function approveSkipQuestInstance(
   await recordDailyAchievement(quest.childId, quest.date);
   await unlockTreasuresOnApprove(
     quest.childId,
-    effectiveTreasureDate(quest.date, quest.template.carryOver),
+    resolveTreasureDate(quest.date, quest.template.carryOver, quest.reportedAt ?? new Date()),
   );
-}
-
-/**
- * 承認時の宝箱 unlock 対象日付を返す。
- * carryOver=true かつ quest.date が今日より過去なら「今日」を返す
- * (生成側 2026-06-19 の集計切替と揃える)。それ以外は quest.date そのまま。
- */
-function effectiveTreasureDate(questDate: Date, carryOver: boolean): Date {
-  const today = todayJST();
-  if (carryOver && questDate.getTime() < today.getTime()) return today;
-  return questDate;
 }

--- a/src/lib/treasureDate.ts
+++ b/src/lib/treasureDate.ts
@@ -1,0 +1,21 @@
+import { jstDateOf } from "@/lib/date";
+
+/**
+ * 宝箱（TreasureLog）の集計・照合に使う「基準日」を解決する純粋関数。
+ *
+ * Issue #108: 生成時（report/skip）と承認時（approve.ts）でそれぞれ独立に
+ * 「今日」を再計算していたため、carryOver=true のクエストで報告日と承認日が
+ * 別の暦日をまたぐと不一致になり、宝箱が永久に LOCKED のまま残るバグがあった。
+ * 呼び出し側は「基準となる時刻 (at)」を明示的に渡し、生成側・承認側で同じ
+ * 基準日を共有する。
+ *
+ * @param questDate クエストの日付（@db.Date、JST日付をUTC0時として保存）
+ * @param carryOver テンプレートの carryOver フラグ
+ * @param at 基準時刻（report/skip 時は報告時刻、approve 時は reportedAt を渡す）
+ */
+export function resolveTreasureDate(questDate: Date, carryOver: boolean, at: Date): Date {
+  if (carryOver && questDate.getTime() < jstDateOf(at).getTime()) {
+    return jstDateOf(at);
+  }
+  return questDate;
+}


### PR DESCRIPTION
## Summary

「開かずの宝箱」バグ（親がすべて承認しているのに `TreasureLog.status = LOCKED`（子画面で「承認待ち」）のまま永久に残る不具合）の恒久修正。

### 根本原因
宝箱の日付が **生成時**（報告/スキップ時: `src/app/api/quests/[id]/report/route.ts` / `skip/route.ts`）と **承認時**（`src/lib/approve.ts` の旧 `effectiveTreasureDate`）で、それぞれ独立に `todayJST()` を呼んで再計算されていた。`carryOver=true` のクエストで報告日と承認日が別の暦日をまたぐと基準日がズレ、`unlockTreasuresOnApprove` が `childId`+`date` の完全一致で対象を検索するため 0 件更新（`updateMany` はエラーにならずサイレントに失敗）となり、宝箱が永久に LOCKED のまま残っていた。

発生条件（`carryOver=true` かつ承認日(JST) > 報告日(JST)）:

| # | quest.date | 報告日 | 承認日 | 生成date | unlock検索date | 結果 |
|---|---|---|---|---|---|---|
| 1 | 8/20 | 8/20 | 8/21 | 8/20 | 8/21 | NG 開かずの宝箱 |
| 2 | 8/19 | 8/20 | 8/21 | 8/20 | 8/21 | NG 開かずの宝箱 |
| 3 | 8/19 | 8/20 | 8/20 | 8/20 | 8/20 | OK |
| 4 | 8/20 | 8/20 | 8/20 | 8/20 | 8/20 | OK |

さらに `vercel.json` の auto-approve cron が JST 00:00 に「前日報告・未承認の carryOver クエスト」を一括承認するため、上記ケース1/2に該当する頻度を実質的に押し上げていた。

### 変更点
- 新規純粋関数 `resolveTreasureDate(questDate, carryOver, at)`（`src/lib/treasureDate.ts`）に日付解決ロジックを一本化。生成時・承認時・差し戻し時すべてがこの関数を経由し、`reportedAt` から生成時の日付を復元して使う（再計算しない）
- `src/lib/approve.ts` の旧 `effectiveTreasureDate`（バグの原因だった二重計算の private 関数）を完全に削除。`approveQuestInstance` / `approveSkipQuestInstance` は `at` に `quest.reportedAt ?? new Date()` を渡す
- `approveSkipQuestInstance` の引数型に `reportedAt` を追加。呼び出し元（`/api/approve/[id]`、`/api/parent/child-view/quests/[id]/skip-approve`）を追随修正
- 差し戻し経路（`/api/approve/[id]` の reject）の日付ズレも同時に修正（`cancelTreasuresOnReject` の対象日付を統一）
- `/api/quests/[id]/report`・`/api/quests/[id]/skip` で `now` と `todayJST()` を別々に取得していた箇所を単一の `now` から導出するよう統一（JST深夜0時をまたぐ理論上の穴を解消）
- `docs/decisions.md` に 2026-06-19 決定の追補として決定理由を追記

### スコープ外（別Issue）
- 既に発生している本番データの孤児 LOCKED の一括修復は #109 で対応予定（本番データ直接書き換えを伴うため本PRのスコープ外）
- スキーマ変更・マイグレーションなし

## Test plan
- [x] `npm test` パス（203 files / 2808 tests、全通過、既存テスト回帰なし）
- [x] 純粋関数 `resolveTreasureDate` の境界値テスト（等号・未来日クエスト・JST日付切り替わり前後）
- [x] 本バグの再現→修正確認テスト（`carryOver=true` かつ報告日と承認日が別暦日をまたぐケースで unlock が報告日基準になることを確認）
- [x] `approveSkipQuestInstance`（スキップ承認経路）でも同じ日付解決になることを確認
- [x] 差し戻し（reject）経路の carryOver 過去日付テスト
- [x] auto-approve cron 経由（モックなし）のリグレッションテスト

## Related decision
- `docs/decisions.md#2026-08-22-開かずの宝箱バグの恒久修正--宝箱日付解決を-resolvetreasuredate-に一本化`

Closes #108

🤖 Generated with [Claude Code](https://claude.com/claude-code)
