### PR TITLE
feat(treasure): 孤児LOCKED宝箱を救済するワンショット復旧スクリプトを追加

### DIFF
--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -123,6 +123,7 @@
 - [2026-08-21: quests画面1枚に限定してストリークを1行ピルとして条件付き再導入する（2026-06-29決定の部分上書き、Issue #106）](#2026-08-21-quests画面1枚に限定してストリークを1行ピルとして条件付き再導入する2026-06-29決定の部分上書きissue-106)
 - [2026-08-21: モンスターテーマ所持記録を子供単位（`ChildMonsterTheme`）から家族単位（`FamilyMonsterTheme`）へ移行する（2026-08-18決定の補足、Issue #111）](#2026-08-21-モンスターテーマ所持記録を子供単位childmonsterthemeから家族単位familymonsterthemeへ移行する2026-08-18決定の補足issue-111)
 - [2026-08-22: 「開かずの宝箱」バグの恒久修正 — 宝箱日付解決を resolveTreasureDate に一本化](#2026-08-22-開かずの宝箱バグの恒久修正--宝箱日付解決を-resolvetreasuredate-に一本化)
+- [2026-08-22: 既存の孤児LOCKED宝箱を救済するワンショット復旧スクリプトを追加（Issue #109）](#2026-08-22-既存の孤児locked宝箱を救済するワンショット復旧スクリプトを追加issue-109)
 
 <!-- TOC:END -->
 
@@ -2852,4 +2853,30 @@
 - `src/__tests__/lib/approve.test.ts` — `carryOver 過去日付タスクの承認 (resolveTreasureDate 経由)` セクション
 - `src/__tests__/api/approve/approve-id.test.ts` — 差し戻し経路の carryOver 過去日付テスト
 - `src/__tests__/api/cron/auto-approve-treasure-date.test.ts` — 新規。cron 経由で実装（モックなし）を通したリグレッションテスト
+
+## 2026-08-22: 既存の孤児LOCKED宝箱を救済するワンショット復旧スクリプトを追加（Issue #109）
+
+### 決定内容
+- Issue #108（`resolveTreasureDate` への一本化）はバグの**恒久修正**であり新規発生を防ぐが、修正前に既にLOCKEDのまま取り残された既存本番データは救済されない。これを検出・救済するワンショット復旧スクリプト `scripts/rescue-orphan-treasures.ts` を追加した
+- 判定ロジックは `src/lib/orphanTreasure.ts` の純粋関数 `classifyOrphanTreasure()` に分離した。対象日 D を実際に「支配」しているクエストを `resolveTreasureDate`（#108）で再計算して特定し、その支配クエストの現在の状態から `UNLOCK` / `CANCEL` / `SKIP` を判定する（REPORTED/SKIP_REPORTED残存や支配クエスト0件など判断がつかないケースは全て `SKIP` にして人間の確認に委ねる）
+- DB操作は `src/lib/orphanTreasureRescue.ts` の `rescueOrphanTreasures()` に分離した。`dryRun` オプションで実際の書き込みを制御し、書き込み時は `UNLOCK`/`CANCEL` それぞれ別の `updateMany` を `where: { status: "LOCKED" }` ガード付きで実行する（TOCTOU対策）
+- `date < today` だけを条件にした単純な一括救済（`treasureLog.updateMany({ where: { status: "LOCKED", date: { lt: today } }, data: { status: "UNLOCKED" } })` のような実装）は不採用とした。理由は後述
+
+### 理由
+- 日次cronの自動承認は `PENDING` を対象にしないため、LOCKEDのまま残る宝箱の中には「支配クエストがREJECTEDで差し戻し確定」「支配クエストが依然REPORTEDで承認待ち」など、単純に開放してよいとは限らないケースが混在する
+- 宝箱の `date` とそれを支配するクエストの実際の日付は、`carryOver` の写像により一致しないことがある（#108のバグの根本原因と同じ構造）。そのため「宝箱のdateが過去だから開放してよい」という短絡判断はできず、必ず `resolveTreasureDate` で支配クエストを特定した上でその状態を確認する必要がある
+- 上記の理由から、判定を伴わない一括UPDATEクエリでは不十分と判断し、既存の判定ロジックを再利用する形にした
+
+### やってはいけないこと
+- `resolveTreasureDate` を再実装せず、必ず `src/lib/treasureDate.ts` からimportして使う
+- 判定ロジックを `scripts/rescue-orphan-treasures.ts` 側に書く（`vitest.config.ts` の `include` が `src/**/*.test.ts` 限定のため `scripts/` 配下はテスト対象外になる。ロジックは必ず `src/lib/` 側に置く）
+- 更新を `status: "LOCKED"` ガード無しの `updateMany` で行う（他プロセスとの競合で二重更新が起きうる）
+- 本番DBに対する `--apply` 実行を自動化する（cron等に組み込む）。本スクリプトは意図的に手動実行専用とし、実行前に出力される対象件数・内訳・監査用JSONを人間が確認するフローを必須とする
+
+### 該当箇所
+- `src/lib/orphanTreasure.ts` — 新規。純粋関数 `classifyOrphanTreasure()`
+- `src/lib/orphanTreasureRescue.ts` — 新規。DB操作 `rescueOrphanTreasures()`
+- `scripts/rescue-orphan-treasures.ts` — 新規。CLIエントリポイント（判定ロジックは持たず呼び出すだけ）
+- `package.json` — `tsx` を devDependency に追加、`npm run rescue:treasures` スクリプトを追加
+- `src/__tests__/lib/orphanTreasure.test.ts` / `src/__tests__/lib/orphanTreasureRescue.test.ts` — 新規。境界値（当日/未来日/冪等性/carryOver写像/JST日付境界）を含む単体テスト
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -41,6 +41,7 @@
         "husky": "^9.1.7",
         "jsdom": "^29.0.2",
         "tailwindcss": "^4",
+        "tsx": "^4.23.12",
         "typescript": "5.9.3",
         "vitest-mock-extended": "^5.1.1"
       }
@@ -9141,6 +9142,483 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "license": "0BSD"
+    },
+    "node_modules/tsx": {
+      "version": "4.23.12",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.23.12.tgz",
+      "integrity": "sha512-FDf4L4sYzKtzWYhU/Xm0AQFdTjdIxNo9ElTf2mxXM6k8YMHXzYUe4yODVaXP4V9uMFbVg8c0qyBccK2OOxb45Q==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.28.0"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.2.tgz",
+      "integrity": "sha512-XExcO+dvLKvVtNTibSTBej1NCAbaGhWn9Ww1ZPx80qsahhPFe/8jgWP0IchNe0F3HwkU7n8ejhH8bjonqht8mQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/android-arm": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.2.tgz",
+      "integrity": "sha512-kXXoiPVVGQcnIYGOeaovwOURpniDBpSq4A03qkQ+BMQqtGG6HYap3xne9C1O1yo4TR3qxlCX5IqqmX6fFo2Lqg==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/android-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.2.tgz",
+      "integrity": "sha512-5YfKeeI8qWfBZIX+u2xZC3Zlb3Os/gLS2sbEKM+I4ZOcsWmHS2WLysCcQZDAFRslDUU5Oiq44gf6PYN1vGwG5A==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/android-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.2.tgz",
+      "integrity": "sha512-O387ite7SzUyCcy3JQX4P4bLtEA7bLLkx+esve5JHnyYfNTxcVpXZo9jhdB0lTKN44gztELTdU7nS8Nr16Fs1Q==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.2.tgz",
+      "integrity": "sha512-n4KqkOQrraxHJcgjM1RvwbigfQKIKJVpM7xp+KsxiyUSrRdIXnt73VhrPAx0fV44hgfmIVKjxMN9J1t5jySVkw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.2.tgz",
+      "integrity": "sha512-uq6suIWYP37qzGddBKPw5QEQPi6HiLGsO7UmkpfyaYNQ3D+rN6w6WfwH+nuqcGXWvawGwxOEroO4YGnFh95azw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.2.tgz",
+      "integrity": "sha512-n+I0BTSRIoy+d6RPKnEVwql5UwBJolytvY4mAOIEJorKlqgPII8ix6slVVrfZ5Tnj7glIZvloylbB/EJPMWEXw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.2.tgz",
+      "integrity": "sha512-78XJTJkvPs0kz2w61301PJjXl4g7q3JqiYMZ/M/yVI73EHBrCRTgkhu9oqG7vPqq+a/yadEW8aD+agKlk5xrmg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-arm": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.2.tgz",
+      "integrity": "sha512-XlDnu2q5yoqems+xay6wSAcg9DDD7K9RLKZEBOMZm3ckNpJBvOX20tSfby8KfrrhINDyv9V2YVZKY/SpoGJI8w==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.2.tgz",
+      "integrity": "sha512-pW4AC0P3it8c7do9MVM4p51FzHzdM/TZrerurgRcHJ2WTa1VQ1CIq18xncfpBJw4ojkiZZrKW2yIBWBP92j6Ug==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.2.tgz",
+      "integrity": "sha512-CYbnj78HsIeA+DhgUKgFCfvNsTHFhMMrinUrMZpDXJXKN8T3XViTZ/+wtHeVxEWY8ewSzTFN+nRmSwO2tZaLUQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.2.tgz",
+      "integrity": "sha512-buwkd8nsph4R+ajRvw0qM5Hja/TXQow3ptzWO2EbG/cqcIkHloRrdlBtQlshyYGTNFvfkfJ5tpPLVkY4DtsPfQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.2.tgz",
+      "integrity": "sha512-ZVykbDyk7519VwiNb9Lcj9m8XM6v5V9uKPvrEMkkEedVewf+0itkhahp4HDpgERXhwLRpWFypsGbG/J8s0QjJA==",
+      "cpu": [
+        "mips64el"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.2.tgz",
+      "integrity": "sha512-CAXl+Dtd9UUuJd8pKKdwh6MLm3MUMiqMPmhZ3tTSXPqfyQ3vDl6R5hZdZ/kYojK4ofXtdfSv1tFq8XzWx3heNQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.2.tgz",
+      "integrity": "sha512-GeXCej4IQtU1B+QlDV8W/RRvbzI3O/Stss+/bCXv4lZls5WGRtu2a+3JkA3i4qIUlMXpcHebWpF8AkJhATowuA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.2.tgz",
+      "integrity": "sha512-3H1weTYZPxt/WOhByszQZybS9w5lKzUn1FDMsgEChbHWQwHYQQRfBxgCcZvPhjHfKyJjIievvMmEUawJrdY9Dg==",
+      "cpu": [
+        "s390x"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.2.tgz",
+      "integrity": "sha512-4xTZr1FUmSoQW4XIWmit3tzQrUTZM+N3P0XV8xROKYF50XfI7xeO90+1bZvNwxIufQ9hDQVRJH5YhgPVF8A/HQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.2.tgz",
+      "integrity": "sha512-sSATRjPeDBg3pdgHoQfoYBob11Kk1FGa9lui5RIHZCoCkJa9QKlvl3/vKz2usCmYYjs7ymJR/2Nnsqe+Hjt5nw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.2.tgz",
+      "integrity": "sha512-lqnzCV+mM0gIADaKihiCg6ifgfU2L3h5E33rNQBN1Y4MaVGnzryzmvvf7UHxprpQdE8hpqLolJ9Rl+SkIRDpyw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.2.tgz",
+      "integrity": "sha512-AL2qJILH7lNjrDmCQDvdxMfAUIv8KMNZOvrwAQ8i8//ntL9FflhOyMJ8OZSMBb8/AWXe3/5v5S20y3zCoZWKoQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.2.tgz",
+      "integrity": "sha512-QtiuPytchRyC4rwUKhexJdQKvDuZ6hWloi3igqPQNUJCS1/v9EiO3UTOXR6A3FoMo4fnAKbWJdqaIwhOzh8qEw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.2.tgz",
+      "integrity": "sha512-WkhYDmpTjLvGlScA1rwjRUmhl4k8oXR3cIbtqWmELgU/dFeHHlEllxDvdWcNJV9rbzCexB5vz8gtNewWLgCT7Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.2.tgz",
+      "integrity": "sha512-GPMSkTOtMnv2U2F8gxe4Io6qmVs+YKyp832Etqqxr0hFngmXQ3rzwytelm3GIn7T4VviRUlf3sOgBOiTdvaf7g==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.2.tgz",
+      "integrity": "sha512-PIhhEkE9uPBleRBrQEJpUn7MBnibZzbGzYWPmY3x+YoVg/95zbjB4CxPPOQ8l5tYYM4mMaCthF8/1DIfBQQyWQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.2.tgz",
+      "integrity": "sha512-YmJbfTlvU7Sdn9BB+4PRES4oB6pxgS37MAONj+hBr/cpXS1aBPKXxNnDbu+QCWPj0o9dgyxeq79g6c5P8KeuYA==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/win32-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.2.tgz",
+      "integrity": "sha512-5ebpxr3nWMzrL/rnUI755Jkuee0bHL/Gq0WTF9lvcpv73wAp5eu8MfBUgWK9bhWvZjj7yX8etf/8tI8Ney695g==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/esbuild": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.2.tgz",
+      "integrity": "sha512-HKVLS8dvII+xoKW9kmqxbRKrnWEXfJJr/FZhhJmiqIB0e053QNYFqOBouTMO/k5sID4MvCiUCvv8b9M4h32wIA==",
+      "devOptional": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.28.2",
+        "@esbuild/android-arm": "0.28.2",
+        "@esbuild/android-arm64": "0.28.2",
+        "@esbuild/android-x64": "0.28.2",
+        "@esbuild/darwin-arm64": "0.28.2",
+        "@esbuild/darwin-x64": "0.28.2",
+        "@esbuild/freebsd-arm64": "0.28.2",
+        "@esbuild/freebsd-x64": "0.28.2",
+        "@esbuild/linux-arm": "0.28.2",
+        "@esbuild/linux-arm64": "0.28.2",
+        "@esbuild/linux-ia32": "0.28.2",
+        "@esbuild/linux-loong64": "0.28.2",
+        "@esbuild/linux-mips64el": "0.28.2",
+        "@esbuild/linux-ppc64": "0.28.2",
+        "@esbuild/linux-riscv64": "0.28.2",
+        "@esbuild/linux-s390x": "0.28.2",
+        "@esbuild/linux-x64": "0.28.2",
+        "@esbuild/netbsd-arm64": "0.28.2",
+        "@esbuild/netbsd-x64": "0.28.2",
+        "@esbuild/openbsd-arm64": "0.28.2",
+        "@esbuild/openbsd-x64": "0.28.2",
+        "@esbuild/openharmony-arm64": "0.28.2",
+        "@esbuild/sunos-x64": "0.28.2",
+        "@esbuild/win32-arm64": "0.28.2",
+        "@esbuild/win32-ia32": "0.28.2",
+        "@esbuild/win32-x64": "0.28.2"
+      }
     },
     "node_modules/type-check": {
       "version": "0.4.0",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "test:e2e": "playwright test",
     "test:e2e:ui": "playwright test --ui",
     "typecheck": "tsc --noEmit",
-    "prepare": "husky"
+    "prepare": "husky",
+    "rescue:treasures": "tsx scripts/rescue-orphan-treasures.ts"
   },
   "dependencies": {
     "@prisma/adapter-pg": "^7.4.2",
@@ -50,6 +51,7 @@
     "husky": "^9.1.7",
     "jsdom": "^29.0.2",
     "tailwindcss": "^4",
+    "tsx": "^4.23.12",
     "typescript": "5.9.3",
     "vitest-mock-extended": "^5.1.1"
   }

--- a/scripts/rescue-orphan-treasures.ts
+++ b/scripts/rescue-orphan-treasures.ts
@@ -1,0 +1,127 @@
+/**
+ * 「開かずの宝箱」（LOCKEDのまま放置されたTreasureLog）を検出・救済するワンショット復旧CLI（Issue #109）。
+ *
+ * !!! 本番DBに対する実行（--apply）は、必ず出力内容と JSON 監査ログを人間が確認した上で
+ * !!! 手動で行うこと。自動実行（cron等）には組み込まない。
+ *
+ * 判定ロジックは一切持たない。src/lib/orphanTreasure.ts（純粋関数）と
+ * src/lib/orphanTreasureRescue.ts（DB操作）を呼び出すだけの薄いラッパー。
+ *
+ * 使い方:
+ *   npm run rescue:treasures -- [--apply] [--child <childId>] [--before <YYYY-MM-DD>] [--limit <n>]
+ *
+ * オプション:
+ *   --dry-run       実際には書き込まず判定結果のみ表示する（既定動作）
+ *   --apply         実際に DB を更新する（明示指定時のみ）
+ *   --child <id>    対象を特定の childId に絞り込む
+ *   --before <date> この日付未満の date を対象にする（省略時は todayJST()）
+ *   --limit <n>     候補件数の上限
+ */
+
+import { writeFileSync } from "node:fs";
+import { rescueOrphanTreasures } from "@/lib/orphanTreasureRescue";
+
+interface CliOptions {
+  dryRun: boolean;
+  childId?: string;
+  before?: Date;
+  limit?: number;
+}
+
+function parseArgs(argv: string[]): CliOptions {
+  const options: CliOptions = { dryRun: true };
+
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+    switch (arg) {
+      case "--dry-run":
+        options.dryRun = true;
+        break;
+      case "--apply":
+        options.dryRun = false;
+        break;
+      case "--child":
+        options.childId = argv[++i];
+        break;
+      case "--before":
+        options.before = new Date(`${argv[++i]}T00:00:00.000Z`);
+        break;
+      case "--limit":
+        options.limit = Number(argv[++i]);
+        break;
+      default:
+        throw new Error(`unknown argument: ${arg}`);
+    }
+  }
+
+  return options;
+}
+
+async function main() {
+  const options = parseArgs(process.argv.slice(2));
+
+  console.log(
+    `[rescue-orphan-treasures] mode=${options.dryRun ? "DRY-RUN" : "APPLY"} ` +
+      `childId=${options.childId ?? "(all)"} before=${options.before?.toISOString() ?? "(todayJST)"} ` +
+      `limit=${options.limit ?? "(none)"}`,
+  );
+
+  const result = await rescueOrphanTreasures(options);
+
+  const skipReasonCounts = new Map<string, number>();
+  let unresolvedCount = 0;
+  for (const s of result.skipped) {
+    skipReasonCounts.set(s.reason, (skipReasonCounts.get(s.reason) ?? 0) + 1);
+    if (s.reason.includes("UNRESOLVED")) unresolvedCount++;
+  }
+
+  const total = result.unlocked.length + result.cancelled.length + result.skipped.length;
+  console.log(`対象件数: ${total}`);
+  console.log(`  UNLOCK: ${result.unlocked.length}`);
+  console.log(`  CANCEL: ${result.cancelled.length}`);
+  console.log(`  SKIP  : ${result.skipped.length}（うち UNRESOLVED: ${unresolvedCount}）`);
+  for (const [reason, count] of skipReasonCounts) {
+    console.log(`    - ${count}件: ${reason}`);
+  }
+
+  const auditRecords = [
+    ...result.unlocked.map((r) => ({
+      id: r.id,
+      childId: r.childId,
+      date: r.date.toISOString(),
+      from: "LOCKED" as const,
+      to: "UNLOCKED" as const,
+      reason: r.reason,
+    })),
+    ...result.cancelled.map((r) => ({
+      id: r.id,
+      childId: r.childId,
+      date: r.date.toISOString(),
+      from: "LOCKED" as const,
+      to: "CANCELLED" as const,
+      reason: r.reason,
+    })),
+    ...result.skipped.map((r) => ({
+      id: r.id,
+      childId: r.childId,
+      date: r.date.toISOString(),
+      from: "LOCKED" as const,
+      to: "LOCKED" as const,
+      reason: r.reason,
+    })),
+  ];
+
+  const auditPath = `rescue-orphan-treasures-${new Date().toISOString().replace(/[:.]/g, "-")}.json`;
+  writeFileSync(auditPath, JSON.stringify(auditRecords, null, 2), "utf-8");
+  console.log(`監査ログを書き出しました: ${auditPath}`);
+
+  if (options.dryRun) {
+    console.log("DRY-RUN のためDBは更新していません。--apply を付けて再実行すると反映されます。");
+  }
+}
+
+main()
+  .catch((err) => {
+    console.error(err);
+    process.exitCode = 1;
+  });

--- a/src/__tests__/lib/orphanTreasure.test.ts
+++ b/src/__tests__/lib/orphanTreasure.test.ts
@@ -1,0 +1,246 @@
+import { describe, it, expect } from "vitest";
+import { classifyOrphanTreasure } from "@/lib/orphanTreasure";
+
+/**
+ * classifyOrphanTreasure の単体テスト（Issue #109）。
+ *
+ * 「開かずの宝箱」= status:"LOCKED" かつ date < todayJST() のまま放置された TreasureLog。
+ * 同一 childId の QuestInstance 群のうち、resolveTreasureDate(quest.date, carryOver, reportedAt ?? quest.date)
+ * が対象日 D に一致するものを「D を支配するクエスト」として分類する。
+ *
+ * 分類ルールの優先順位:
+ *   1. REPORTED / SKIP_REPORTED が支配クエストに1件でも残る → SKIP
+ *   2. quest.date === D の PENDING が支配クエストに1件でも残る → SKIP（APPROVED併存でもSKIP優先）
+ *   3. APPROVED または SKIPPED が1件以上 → UNLOCK（APPROVED/REJECTED混在時はreasonに明記）
+ *   4. 支配クエストが1件以上あり全て REJECTED → CANCEL
+ *   5. 支配クエストが0件 → SKIP（reasonにUNRESOLVEDを含む）
+ */
+
+/** JST日付のUTC 0時表現（@db.Date と同じ形）を作るヘルパー。month は 1-12 で指定。 */
+function d(year: number, month: number, day: number): Date {
+  return new Date(Date.UTC(year, month - 1, day));
+}
+
+// 「今日」= 2026-08-22 JST。対象宝箱の date は基本的にこれより過去（8/19〜8/21）とする。
+const TODAY = d(2026, 8, 22);
+// 分類対象 TreasureLog の date (D) の既定値。
+const D = d(2026, 8, 20);
+
+interface QuestCandidateInput {
+  date?: Date;
+  status?: "PENDING" | "REPORTED" | "APPROVED" | "REJECTED" | "SKIPPED" | "SKIP_REPORTED";
+  reportedAt?: Date | null;
+  carryOver?: boolean;
+}
+
+/** D (2026-08-20) を支配する QuestInstance 候補の既定値（carryOverなし、当日中に承認）。 */
+function quest(overrides?: QuestCandidateInput) {
+  return {
+    date: D,
+    status: "APPROVED" as const,
+    reportedAt: D,
+    carryOver: false,
+    ...overrides,
+  };
+}
+
+interface ClassifyInput {
+  treasureDate: Date;
+  treasureStatus: "LOCKED" | "UNLOCKED" | "OPENED" | "CANCELLED";
+  today: Date;
+  quests: ReturnType<typeof quest>[];
+}
+
+function classify(overrides: Partial<ClassifyInput> & { quests: ReturnType<typeof quest>[] }) {
+  return classifyOrphanTreasure({
+    treasureDate: D,
+    treasureStatus: "LOCKED",
+    today: TODAY,
+    ...overrides,
+  });
+}
+
+describe("classifyOrphanTreasure", () => {
+  it("LOCKED / date < today / 支配クエストにAPPROVEDが1件 → UNLOCK", () => {
+    const result = classify({ quests: [quest({ status: "APPROVED" })] });
+    expect(result.action).toBe("UNLOCK");
+  });
+
+  it("LOCKED / 支配クエストにSKIPPEDが1件 → UNLOCK", () => {
+    const result = classify({ quests: [quest({ status: "SKIPPED" })] });
+    expect(result.action).toBe("UNLOCK");
+  });
+
+  it("LOCKED / 支配クエストがAPPROVED+REJECTEDの混在 → UNLOCK（reasonに混在である旨を含む）", () => {
+    const result = classify({
+      quests: [quest({ status: "APPROVED" }), quest({ status: "REJECTED" })],
+    });
+    expect(result.action).toBe("UNLOCK");
+    expect(result.reason).toContain("混在");
+  });
+
+  it("LOCKED / 支配クエストが全てREJECTED → CANCEL", () => {
+    const result = classify({
+      quests: [quest({ status: "REJECTED" }), quest({ status: "REJECTED" })],
+    });
+    expect(result.action).toBe("CANCEL");
+  });
+
+  it("LOCKED / 支配クエストにREPORTEDが1件でも残る → SKIP", () => {
+    const result = classify({
+      quests: [quest({ status: "APPROVED" }), quest({ status: "REPORTED" })],
+    });
+    expect(result.action).toBe("SKIP");
+  });
+
+  it("LOCKED / 支配クエストにSKIP_REPORTEDが1件でも残る → SKIP", () => {
+    const result = classify({
+      quests: [quest({ status: "APPROVED" }), quest({ status: "SKIP_REPORTED" })],
+    });
+    expect(result.action).toBe("SKIP");
+  });
+
+  it("LOCKED / quest.date===DのPENDINGが1件でも残る → SKIP（APPROVEDが併存していてもSKIP優先）", () => {
+    const result = classify({
+      quests: [quest({ status: "APPROVED" }), quest({ status: "PENDING", reportedAt: null })],
+    });
+    expect(result.action).toBe("SKIP");
+  });
+
+  it("LOCKED / 支配クエストが0件 → SKIPかつreasonがUNRESOLVED", () => {
+    const result = classify({ quests: [] });
+    expect(result.action).toBe("SKIP");
+    expect(result.reason).toContain("UNRESOLVED");
+  });
+
+  it("境界値: date===todayJST() → SKIP（当日は正常な承認待ち、救済対象外）", () => {
+    const result = classifyOrphanTreasure({
+      treasureDate: TODAY,
+      treasureStatus: "LOCKED",
+      today: TODAY,
+      quests: [quest({ date: TODAY, status: "APPROVED", reportedAt: TODAY })],
+    });
+    expect(result.action).toBe("SKIP");
+  });
+
+  it("境界値: date>todayJST()（未来日）→ SKIP", () => {
+    const future = d(2026, 8, 23);
+    const result = classifyOrphanTreasure({
+      treasureDate: future,
+      treasureStatus: "LOCKED",
+      today: TODAY,
+      quests: [quest({ date: future, status: "APPROVED", reportedAt: future })],
+    });
+    expect(result.action).toBe("SKIP");
+  });
+
+  it.each(["UNLOCKED", "OPENED", "CANCELLED"] as const)(
+    "冪等性: statusが%sならSKIP（actionがUNLOCK/CANCELにならない）",
+    (status) => {
+      const result = classify({
+        treasureStatus: status,
+        quests: [quest({ status: "APPROVED" })],
+      });
+      expect(result.action).toBe("SKIP");
+    },
+  );
+
+  it("carryOver写像: quest.date=8/19 / carryOver=true / reportedAt=8/20 は8/20の宝箱を支配し、8/19の宝箱は支配しない", () => {
+    const carryQuest = quest({
+      date: d(2026, 8, 19),
+      carryOver: true,
+      reportedAt: d(2026, 8, 20),
+      status: "APPROVED",
+    });
+
+    const dominates20 = classifyOrphanTreasure({
+      treasureDate: d(2026, 8, 20),
+      treasureStatus: "LOCKED",
+      today: TODAY,
+      quests: [carryQuest],
+    });
+    expect(dominates20.action).toBe("UNLOCK");
+
+    const notDominates19 = classifyOrphanTreasure({
+      treasureDate: d(2026, 8, 19),
+      treasureStatus: "LOCKED",
+      today: TODAY,
+      quests: [carryQuest],
+    });
+    expect(notDominates19.action).toBe("SKIP");
+    expect(notDominates19.reason).toContain("UNRESOLVED");
+  });
+
+  it("carryOver=falseのquest.date=8/19は常に8/19の宝箱を支配する（reportedAtが何日でも）", () => {
+    const quest19 = quest({
+      date: d(2026, 8, 19),
+      carryOver: false,
+      reportedAt: d(2026, 8, 25), // 差し戻し→再報告等で承認日が大きくずれても写像は変わらない
+      status: "APPROVED",
+    });
+    const result = classifyOrphanTreasure({
+      treasureDate: d(2026, 8, 19),
+      treasureStatus: "LOCKED",
+      today: TODAY,
+      quests: [quest19],
+    });
+    expect(result.action).toBe("UNLOCK");
+  });
+
+  it("JST境界値: reportedAt=2026-08-20T14:59:59.999Z（JST 8/20 23:59）→ 支配日は8/20", () => {
+    const q = quest({
+      date: d(2026, 8, 19),
+      carryOver: true,
+      reportedAt: new Date("2026-08-20T14:59:59.999Z"),
+      status: "APPROVED",
+    });
+    const result = classifyOrphanTreasure({
+      treasureDate: d(2026, 8, 20),
+      treasureStatus: "LOCKED",
+      today: TODAY,
+      quests: [q],
+    });
+    expect(result.action).toBe("UNLOCK");
+  });
+
+  it("JST境界値: reportedAt=2026-08-20T15:00:00.000Z（JST 8/21 00:00）→ 支配日は8/21", () => {
+    const q = quest({
+      date: d(2026, 8, 19),
+      carryOver: true,
+      reportedAt: new Date("2026-08-20T15:00:00.000Z"),
+      status: "APPROVED",
+    });
+    const result = classifyOrphanTreasure({
+      treasureDate: d(2026, 8, 21),
+      treasureStatus: "LOCKED",
+      today: TODAY,
+      quests: [q],
+    });
+    expect(result.action).toBe("UNLOCK");
+  });
+
+  it("reportedAt=nullのクエストはquest.dateで写像される（クラッシュしない）", () => {
+    const q = quest({
+      date: d(2026, 8, 19),
+      carryOver: true,
+      reportedAt: null,
+      status: "APPROVED",
+    });
+    expect(() =>
+      classifyOrphanTreasure({
+        treasureDate: d(2026, 8, 19),
+        treasureStatus: "LOCKED",
+        today: TODAY,
+        quests: [q],
+      }),
+    ).not.toThrow();
+
+    const result = classifyOrphanTreasure({
+      treasureDate: d(2026, 8, 19),
+      treasureStatus: "LOCKED",
+      today: TODAY,
+      quests: [q],
+    });
+    expect(result.action).toBe("UNLOCK");
+  });
+});

--- a/src/__tests__/lib/orphanTreasureRescue.test.ts
+++ b/src/__tests__/lib/orphanTreasureRescue.test.ts
@@ -1,0 +1,209 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { rescueOrphanTreasures } from "@/lib/orphanTreasureRescue";
+import { prismaMock as mockPrisma } from "../helpers/prisma-mock";
+import { treasureLog, questWithTemplate } from "../helpers/fixtures";
+
+/**
+ * rescueOrphanTreasures の単体テスト（Issue #109）。
+ *
+ * classifyOrphanTreasure (src/lib/orphanTreasure.ts) を使って開かずの宝箱候補を分類し、
+ * dryRun=false のときのみ treasureLog.updateMany で実際に書き込む。
+ *
+ * 実際の「今日」に依存させないため、全テストで `before` オプションを明示的に渡す。
+ */
+
+function d(year: number, month: number, day: number): Date {
+  return new Date(Date.UTC(year, month - 1, day));
+}
+
+// 分類対象 TreasureLog.date (D)。before はこれより後の日付を渡し「過去」として扱わせる。
+const D = d(2026, 8, 20);
+const BEFORE = d(2026, 8, 22);
+
+beforeEach(() => {
+  mockPrisma.treasureLog.findMany.mockReset();
+  mockPrisma.questInstance.findMany.mockReset();
+  mockPrisma.treasureLog.updateMany.mockReset();
+});
+
+describe("rescueOrphanTreasures", () => {
+  it("dryRun: true では treasureLog.updateMany が一度も呼ばれない（集計結果だけ返る）", async () => {
+    mockPrisma.treasureLog.findMany.mockResolvedValue([
+      treasureLog({ id: "t1", childId: "child-1", date: D, status: "LOCKED" }),
+    ]);
+    mockPrisma.questInstance.findMany.mockResolvedValue([
+      questWithTemplate(
+        { id: "q1", childId: "child-1", date: D, status: "APPROVED", reportedAt: D },
+        { carryOver: false },
+      ),
+    ]);
+
+    const result = await rescueOrphanTreasures({ dryRun: true, before: BEFORE });
+
+    expect(mockPrisma.treasureLog.updateMany).not.toHaveBeenCalled();
+    expect(result.unlocked.map((u) => u.id)).toEqual(["t1"]);
+    expect(result.cancelled).toEqual([]);
+    expect(result.skipped).toEqual([]);
+  });
+
+  it("dryRun: false で UNLOCK群がstatus:LOCKEDガード付きでupdateManyされる", async () => {
+    mockPrisma.treasureLog.findMany.mockResolvedValue([
+      treasureLog({ id: "t1", childId: "child-1", date: D, status: "LOCKED" }),
+    ]);
+    mockPrisma.questInstance.findMany.mockResolvedValue([
+      questWithTemplate(
+        { id: "q1", childId: "child-1", date: D, status: "APPROVED", reportedAt: D },
+        { carryOver: false },
+      ),
+    ]);
+    mockPrisma.treasureLog.updateMany.mockResolvedValue({ count: 1 });
+
+    const result = await rescueOrphanTreasures({ dryRun: false, before: BEFORE });
+
+    expect(result.unlocked.map((u) => u.id)).toEqual(["t1"]);
+    expect(mockPrisma.treasureLog.updateMany).toHaveBeenCalledWith({
+      where: { id: { in: ["t1"] }, status: "LOCKED" },
+      data: { status: "UNLOCKED" },
+    });
+  });
+
+  it("CANCEL群は別のupdateManyでstatus:CANCELLEDに更新される", async () => {
+    mockPrisma.treasureLog.findMany.mockResolvedValue([
+      treasureLog({ id: "t2", childId: "child-1", date: D, status: "LOCKED" }),
+    ]);
+    mockPrisma.questInstance.findMany.mockResolvedValue([
+      questWithTemplate(
+        { id: "q2", childId: "child-1", date: D, status: "REJECTED", reportedAt: D },
+        { carryOver: false },
+      ),
+    ]);
+    mockPrisma.treasureLog.updateMany.mockResolvedValue({ count: 1 });
+
+    const result = await rescueOrphanTreasures({ dryRun: false, before: BEFORE });
+
+    expect(result.cancelled.map((c) => c.id)).toEqual(["t2"]);
+    expect(mockPrisma.treasureLog.updateMany).toHaveBeenCalledWith({
+      where: { id: { in: ["t2"] }, status: "LOCKED" },
+      data: { status: "CANCELLED" },
+    });
+  });
+
+  it("UNLOCK群とCANCEL群が両方ある場合、別々のupdateMany呼び出しになる", async () => {
+    mockPrisma.treasureLog.findMany.mockResolvedValue([
+      treasureLog({ id: "t-unlock", childId: "child-1", date: D, status: "LOCKED" }),
+      treasureLog({ id: "t-cancel", childId: "child-2", date: D, status: "LOCKED" }),
+    ]);
+    mockPrisma.questInstance.findMany.mockImplementation((args?: unknown) => {
+      const where = (args as { where?: { childId?: string } } | undefined)?.where;
+      if (where?.childId === "child-1") {
+        return Promise.resolve([
+          questWithTemplate(
+            { id: "q-u", childId: "child-1", date: D, status: "APPROVED", reportedAt: D },
+            { carryOver: false },
+          ),
+        ]);
+      }
+      return Promise.resolve([
+        questWithTemplate(
+          { id: "q-c", childId: "child-2", date: D, status: "REJECTED", reportedAt: D },
+          { carryOver: false },
+        ),
+      ]);
+    });
+    mockPrisma.treasureLog.updateMany.mockResolvedValue({ count: 1 });
+
+    const result = await rescueOrphanTreasures({ dryRun: false, before: BEFORE });
+
+    expect(result.unlocked.map((u) => u.id)).toEqual(["t-unlock"]);
+    expect(result.cancelled.map((c) => c.id)).toEqual(["t-cancel"]);
+    expect(mockPrisma.treasureLog.updateMany).toHaveBeenCalledTimes(2);
+    expect(mockPrisma.treasureLog.updateMany).toHaveBeenCalledWith({
+      where: { id: { in: ["t-unlock"] }, status: "LOCKED" },
+      data: { status: "UNLOCKED" },
+    });
+    expect(mockPrisma.treasureLog.updateMany).toHaveBeenCalledWith({
+      where: { id: { in: ["t-cancel"] }, status: "LOCKED" },
+      data: { status: "CANCELLED" },
+    });
+  });
+
+  it("対象が0件のときupdateManyを呼ばない", async () => {
+    mockPrisma.treasureLog.findMany.mockResolvedValue([]);
+
+    const result = await rescueOrphanTreasures({ dryRun: false, before: BEFORE });
+
+    expect(mockPrisma.treasureLog.updateMany).not.toHaveBeenCalled();
+    expect(result.unlocked).toEqual([]);
+    expect(result.cancelled).toEqual([]);
+    expect(result.skipped).toEqual([]);
+  });
+
+  it("戻り値に救済した全idと分類理由が含まれる（監査ログ用）", async () => {
+    mockPrisma.treasureLog.findMany.mockResolvedValue([
+      treasureLog({ id: "t1", childId: "child-1", date: D, status: "LOCKED" }),
+    ]);
+    mockPrisma.questInstance.findMany.mockResolvedValue([
+      questWithTemplate(
+        { id: "q1", childId: "child-1", date: D, status: "APPROVED", reportedAt: D },
+        { carryOver: false },
+      ),
+    ]);
+    mockPrisma.treasureLog.updateMany.mockResolvedValue({ count: 1 });
+
+    const result = await rescueOrphanTreasures({ dryRun: false, before: BEFORE });
+
+    expect(result.unlocked).toHaveLength(1);
+    expect(result.unlocked[0]).toEqual(
+      expect.objectContaining({ id: "t1", childId: "child-1", reason: expect.any(String) }),
+    );
+  });
+
+  it("支配クエストが見つからないものはskippedに分類され、reasonにUNRESOLVEDを含む", async () => {
+    mockPrisma.treasureLog.findMany.mockResolvedValue([
+      treasureLog({ id: "t-orphan", childId: "child-1", date: D, status: "LOCKED" }),
+    ]);
+    mockPrisma.questInstance.findMany.mockResolvedValue([]);
+
+    const result = await rescueOrphanTreasures({ dryRun: false, before: BEFORE });
+
+    expect(result.skipped).toHaveLength(1);
+    expect(result.skipped[0]).toEqual(
+      expect.objectContaining({ id: "t-orphan", reason: expect.stringContaining("UNRESOLVED") }),
+    );
+    expect(mockPrisma.treasureLog.updateMany).not.toHaveBeenCalled();
+  });
+
+  it("childIdオプション指定時、treasureLog.findManyのwhereにchildIdが含まれる", async () => {
+    mockPrisma.treasureLog.findMany.mockResolvedValue([]);
+
+    await rescueOrphanTreasures({ dryRun: true, before: BEFORE, childId: "child-9" });
+
+    expect(mockPrisma.treasureLog.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({ childId: "child-9" }),
+      }),
+    );
+  });
+
+  it("limitオプションが件数を制限する", async () => {
+    mockPrisma.treasureLog.findMany.mockResolvedValue([]);
+
+    await rescueOrphanTreasures({ dryRun: true, before: BEFORE, limit: 50 });
+
+    expect(mockPrisma.treasureLog.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({ take: 50 }),
+    );
+  });
+
+  it("2回目の実行（候補が空で返る状態）で対象0件・updateMany未呼び出し（冪等）", async () => {
+    // 1回目の救済で LOCKED が無くなった後を想定し、2回目は最初から空を返す
+    mockPrisma.treasureLog.findMany.mockResolvedValue([]);
+
+    const result = await rescueOrphanTreasures({ dryRun: false, before: BEFORE });
+
+    expect(result.unlocked).toEqual([]);
+    expect(result.cancelled).toEqual([]);
+    expect(result.skipped).toEqual([]);
+    expect(mockPrisma.treasureLog.updateMany).not.toHaveBeenCalled();
+  });
+});

