### PR TITLE
fix(monster-theme): 仏様テーマの転生カテゴリ卵を既定の色卵に戻す

### DIFF
--- a/src/__tests__/components/child-monster-page-theme.test.tsx
+++ b/src/__tests__/components/child-monster-page-theme.test.tsx
@@ -139,9 +139,15 @@ describe("子 育成ページ: モンスターテーマ解決（Issue #100）", 
   });
 });
 
-describe("子 育成ページ: 転生卵ボーナスのテーマ解決（Issue #115）", () => {
+describe("子 育成ページ: 転生卵ボーナスのテーマ解決（Issue #115 → #119で色卵に戻す）", () => {
+  const DEFAULT_EGG_IMAGE: Record<"STUDY" | "STAMINA" | "LIFE", string> = {
+    STUDY: "/monsters/egg-study.webp",
+    STAMINA: "/monsters/egg-stamina.webp",
+    LIFE: "/monsters/egg-life.webp",
+  };
+
   it.each(["STUDY", "STAMINA", "LIFE"] as const)(
-    "rebirthEggBonus=%s かつ monsterSetId が buddha のとき、メインヒーロー画像が buddha のいしのたまごになる",
+    "rebirthEggBonus=%s かつ monsterSetId が buddha のとき、メインヒーロー画像が既定の色卵になる（Issue #119: 視認性改善）",
     async (eggType) => {
       setupHook(
         makeData({
@@ -158,12 +164,12 @@ describe("子 育成ページ: 転生卵ボーナスのテーマ解決（Issue #
 
       await waitFor(() => {
         const img = screen.getByAltText("たまご");
-        expect((img as HTMLImageElement).src).toContain("/monsters/buddha/egg-stone.webp");
+        expect((img as HTMLImageElement).src).toContain(DEFAULT_EGG_IMAGE[eggType]);
       });
     }
   );
 
-  it("rebirthEggBonus=STUDY かつ monsterSetId が buddha のとき、転生カットインの卵画像も buddha のいしのたまごになる", async () => {
+  it("rebirthEggBonus=STUDY かつ monsterSetId が buddha のとき、転生カットインの卵画像も既定の勉強の卵になる（Issue #119: 視認性改善）", async () => {
     setupHook(
       makeData({
         side: "DARK",
@@ -182,7 +188,7 @@ describe("子 育成ページ: 転生卵ボーナスのテーマ解決（Issue #
       const imgs = screen.getAllByAltText("たまご");
       expect(imgs.length).toBeGreaterThan(0);
       for (const img of imgs) {
-        expect((img as HTMLImageElement).src).toContain("/monsters/buddha/egg-stone.webp");
+        expect((img as HTMLImageElement).src).toContain("/monsters/egg-study.webp");
       }
     });
   });

--- a/src/__tests__/components/egg-selection-modal-theme.test.tsx
+++ b/src/__tests__/components/egg-selection-modal-theme.test.tsx
@@ -99,15 +99,18 @@ describe("EggSelectionModal: 現在のテーマの卵画像を表示すること
   });
 });
 
-// Issue #115: 仏様テーマの転生卵を「いしのたまご」にし、STUDY/STAMINA/LIFE の卵画像も
-// monsterSetId に応じて動的に決まるようにする。
+// Issue #115 → #119: 仏様テーマの転生カテゴリ卵(STUDY/STAMINA/LIFE)は「いしのたまご」で
+// 統一する方針だったが、石卵4種が並んで視認性が悪いため方針転換。
+// カテゴリ卵(STUDY/STAMINA/LIFE)だけ dark/light と同じ既定の色卵画像に戻す
+// （通常卵＝NORMAL は引き続きいしのたまごのまま）。
 // 期待するUI契約（implementer 実装時の参照用）:
-//  - 「勉強の卵」「体力の卵」「生活力の卵」の画像も @/lib/monsterThemes/eggs の
-//    getRebirthEggImage(eggType, monsterSetId) から解決する
-//  - buddha テーマでは4つ（NORMAL含む）すべて /monsters/buddha/egg-stone.webp になる
+//  - 「ふつうの卵」(NORMAL) の画像は引き続き buddha ではいしのたまごのまま
+//  - 「勉強の卵」「体力の卵」「生活力の卵」の画像は @/lib/monsterThemes/eggs の
+//    getRebirthEggImage(eggType, monsterSetId) から解決するが、buddha でも
+//    DEFAULT_REBIRTH_EGG_IMAGES（既定の色卵）にフォールバックする（Issue #119）
 //  - dark/light テーマでは従来通りの固定パス（/monsters/egg-study.webp 等）のまま
-describe("EggSelectionModal: STUDY/STAMINA/LIFE 卵画像のテーマ追従（Issue #115）", () => {
-  it("monsterSetId='buddha' の場合、NORMAL/STUDY/STAMINA/LIFE すべての卵画像がいしのたまごであること", () => {
+describe("EggSelectionModal: カテゴリ卵のテーマ追従（Issue #115 → #119で色卵に戻す）", () => {
+  it("monsterSetId='buddha' の場合、ふつうの卵(NORMAL)のみいしのたまごであること", () => {
     render(
       <EggSelectionModal
         monsterSetId="buddha"
@@ -117,11 +120,24 @@ describe("EggSelectionModal: STUDY/STAMINA/LIFE 卵画像のテーマ追従（Is
       />,
     );
 
-    const stoneEgg = "/monsters/buddha/egg-stone.webp";
-    expect((screen.getByAltText("ふつうの卵") as HTMLImageElement).getAttribute("src")).toBe(stoneEgg);
-    expect((screen.getByAltText("勉強の卵") as HTMLImageElement).getAttribute("src")).toBe(stoneEgg);
-    expect((screen.getByAltText("体力の卵") as HTMLImageElement).getAttribute("src")).toBe(stoneEgg);
-    expect((screen.getByAltText("生活力の卵") as HTMLImageElement).getAttribute("src")).toBe(stoneEgg);
+    expect((screen.getByAltText("ふつうの卵") as HTMLImageElement).getAttribute("src")).toBe(
+      "/monsters/buddha/egg-stone.webp"
+    );
+  });
+
+  it("monsterSetId='buddha' の場合、STUDY/STAMINA/LIFE の卵画像は既定の色卵であること（Issue #119: 視認性改善）", () => {
+    render(
+      <EggSelectionModal
+        monsterSetId="buddha"
+        loading={false}
+        onSelect={vi.fn()}
+        onCancel={vi.fn()}
+      />,
+    );
+
+    expect((screen.getByAltText("勉強の卵") as HTMLImageElement).getAttribute("src")).toBe("/monsters/egg-study.webp");
+    expect((screen.getByAltText("体力の卵") as HTMLImageElement).getAttribute("src")).toBe("/monsters/egg-stamina.webp");
+    expect((screen.getByAltText("生活力の卵") as HTMLImageElement).getAttribute("src")).toBe("/monsters/egg-life.webp");
   });
 
   it("回帰確認: monsterSetId='dark' の場合、STUDY/STAMINA/LIFE の卵画像は従来通りの固定パスのままであること", () => {
@@ -137,5 +153,25 @@ describe("EggSelectionModal: STUDY/STAMINA/LIFE 卵画像のテーマ追従（Is
     expect((screen.getByAltText("勉強の卵") as HTMLImageElement).getAttribute("src")).toBe("/monsters/egg-study.webp");
     expect((screen.getByAltText("体力の卵") as HTMLImageElement).getAttribute("src")).toBe("/monsters/egg-stamina.webp");
     expect((screen.getByAltText("生活力の卵") as HTMLImageElement).getAttribute("src")).toBe("/monsters/egg-life.webp");
+  });
+
+  it("視認性確認: monsterSetId='buddha' の場合、NORMAL/STUDY/STAMINA/LIFE の4つの卵画像パスが互いに異なること（Issue #119の目的）", () => {
+    render(
+      <EggSelectionModal
+        monsterSetId="buddha"
+        loading={false}
+        onSelect={vi.fn()}
+        onCancel={vi.fn()}
+      />,
+    );
+
+    const srcs = [
+      (screen.getByAltText("ふつうの卵") as HTMLImageElement).getAttribute("src"),
+      (screen.getByAltText("勉強の卵") as HTMLImageElement).getAttribute("src"),
+      (screen.getByAltText("体力の卵") as HTMLImageElement).getAttribute("src"),
+      (screen.getByAltText("生活力の卵") as HTMLImageElement).getAttribute("src"),
+    ];
+
+    expect(new Set(srcs).size).toBe(srcs.length);
   });
 });

--- a/src/__tests__/components/parent-family-member-icon-theme.test.tsx
+++ b/src/__tests__/components/parent-family-member-icon-theme.test.tsx
@@ -145,9 +145,15 @@ describe("親 ファミリーページ: メンバー一覧のモンスターア�
   });
 });
 
-describe("親 ファミリーページ: メンバー一覧の転生卵ボーナス アイコン テーマ解決（Issue #115）", () => {
+describe("親 ファミリーページ: メンバー一覧の転生卵ボーナス アイコン テーマ解決（Issue #115 → #119で色卵に戻す）", () => {
+  const DEFAULT_EGG_IMAGE: Record<"STUDY" | "STAMINA" | "LIFE", string> = {
+    STUDY: "/monsters/egg-study.webp",
+    STAMINA: "/monsters/egg-stamina.webp",
+    LIFE: "/monsters/egg-life.webp",
+  };
+
   it.each(["STUDY", "STAMINA", "LIFE"] as const)(
-    "rebirthEggBonus=%s かつ monsterSetId が buddha のメンバーは、buddha のいしのたまごアイコンが表示される",
+    "rebirthEggBonus=%s かつ monsterSetId が buddha のメンバーは、既定の色卵アイコンが表示される（Issue #119: 視認性改善）",
     async (eggType) => {
       mockFetchWithMembers([
         makeChild({
@@ -164,7 +170,7 @@ describe("親 ファミリーページ: メンバー一覧の転生卵ボーナ�
 
       await waitFor(() => {
         const img = screen.getByAltText("たまご");
-        expect((img as HTMLImageElement).src).toContain("/monsters/buddha/egg-stone.webp");
+        expect((img as HTMLImageElement).src).toContain(DEFAULT_EGG_IMAGE[eggType]);
       });
     }
   );

--- a/src/__tests__/components/zukan-egg-section.test.tsx
+++ b/src/__tests__/components/zukan-egg-section.test.tsx
@@ -1,19 +1,17 @@
 // @vitest-environment jsdom
 //
-// Issue #115: 仏様テーマの転生卵を「いしのたまご」にし、卵画像をテーマ追従させる。
-// 対象: src/components/child/ZukanEggSection.tsx（未実装。現状は STUDY/STAMINA/LIFE の
-// 卵画像を "/monsters/egg-study.webp" 等の固定パスでハードコードしている）
+// Issue #115 → #119: 仏様テーマの転生カテゴリ卵(STUDY/STAMINA/LIFE)は「いしのたまご」で
+// 統一する方針だったが、石卵4種が並んで視認性が悪いため方針転換。
+// カテゴリ卵(STUDY/STAMINA/LIFE)だけ dark/light と同じ既定の色卵画像に戻す。
+// 対象: src/components/child/ZukanEggSection.tsx
 //
 // 期待するUI契約（implementer 実装時の参照用）:
-//  - 新たに `monsterSetId: string | null` を props として受け取る（省略可、デフォルトは
-//    null 相当のフォールバック動作。既存呼び出し元を壊さないこと）
+//  - `monsterSetId: string | null` を props として受け取る（省略可）
 //  - STUDY/STAMINA/LIFE の卵画像は @/lib/monsterThemes/eggs の
-//    getRebirthEggImage(eggType, monsterSetId) から解決する
-//  - buddha テーマでは3つとも /monsters/buddha/egg-stone.webp になる
+//    getRebirthEggImage(eggType, monsterSetId) から解決するが、buddha でも
+//    DEFAULT_REBIRTH_EGG_IMAGES（既定の色卵）にフォールバックする（Issue #119）
 //  - monsterSetId 未指定・null・未知のIDの場合は従来通りの固定パスのまま
 //    （dark/light 相当のフォールバック、回帰確認）
-//
-// 実装がまだ存在しないため、これらのテストはすべて Red（失敗）になる想定。
 
 import React from "react";
 import { render, screen } from "@testing-library/react";
@@ -29,14 +27,13 @@ import ZukanEggSection from "@/components/child/ZukanEggSection";
 const eggData = { image: "/monsters/dark/egg.webp" };
 const usedEggs = new Set<string>(["STUDY", "STAMINA", "LIFE"]);
 
-describe("ZukanEggSection: 転生卵画像のテーマ追従（Issue #115）", () => {
-  it("monsterSetId='buddha' の場合、収集済みの勉強/体力/生活力の卵画像がすべていしのたまごになること", () => {
+describe("ZukanEggSection: 転生卵画像のテーマ追従（Issue #115 → #119で色卵に戻す）", () => {
+  it("monsterSetId='buddha' の場合、収集済みの勉強/体力/生活力の卵画像は既定の色卵になること（Issue #119: 視認性改善）", () => {
     render(<ZukanEggSection eggData={eggData} usedEggs={usedEggs} monsterSetId="buddha" />);
 
-    const stoneEgg = "/monsters/buddha/egg-stone.webp";
-    expect((screen.getByAltText("📚 勉強の卵") as HTMLImageElement).getAttribute("src")).toBe(stoneEgg);
-    expect((screen.getByAltText("💪 体力の卵") as HTMLImageElement).getAttribute("src")).toBe(stoneEgg);
-    expect((screen.getByAltText("🌿 生活力の卵") as HTMLImageElement).getAttribute("src")).toBe(stoneEgg);
+    expect((screen.getByAltText("📚 勉強の卵") as HTMLImageElement).getAttribute("src")).toBe("/monsters/egg-study.webp");
+    expect((screen.getByAltText("💪 体力の卵") as HTMLImageElement).getAttribute("src")).toBe("/monsters/egg-stamina.webp");
+    expect((screen.getByAltText("🌿 生活力の卵") as HTMLImageElement).getAttribute("src")).toBe("/monsters/egg-life.webp");
   });
 
   it("回帰確認: monsterSetId='dark' の場合、収集済みの卵画像は従来通りの固定パスのままであること", () => {

--- a/src/__tests__/lib/monster-mini.test.ts
+++ b/src/__tests__/lib/monster-mini.test.ts
@@ -152,8 +152,8 @@ describe("getMonsterMiniData", () => {
     expect(result.monsterName).toBe("ルミナ");
   });
 
-  // ─── Issue #115: buddha テーマの転生卵（いしのたまご）画像 ──────────────
-  it("rebirthEggBonus=STAMINA + monsterSetId='buddha' の場合、stage0 でいしのたまご画像を返す", () => {
+  // ─── Issue #115 → #119: buddha テーマの転生卵（カテゴリ卵は色卵に戻す） ──
+  it("rebirthEggBonus=STAMINA + monsterSetId='buddha' の場合、stage0 で既定の体力の卵画像を返す（Issue #119: 色卵に戻す）", () => {
     const result = getMonsterMiniData({
       ...base,
       evolutionStage: 0,
@@ -161,7 +161,7 @@ describe("getMonsterMiniData", () => {
       rebirthEggBonus: "STAMINA",
       monsterSetId: "buddha",
     });
-    expect(result.image).toBe("/monsters/buddha/egg-stone.webp");
+    expect(result.image).toBe("/monsters/egg-stamina.webp");
   });
 
   it("rebirthEggBonus=null + monsterSetId='buddha'（通常卵）の場合も、stage0 でいしのたまご画像を返す", () => {

--- a/src/__tests__/lib/monsterThemes/eggs.test.ts
+++ b/src/__tests__/lib/monsterThemes/eggs.test.ts
@@ -1,9 +1,13 @@
 // Issue #115: 仏様テーマの転生卵を「いしのたまご」にし、卵画像をテーマ追従させる。
-// 対象: src/lib/monsterThemes/eggs.ts (未実装。実装は implementer が行う)
+// Issue #119: ↑の方針転換。石卵4種が並んで視認性が悪いため、カテゴリ卵
+// （STUDY/STAMINA/LIFE）だけ dark/light と同じ既定の色卵画像に戻す
+// （通常卵＝いしのたまごは維持）。
+// 対象: src/lib/monsterThemes/eggs.ts / src/lib/monsterThemes/index.ts
 //
 // getRebirthEggImage(eggType, monsterSetId) は転生卵選択ボーナス（STUDY/STAMINA/LIFE）
 // の画像パスを、有効なモンスターテーマセットに応じて解決する純粋関数。
-// - buddha テーマでは3カテゴリとも共通の「いしのたまご」画像を返す。
+// - buddha テーマでも STUDY/STAMINA/LIFE は既定の色卵画像（DEFAULT_REBIRTH_EGG_IMAGES）
+//   にフォールバックする（dark/light と同じ挙動。Issue #119）。
 // - rebirthEggImages を持たないテーマ（dark/light）は既存の既定マップにフォールバックする。
 // - eggType が NORMAL・null・undefined・未知の文字列の場合は null を返す
 //   （呼び出し側がテーマの通常卵にフォールバックする）。
@@ -13,16 +17,16 @@ import { describe, it, expect } from "vitest";
 import { getRebirthEggImage } from "@/lib/monsterThemes/eggs";
 
 describe("getRebirthEggImage", () => {
-  it("STUDY + buddha はいしのたまご画像を返す", () => {
-    expect(getRebirthEggImage("STUDY", "buddha")).toBe("/monsters/buddha/egg-stone.webp");
+  it("STUDY + buddha は既定の勉強の卵画像を返す（Issue #119: 色卵に戻す）", () => {
+    expect(getRebirthEggImage("STUDY", "buddha")).toBe("/monsters/egg-study.webp");
   });
 
-  it("STAMINA + buddha はいしのたまご画像を返す", () => {
-    expect(getRebirthEggImage("STAMINA", "buddha")).toBe("/monsters/buddha/egg-stone.webp");
+  it("STAMINA + buddha は既定の体力の卵画像を返す（Issue #119: 色卵に戻す）", () => {
+    expect(getRebirthEggImage("STAMINA", "buddha")).toBe("/monsters/egg-stamina.webp");
   });
 
-  it("LIFE + buddha はいしのたまご画像を返す", () => {
-    expect(getRebirthEggImage("LIFE", "buddha")).toBe("/monsters/buddha/egg-stone.webp");
+  it("LIFE + buddha は既定の生活力の卵画像を返す（Issue #119: 色卵に戻す）", () => {
+    expect(getRebirthEggImage("LIFE", "buddha")).toBe("/monsters/egg-life.webp");
   });
 
   it("STUDY + dark は既存の既定卵画像を返す（後方互換）", () => {

--- a/src/__tests__/lib/monsterThemes/registry.test.ts
+++ b/src/__tests__/lib/monsterThemes/registry.test.ts
@@ -61,14 +61,13 @@ describe("MONSTER_THEMES registry", () => {
     expect(MONSTER_THEMES["nonexistent-theme"]).toBeUndefined();
   });
 
-  // ─── Issue #115: 転生卵（rebirthEggImages）のテーマ追従 ──────────────────
-  describe("rebirthEggImages（Issue #115）", () => {
-    it("buddha の rebirthEggImages の STUDY/STAMINA/LIFE すべてが /monsters/buddha/egg-stone.webp であること", () => {
-      expect(MONSTER_THEMES.buddha.rebirthEggImages).toEqual({
-        STUDY: "/monsters/buddha/egg-stone.webp",
-        STAMINA: "/monsters/buddha/egg-stone.webp",
-        LIFE: "/monsters/buddha/egg-stone.webp",
-      });
+  // ─── Issue #115 → #119: 転生卵（rebirthEggImages）のテーマ追従 ──────────
+  // Issue #119: buddha のカテゴリ卵(STUDY/STAMINA/LIFE)は石卵4種並びの視認性問題により
+  // dark/light と同じ既定の色卵に戻す。rebirthEggImages 自体を持たないことで
+  // getRebirthEggImage が DEFAULT_REBIRTH_EGG_IMAGES にフォールバックする。
+  describe("rebirthEggImages（Issue #115 → #119で色卵に戻す）", () => {
+    it("buddha の rebirthEggImages は未定義であること（Issue #119: 既定マップへのフォールバック確認用）", () => {
+      expect(MONSTER_THEMES.buddha.rebirthEggImages).toBeUndefined();
     });
 
     it("dark は rebirthEggImages が未定義であること（既定マップへのフォールバック確認用）", () => {

--- a/src/lib/monsterThemes/eggs.ts
+++ b/src/lib/monsterThemes/eggs.ts
@@ -1,6 +1,11 @@
 // 転生卵選択ボーナス（STUDY/STAMINA/LIFE）の画像解決ロジック（データ定義+純粋関数）。
-// Issue #115: buddha テーマでは「いしのたまご」に、rebirthEggImages を持たないテーマ
-// （dark/light）は既定の固定パスにフォールバックする。
+// Issue #115 で buddha テーマに「いしのたまご」を割り当てる案を実装したが、
+// 石卵4種（STUDY/STAMINA/LIFE/通常）が並ぶと視認性が悪いため Issue #119 で撤回し、
+// カテゴリ卵は dark/light と同じ既定の色卵に戻した（通常卵＝いしのたまごは維持）。
+// 現状 rebirthEggImages を定義しているテーマは無く、monsterSetId 引数を使った
+// テーマ別分岐（下記 theme?.rebirthEggImages?.[eggType]）は実質発火しないが、
+// 将来テーマ別のカテゴリ卵アセットを追加する場合の拡張点として意図的に残している
+// （デッドコードではない。@/lib/monsterThemes/index の rebirthEggImages 型定義も参照）。
 //
 // NOTE: MONSTER_THEMES は @/lib/monsterThemes/index からのみインポートする
 // （buddha.ts からの循環インポートを避けるため、この方向の依存のみを許可する）。

--- a/src/lib/monsterThemes/index.ts
+++ b/src/lib/monsterThemes/index.ts
@@ -18,8 +18,10 @@ export type MonsterThemeDefinition = {
   table: Record<string, { image: string; name: string; description: string }>;
   isFree: boolean;
   /** 転生卵選択ボーナス（STUDY/STAMINA/LIFE）の画像。
-   *  未定義のテーマは既定の egg-study/egg-stamina/egg-life 画像にフォールバックする
-   *  （@/lib/monsterThemes/eggs の getRebirthEggImage 参照）。 */
+   *  現状これを定義しているテーマは無く、全テーマが既定の egg-study/egg-stamina/egg-life
+   *  画像にフォールバックする（@/lib/monsterThemes/eggs の getRebirthEggImage 参照）。
+   *  将来テーマ別のカテゴリ卵アセットを追加する場合の拡張点として型を残している
+   *  （Issue #119: buddha 専用の石卵は視認性問題により廃止し、色卵に統一した）。 */
   rebirthEggImages?: Record<"STUDY" | "STAMINA" | "LIFE", string>;
 };
 
@@ -50,10 +52,5 @@ export const MONSTER_THEMES: Record<string, MonsterThemeDefinition> = {
     eggImage: BUDDHA_EGG_STAGE.image,
     table: BUDDHA_TABLE,
     isFree: false,
-    rebirthEggImages: {
-      STUDY: "/monsters/buddha/egg-stone.webp",
-      STAMINA: "/monsters/buddha/egg-stone.webp",
-      LIFE: "/monsters/buddha/egg-stone.webp",
-    },
   },
 };


### PR DESCRIPTION
## Summary
- Issue #115�E�ER #116�E�で仏槁Ebuddha)チE�Eマ��E通常卵+転生カチE��リ卵(STUDY/STAMINA/LIFE)を��Eて「いし��Eたまご」に統一したが、同じ石卵ぁE種並ぶと視認性が悪ぁE��とが判明したため撤囁E- `src/lib/monsterThemes/index.ts` の buddha エントリから `rebirthEggImages` フィールドを削除し、カチE��リ卵(STUDY/STAMINA/LIFE)めEdark/light と同じ既定��E色卵画僁E`egg-study.webp`/`egg-stamina.webp`/`egg-life.webp`)に戻した
- 通常卵(ぁE��のたまご、`eggImage`)は変更なし。`getRebirthEggImage()` に一本化済みのため呼び出し��E5箁E��は無変更、`MonsterThemeDefinition.rebirthEggImages?` 型��E封E��の拡張点として維持E
Closes #119

## Test plan
- [x] `npm test` パス�E�E07 files / 2876 tests�E�E- [ ] `npm run lint` パス
- [x] 既存テスト��E期征E��反転7ファイル�E�視認性拁E����E新規テストを含めて確誁E
🤁EGenerated with [Claude Code](https://claude.com/claude-code)