--- a/src/lib/orphanTreasure.ts
+++ b/src/lib/orphanTreasure.ts
@@ -1,0 +1,117 @@
+// 「開かずの宝箱」（status: "LOCKED" のまま date < todayJST() で放置された TreasureLog）を
+// UNLOCK / CANCEL / SKIP に分類する純粋関数（Prisma 非依存、DB操作は orphanTreasureRescue.ts）。
+//
+// Issue #109: cron の日次処理は「今日」の宝箱しか見ないため、report/approve の実装バグや
+// 手動DB操作等で LOCKED のまま取り残された過去の宝箱は自然には解消されない。
+// 本モジュールは、対象日 D を実際に「支配」しているクエストの現在の状態を
+// resolveTreasureDate（Issue #108, src/lib/treasureDate.ts）で再計算し、
+// 承認済みなら UNLOCK、差し戻し確定なら CANCEL、判断がつかないものは SKIP して
+// 人間の確認に委ねる。
+
+import { resolveTreasureDate } from "@/lib/treasureDate";
+
+export type OrphanTreasureAction = "UNLOCK" | "CANCEL" | "SKIP";
+
+export type OrphanQuestStatus =
+  | "PENDING"
+  | "REPORTED"
+  | "APPROVED"
+  | "REJECTED"
+  | "SKIPPED"
+  | "SKIP_REPORTED";
+
+export type OrphanTreasureStatus = "LOCKED" | "UNLOCKED" | "OPENED" | "CANCELLED";
+
+export interface OrphanTreasureQuestInput {
+  date: Date;
+  status: OrphanQuestStatus;
+  reportedAt: Date | null;
+  carryOver: boolean;
+}
+
+export interface ClassifyOrphanTreasureInput {
+  treasureDate: Date;
+  treasureStatus: OrphanTreasureStatus;
+  today: Date;
+  quests: OrphanTreasureQuestInput[];
+}
+
+export interface OrphanTreasureClassification {
+  action: OrphanTreasureAction;
+  reason: string;
+}
+
+/**
+ * 対象の TreasureLog（treasureDate/treasureStatus）と、同一 childId の QuestInstance 群から
+ * 「開かずの宝箱」の救済アクションを判定する。
+ *
+ * 分類ルールの優先順位:
+ *   0. treasureStatus !== "LOCKED" または treasureDate >= today → 無条件 SKIP（対象外・冪等）
+ *   1. resolveTreasureDate(quest.date, quest.carryOver, quest.reportedAt ?? quest.date) が
+ *      treasureDate に一致するクエストを「支配クエスト」とする
+ *   2. 支配クエストに REPORTED / SKIP_REPORTED が1件でも残る → SKIP
+ *   3. quest.date === treasureDate の PENDING が1件でも残る → SKIP（APPROVED併存でも優先）
+ *   4. 支配クエストに APPROVED または SKIPPED が1件以上 → UNLOCK
+ *      （REJECTED が混在する場合は reason にその旨を明記）
+ *   5. 支配クエストが1件以上あり全て REJECTED → CANCEL
+ *   6. 支配クエストが0件 → SKIP（reason に UNRESOLVED を含む）
+ */
+export function classifyOrphanTreasure(
+  input: ClassifyOrphanTreasureInput,
+): OrphanTreasureClassification {
+  const { treasureDate, treasureStatus, today, quests } = input;
+
+  if (treasureStatus !== "LOCKED" || treasureDate.getTime() >= today.getTime()) {
+    return {
+      action: "SKIP",
+      reason: "対象外（LOCKEDでない、または過去日ではない。冪等スキップ）",
+    };
+  }
+
+  const dominating = quests.filter(
+    (q) =>
+      resolveTreasureDate(q.date, q.carryOver, q.reportedAt ?? q.date).getTime() ===
+      treasureDate.getTime(),
+  );
+
+  if (dominating.some((q) => q.status === "REPORTED" || q.status === "SKIP_REPORTED")) {
+    return {
+      action: "SKIP",
+      reason: "支配クエストに REPORTED / SKIP_REPORTED が残っているため保留",
+    };
+  }
+
+  const hasPendingOnDate = quests.some(
+    (q) => q.date.getTime() === treasureDate.getTime() && q.status === "PENDING",
+  );
+  if (hasPendingOnDate) {
+    return {
+      action: "SKIP",
+      reason: "quest.date一致の PENDING が残っているため保留（APPROVED併存でもSKIP優先）",
+    };
+  }
+
+  const approvedOrSkipped = dominating.filter(
+    (q) => q.status === "APPROVED" || q.status === "SKIPPED",
+  );
+  const rejected = dominating.filter((q) => q.status === "REJECTED");
+
+  if (approvedOrSkipped.length > 0) {
+    if (rejected.length > 0) {
+      return {
+        action: "UNLOCK",
+        reason: "支配クエストに APPROVED/SKIPPED と REJECTED が混在。承認済み分を優先しUNLOCK",
+      };
+    }
+    return { action: "UNLOCK", reason: "支配クエストに APPROVED または SKIPPED があるためUNLOCK" };
+  }
+
+  if (dominating.length > 0 && dominating.every((q) => q.status === "REJECTED")) {
+    return { action: "CANCEL", reason: "支配クエストが全て REJECTED のためCANCEL" };
+  }
+
+  return {
+    action: "SKIP",
+    reason: "支配クエストが見つからない（UNRESOLVED）。人間による確認が必要",
+  };
+}

--- a/src/lib/orphanTreasureRescue.ts
+++ b/src/lib/orphanTreasureRescue.ts
@@ -1,0 +1,115 @@
+// 「開かずの宝箱」救済のDB操作層（Issue #109）。
+// 判定ロジック（純粋関数）は src/lib/orphanTreasure.ts に分離してある。
+//
+// 呼び出し元: scripts/rescue-orphan-treasures.ts（ワンショット復旧CLI）。
+// 本番DBへの適用（dryRun: false）は人間の確認を経て手動実行することを前提とする。
+
+import { prisma } from "@/lib/prisma";
+import { todayJST } from "@/lib/date";
+import { classifyOrphanTreasure } from "@/lib/orphanTreasure";
+
+export interface RescueOrphanTreasuresInput {
+  /** true ならDB更新を行わず分類結果のみ返す */
+  dryRun: boolean;
+  /** 指定時は当該 childId の宝箱のみ対象にする */
+  childId?: string;
+  /** 対象とする date の上限（この日付未満のLOCKEDが対象）。省略時は todayJST() */
+  before?: Date;
+  /** 候補件数の上限 */
+  limit?: number;
+}
+
+export interface RescuedTreasureRecord {
+  id: string;
+  childId: string;
+  date: Date;
+  reason: string;
+}
+
+export interface RescueOrphanTreasuresResult {
+  unlocked: RescuedTreasureRecord[];
+  cancelled: RescuedTreasureRecord[];
+  skipped: RescuedTreasureRecord[];
+}
+
+/**
+ * status: "LOCKED" かつ date < before(既定 todayJST()) の TreasureLog を候補として取得し、
+ * 同一 childId の QuestInstance（template.carryOver 込み）を参照して classifyOrphanTreasure で
+ * UNLOCK / CANCEL / SKIP に分類する。
+ *
+ * dryRun === false のときのみ、UNLOCK群・CANCEL群をそれぞれ別の updateMany で更新する。
+ * 更新は必ず where に status: "LOCKED" を含める（TOCTOU対策。他プロセスが既に処理済みなら
+ * ヒットしないため二重更新を防げる）。
+ */
+export async function rescueOrphanTreasures(
+  input: RescueOrphanTreasuresInput,
+): Promise<RescueOrphanTreasuresResult> {
+  const { dryRun, childId, before, limit } = input;
+  const today = before ?? todayJST();
+
+  const where: { status: "LOCKED"; date: { lt: Date }; childId?: string } = {
+    status: "LOCKED",
+    date: { lt: today },
+  };
+  if (childId) where.childId = childId;
+
+  const findArgs: { where: typeof where; take?: number } = { where };
+  if (limit !== undefined) findArgs.take = limit;
+
+  const candidates = await prisma.treasureLog.findMany(findArgs);
+
+  const unlocked: RescuedTreasureRecord[] = [];
+  const cancelled: RescuedTreasureRecord[] = [];
+  const skipped: RescuedTreasureRecord[] = [];
+
+  if (candidates.length === 0) {
+    return { unlocked, cancelled, skipped };
+  }
+
+  for (const candidate of candidates) {
+    const quests = await prisma.questInstance.findMany({
+      where: { childId: candidate.childId },
+      include: { template: true },
+    });
+
+    const classification = classifyOrphanTreasure({
+      treasureDate: candidate.date,
+      treasureStatus: candidate.status,
+      today,
+      quests: quests.map((q) => ({
+        date: q.date,
+        status: q.status,
+        reportedAt: q.reportedAt,
+        carryOver: q.template.carryOver,
+      })),
+    });
+
+    const record: RescuedTreasureRecord = {
+      id: candidate.id,
+      childId: candidate.childId,
+      date: candidate.date,
+      reason: classification.reason,
+    };
+
+    if (classification.action === "UNLOCK") unlocked.push(record);
+    else if (classification.action === "CANCEL") cancelled.push(record);
+    else skipped.push(record);
+  }
+
+  if (!dryRun) {
+    if (unlocked.length > 0) {
+      await prisma.treasureLog.updateMany({
+        where: { id: { in: unlocked.map((u) => u.id) }, status: "LOCKED" },
+        data: { status: "UNLOCKED" },
+      });
+    }
+    if (cancelled.length > 0) {
+      await prisma.treasureLog.updateMany({
+        where: { id: { in: cancelled.map((c) => c.id) }, status: "LOCKED" },
+        data: { status: "CANCELLED" },
+      });
+    }
+  }
+
+  return { unlocked, cancelled, skipped };
+}


### PR DESCRIPTION
> **本PRは本番DBへのデータ変更を一切含みません。** マイグレーションもAPIの実行パス変更もありません。追加されるのは新規ファイル（孤児判定の純粋関数・DB操作関数・手動実行専用CLIスクリプト）のみです。実際の本番データ救済（`--apply`の実行）はこのPRのマージ後、人間が確認の上で別途手動で行います。

## Summary

- 既にLOCKEDのまま取り残された「開かずの宝箱」（本番データ）を検出・救済するワンショット復旧スクリプトを追加。#108（恒久修正）のスコープ外とされたデータ救済分を切り出したもの
- 孤児判定ロジック `classifyOrphanTreasure`（`src/lib/orphanTreasure.ts`、純粋関数）: `resolveTreasureDate`（#108）で対象日Dを実際に支配しているクエストを再計算し、その支配クエストの現状態からUNLOCK/CANCEL/SKIPを判定する。判断に迷うケース（REPORTED/SKIP_REPORTED残存、支配クエスト0件など）はすべてSKIPにして人間の確認に委ねる
- DB操作 `rescueOrphanTreasures`（`src/lib/orphanTreasureRescue.ts`）: 候補取得→分類→適用。`dry-run`を既定とし、実際の書き込みは`--apply`明示時のみ発生。書き込みは`status: "LOCKED"`ガード付き`updateMany`でTOCTOU対策済み（cronとの同時実行でも安全）
- CLIスクリプト `scripts/rescue-orphan-treasures.ts`（`npm run rescue:treasures`）: `--dry-run`/`--apply`/`--child <id>`/`--before <date>`/`--limit <n>`オプション、監査用JSON出力（誤爆時は該当idをLOCKEDに戻すだけでロールバック可能）
- 「cronが`date < today`を漏れなく処理しているので単純な一括救済ができるのでは」という簡略化案を検証したが不採用と判定（Issue #109本文参照）。理由:
  - cronの自動承認（`/api/cron/auto-approve`）は`REPORTED`/`SKIP_REPORTED`のみを対象とし`PENDING`は対象外（carryOverの仕様上、意図的に決着させない）
  - `TreasureLog.date`と支配クエストの`QuestInstance.date`はcarryOverの写像により一致しないことがある（#108のバグの根本原因と同じ構造）ため、宝箱のdateが過去であることだけでは開放可否を判断できない
  - 一律UNLOCKEDにすると、差し戻し経路の日付ズレで本来CANCELLEDにされるべきだった宝箱まで開放してしまう（over-grant）
- `docs/decisions.md`に決定理由を追記

## Test plan

- [x] `npm test` パス（フルスイート205ファイル/2836テスト全通過、既存テスト回帰なし）
- [ ] `npm run lint` パス
- [ ] （マージ後・別途）人間が `npm run rescue:treasures`（dry-run既定）を本番相当データに対して実行し、対象件数・内訳を確認した上で`--child`指定の段階実行→`--apply`を判断

## Related decision
- `docs/decisions.md#2026-08-22-既存の孤児locked宝箱を救済するワンショット復旧スクリプトを追加issue-109`

Closes #109
Refs #108

🤖 Generated with [Claude Code](https://claude.com/claude-code)
