### PR TITLE
chore(workflow): 設計凍結前の Codex 実現可能性レビュー工程を追加 (#120)

### DIFF
--- a/.claude/commands/codex-design-review.md
+++ b/.claude/commands/codex-design-review.md
@@ -1,0 +1,95 @@
+---
+description: 設計ドキュメントをローカル codex CLI に渡し実現可能性をレビューさせる。要再設計なら設計に戻す（最大5反復）。
+---
+
+# codex-design-review
+
+`policy-checker` が OK を返した後、`test-writer` / `implementer` に進む前に、**設計を凍結する前**の設計ドキュメントを別系統モデル（Codex）へ渡し「設計が既存コードと噛み合うか」を検証する。実装後の高コストな手戻りを防ぐのが目的。
+
+実装後の PR レビュー反復（`/codex-followup`）とは別物。こちらは**コードを1行も書く前**の工程で、成果物は設計ドキュメントとレビュー記録のみ。
+
+## 目的
+
+設計凍結前に別系統モデル（Codex）で「設計が既存コードと噛み合うか」を検証し、設計ミスが実装完了後に高コストで発覚するのを防ぐ。実装者は Claude のまま（`implementer` を Codex に替えない）。
+
+## 前提
+
+- `codex` CLI がローカルにインストール済みであること。**無い場合はこの工程をスキップし、その旨を Issue にコメントして先へ進む**（パイプライン全体は止めない）
+- `gh` は `"C:\Program Files\GitHub CLI\gh.exe"` を PowerShell から呼ぶ（`issue-picker.md` と同じ記法）
+- 対象は `src/` のロジック変更・スキーマ（Prisma schema）変更を含むタスクのみ。**該当しなければ即終了**（1行バグ修正、ドキュメント/設定ファイルのみの変更、`.claude/` 配下のみの変更はスキップ）
+- Issue 起点（`issue-planner` / `issue-picker` 経由）の場合も、設計提示・レビュー結果・再設計のやり取りはすべて対象 Issue 上で行う
+
+## 手順
+
+### 1. 設計ドキュメントを用意する
+
+以下のセクションを持つ Markdown を用意する:
+
+- 目的
+- 背景
+- 変更対象ファイル
+- 実装方針
+- 影響範囲
+- 代替案検討
+
+Issue 起点の場合は、この設計ドキュメントを対象 Issue にコメントとして投稿し記録を残す。
+
+```powershell
+$gh = "C:\Program Files\GitHub CLI\gh.exe"
+& $gh issue comment <N> --body-file <設計ドキュメントのパス>
+if ($LASTEXITCODE -ne 0) { throw "設計ドキュメントのIssueコメント投稿に失敗 (exit=$LASTEXITCODE)" }
+```
+
+### 2. codex CLI に設計レビューを依頼する
+
+`codex` CLI に、次のプロンプトと設計ドキュメントを渡して非対話実行する:
+
+> このリポジトリを調べ、次の設計の実現可能性をレビューせよ。既存コードとの整合性・規約(CLAUDE.md)との齟齬・見落とされた影響範囲・より単純な代替案を指摘せよ。日本語で回答。
+
+Codex CLI の非対話実行サブコマンドは **`codex exec`**（Run Codex non-interactively）を使う。`codex exec review`（= `codex review`）というサブコマンドも存在するが、これは**既存のコード差分に対するコードレビュー用途**であり、まだコードが1行も無い設計レビューには不適。設計レビューでは生プロンプト（設計ドキュメント本文＋レビュー観点）を `codex exec "<プロンプト>"` に直接渡す。
+
+起動コマンド例（確定形）:
+
+```powershell
+$repo = (& git rev-parse --show-toplevel)
+$prompt = @"
+$(Get-Content -Raw <設計ドキュメントのパス>)
+
+--- レビュー依頼 ---
+上記はこれから実装する設計です。このリポジトリを調べ、設計の実現可能性をレビューせよ。既存コードとの整合性・規約(CLAUDE.md)との齟齬・見落とされた影響範囲・より単純な代替案を指摘せよ。日本語で回答。
+"@
+$review = codex exec --cd $repo $prompt
+if ($LASTEXITCODE -ne 0) { throw "codex 実行に失敗 (exit=$LASTEXITCODE)" }
+$review | Set-Content -Encoding utf8 <レビュー結果の一時ファイル>
+```
+
+`codex` コマンド自体が見つからない場合は、この工程をスキップし Issue に「`codex` CLI 未導入のため設計レビューをスキップして実装へ進む」とコメントして終了する。
+
+### 3. レビュー結果を Issue に記録する
+
+```powershell
+& $gh issue comment <N> --body-file <レビュー結果の一時ファイル>
+if ($LASTEXITCODE -ne 0) { throw "レビュー結果のIssueコメント投稿に失敗 (exit=$LASTEXITCODE)" }
+```
+
+### 4. 指摘を分類する
+
+- **実現可能・軽微な調整のみ** → Claude が設計を更新して凍結する。通常フロー（`test-writer` → `implementer`）へ進む
+- **要再設計**（設計の前提が破綻、既存アーキテクチャと衝突） → Claude が設計をやり直し、**手順1へ戻る**
+
+### 5. 反復上限
+
+- 手順1〜4の反復は**最大5回**
+- 5回で「実現可能」に収束しない場合は中断し、Issue にコメントして人間の判断を仰ぐ。`auto:blocked` ラベルが存在するリポジトリでは付与する
+
+```powershell
+& $gh issue edit <N> --add-label "auto:blocked"
+& $gh issue comment <N> --body "設計レビューを5回反復しても実現可能な設計に収束しなかったため中断します。内容を確認してください。"
+```
+
+## やってはいけないこと
+
+- `codex` CLI が無いことを理由にパイプライン全体を停止する（スキップして先へ進み、Issue に明記する）
+- 反復上限5回を超えて設計レビューを回し続ける
+- 設計レビューを口実に実装（コード編集）を始める。この工程の成果物は設計ドキュメントとレビュー記録のみ
+- `src/` に変更が及ばないタスク（ドキュメント/設定のみ）で無理にこの工程を実行する

--- a/.claude/commands/issue-picker.md
+++ b/.claude/commands/issue-picker.md
@@ -163,7 +163,26 @@ Step 4（`policy-checker` の `NEEDS_CONFIRMATION`）と Step 5（レビュー�
   - ラベルを `auto:in-progress` → `auto:blocked` に変更
   - `PushNotification("Issue #<N> は方針衝突のため自動着手不可 — 確認してください")`
   - worktreeを破棄（`ExitWorktree`）し、**`git branch -D issue-<N>-<slug>` でローカルブランチも削除する**（この時点でpushはまだ行われていないので安全に削除できる。削除しないと、人間が内容を確認して `auto:blocked` を解除し同じIssueを再試行した際、Step 3の `-b` によるブランチ作成が `already exists` で失敗する）。終了
-- `OK` の場合 → Step 5へ
+- `OK` の場合 → Step 4.5へ
+
+### Step 4.5. `codex-design-review`（設計レビュー）
+
+設計を凍結する前に、別系統モデル（ローカル `codex` CLI）で設計の実現可能性を検証する工程。詳細な手順は `.claude/commands/codex-design-review.md` を参照。CLAUDE.md / decisions.md が「issue-picker 経由でも設計レビューを Issue 上でやり取りする」と定めているため、Issue 起点でもこのステップを実行する。
+
+0. **対象判定（Step 5.0 と同じ判定を先に行う）**: `$approvedIssueBody` の影響範囲が `src/` のロジック変更・Prisma スキーマ（`prisma/schema.prisma`）変更を含むか判定する。含まない場合（ドキュメント/設定ファイルのみ、`.claude/` 配下のみ、1行バグ修正）は**このステップ全体をスキップして Step 5 へ**。判定に迷う場合は「含む」側に倒す
+1. **`codex` CLI が使えない環境**（`codex` コマンドが見つからない）→ このステップをスキップし、`gh issue comment <N>` で「`codex` CLI 未導入のため設計レビューをスキップして実装へ進む」と記録して **Step 5 へ**（パイプライン全体は止めない）
+2. **設計ドキュメントを用意**する（目的 / 背景 / 変更対象ファイル / 実装方針 / 影響範囲 / 代替案検討）。`gh issue comment <N> --body-file <設計ドキュメント>` で対象 Issue に投稿して記録を残す
+3. `.claude/commands/codex-design-review.md` の手順2に従い、ローカルの `codex exec --cd <repo> "<設計ドキュメント本文＋レビュー観点>"` を実行してレビュー結果を得る
+4. レビュー結果を `gh issue comment <N> --body-file <レビュー結果>` で Issue に記録する
+5. 指摘を分類する:
+   - **実現可能・軽微な調整のみ** → 設計を確定し **Step 5 へ**
+   - **要再設計**（設計の前提が破綻・既存アーキテクチャと衝突）→ 設計を修正して手順2〜5を再実行する。**反復上限は5回**
+6. 5回反復しても「実現可能」に収束しない場合は、Step 2.5 のセーフティネットに準じて後片付けする:
+   - worktree を破棄（`ExitWorktree`）し、**`git branch -D issue-<N>-<slug>` でローカルブランチも削除**（push 前なので安全）
+   - ラベルを `auto:in-progress` → `auto:blocked` に変更
+   - `gh issue comment <N>` で「設計レビューを5回反復しても実現可能な設計に収束しなかった」旨を日本語で報告
+   - `PushNotification("Issue #<N> 設計レビューが5反復で収束せず自動着手を中断 — 確認してください")`
+   - 終了
 
 ### Step 5. TDD実装ループ
 
@@ -210,6 +229,9 @@ Step 4（`policy-checker` の `NEEDS_CONFIRMATION`）と Step 5（レビュー�
 ### 判定
 [方針OK→実装続行 | NEEDS_CONFIRMATION→blocked | 対象なし→終了]
 
+### 設計レビュー（Step 4.5）
+- [実施: <N>反復で実現可能 | スキップ（src変更なし）| スキップ（codex CLI 未導入）| blocked（5反復で未収束）]
+
 ### 実装結果（Step 5まで進んだ場合）
 - TDDループ反復回数: <N>/3
 - 結果: [APPROVED→PR作成 | 上限到達→blocked]
@@ -224,6 +246,7 @@ Step 4（`policy-checker` の `NEEDS_CONFIRMATION`）と Step 5（レビュー�
 ## やってはいけないこと
 
 - `auto-pickup` ラベルが無いIssueに着手しない
+- `src/` のロジック/スキーマ変更を含むのに Step 4.5 の設計レビューを省略しない（`codex` CLI 未導入の環境でのスキップは可、ただし Issue にその旨を明記する）
 - 同一起動で2件以上のIssueを並行処理しない
 - Step 1冒頭の `auto:in-progress` 全体チェックを省略しない（対象Issue個別の再確認だけでは、別Issueが既に処理中のケースを検知できない）
 - PRの紐付けを `--search` の結果だけで確定しない（無関係なPRが偶然ヒットしうる）。必ず取得した本文を正規表現 `(?i)\bcloses\s+#<N>\b` で照合する。`closingIssuesReferences` は `develop` 向けPRでは常に空なので使わない

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -255,10 +255,11 @@ const parent = await requireUser("PARENT");
 |---|--------------|------|----------------|
 | 0 | `issue-planner` | ユーザーの雑な指示を目的・背景・実装方針・影響範囲・テスト要件・エッジケースまで深掘りし `gh issue create`（Issue自動着手パイプライン用。通常の対話フローでは不要） | Issue化されていない指示を Issue 自動着手パイプラインに乗せたい場合のみ |
 | 1 | `policy-checker` | `docs/decisions.md` / `CLAUDE.md` 参照、方針衝突・非標準アプローチ検出 | タスク着手時（必ず最初） |
-| 2 | `test-writer` | TDD Red: `src/__tests__/` に失敗テストを書く | `policy-checker` が OK / ユーザー確認後 |
-| 3 | `implementer` | TDD Green + Refactor: 最小実装 → 規約準拠に整理 | `test-writer` の失敗テスト取得後 |
-| 4 | `code-reviewer` | プロジェクト規約に照らして最終レビュー | `implementer` 完了後、PR 前 |
-| 5 | `pr-submitter` | ブランチ作成・コミット・push・PR 作成 | `code-reviewer` が APPROVED を出した後のみ |
+| 2 | `codex-design-review` | `.claude/commands/codex-design-review.md` のコマンド（専用サブエージェントは作らない）。設計ドキュメントをローカル `codex` CLI に渡し、既存コードとの整合性・実現可能性をレビューさせる。結果は対象 Issue にコメントで記録 | `policy-checker` が OK を返した後、`src/` のロジック/スキーマ変更を含むタスクで設計を凍結する前 |
+| 3 | `test-writer` | TDD Red: `src/__tests__/` に失敗テストを書く | `policy-checker` が OK / ユーザー確認後 |
+| 4 | `implementer` | TDD Green + Refactor: 最小実装 → 規約準拠に整理 | `test-writer` の失敗テスト取得後 |
+| 5 | `code-reviewer` | プロジェクト規約に照らして最終レビュー | `implementer` 完了後、PR 前 |
+| 6 | `pr-submitter` | ブランチ作成・コミット・push・PR 作成 | `code-reviewer` が APPROVED を出した後のみ |
 
 ### 基本フロー
 
@@ -266,12 +267,22 @@ const parent = await requireUser("PARENT");
 指示受領
   → policy-checker
   → (NEEDS_CONFIRMATION ならユーザーに確認、OK なら次へ)
+  → codex-design-review（設計レビュー。要再設計なら設計ステップへ戻る、最大5反復）
   → test-writer (Red)
   → implementer (Green + Refactor)
   → code-reviewer (APPROVED か CHANGES_REQUESTED)
   → (CHANGES_REQUESTED なら implementer に戻る)
   → pr-submitter
 ```
+
+### 設計レビュー工程（codex-design-review）
+
+`codex-design-review`（#2）は実装後の `code-reviewer` とは別物で、**設計を凍結する前**にローカル `codex` CLI（別系統モデル）へ設計ドキュメントを渡し、既存コードとの整合性・実現可能性を検証する工程。詳細は `.claude/commands/codex-design-review.md` を参照。
+
+- **対象**: `src/` のロジック変更・スキーマ（Prisma schema）変更を含むタスク
+- **スキップ可**: 1行バグ修正、ドキュメント/設定ファイルのみの変更、`.claude/` 配下のみの変更
+- **「要再設計」判定時**（設計の前提が破綻、既存アーキテクチャと衝突）は Claude の設計ステップへ戻す。反復上限は **5回**。5回で「実現可能」に収束しない場合は中断し、人間の判断を仰ぐ（`auto:blocked` 相当）
+- `codex` CLI が未インストールの環境ではこの工程をスキップし、その旨を Issue にコメントして先へ進む
 
 ### スキップしてよい場合
 
@@ -285,6 +296,8 @@ const parent = await requireUser("PARENT");
 `code-reviewer` を通した後、`pr-submitter` に進む前に `docs/decisions.md` に決定理由を1エントリ追記する。追記フォーマットは同ファイルの既存エントリに準拠。
 
 ### Codex レビューの自動反復
+
+これは **実装後（PR 作成後）のレビュー** の自動反復であり、設計前レビューの `codex-design-review`（#2）とは別物。`codex-design-review` は設計凍結前に設計ドキュメントを検証する工程、こちらは PR に付いた Codex の指摘を実コードへ反映する工程。
 
 `pr-submitter` が `@codex review Please review in Japanese.` を投稿した後、`/loop /codex-followup` を実行すると Codex のレビュー取得 → 対応 → 再依頼を最大 20 反復まで自動で回せる。詳細は `.claude/commands/codex-followup.md` を参照。指摘は UI / ロジック・パフォーマンス / QA の3カテゴリに判定した上で `implementer` に重点確認事項を注入する（専用エージェントには分けない）。
 

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -2880,3 +2880,25 @@
 - `package.json` — `tsx` を devDependency に追加、`npm run rescue:treasures` スクリプトを追加
 - `src/__tests__/lib/orphanTreasure.test.ts` / `src/__tests__/lib/orphanTreasureRescue.test.ts` — 新規。境界値（当日/未来日/冪等性/carryOver写像/JST日付境界）を含む単体テスト
 
+## 2026-08-30: 設計凍結前に Codex 実現可能性レビュー工程を追加（Issue #120）
+
+### 背景
+- これまでのサブエージェント運用フローでは、独立レビュー（別系統モデル = Codex）が**実装後**（PR 作成後の `/codex-followup`）にしか入っておらず、設計ミスが実装完了後に高コストで発覚していた
+- 設計凍結前に Codex による実現可能性レビューを1段追加し、既存コードとの整合性・規約との齟齬・見落とされた影響範囲・より単純な代替案を早期に検出する
+
+### 決定内容
+- サブエージェント運用フローに `codex-design-review`（#2、`policy-checker` の後・`test-writer` の前）を追加する。専用サブエージェントは作らず `.claude/commands/codex-design-review.md` のコマンドとして実装する
+- **起動方法**: 設計ドキュメント（目的 / 背景 / 変更対象ファイル / 実装方針 / 影響範囲 / 代替案検討）をローカルの `codex` CLI に渡して非対話実行し、実現可能性レビューを日本語で得る。`codex` CLI が未導入の環境ではこの工程をスキップし、その旨を Issue にコメントして先へ進む（パイプライン全体は止めない）
+- **対象**: `src/` のロジック変更・スキーマ（Prisma schema）変更を含むタスクのみ。1行バグ修正、ドキュメント/設定ファイルのみの変更、`.claude/` 配下のみの変更はスキップ可
+- **要再設計時の扱い**: 設計の前提が破綻・既存アーキテクチャと衝突する指摘が出た場合は Claude の設計ステップへ戻す。設計提示→レビュー→再設計の反復上限は **5回**。5回で実現可能な設計に収束しない場合は中断し、人間の判断を仰ぐ（`auto:blocked` 相当）
+- **Issue 上でのやり取り**: `issue-planner` / `issue-picker` 経由の Issue の場合も、設計ドキュメントの提示・Codex のレビュー結果・再設計のやり取りはすべて対象 Issue のコメントとして記録する
+- 実装後レビューの `/codex-followup`（`code-reviewer` 後の PR レビュー反復、上限20回）とは別物。こちらは設計前レビューであることを CLAUDE.md 上で明記する
+
+### 不採用とした案
+- `implementer` を Codex に置き換える案は不採用とした。既存パイプライン（TDD サイクル・サブエージェント連携）とプロジェクト規約知識（CLAUDE.md / decisions.md）を捨てることになり、得られる独立性のメリットより失うものが大きい。独立レビューは設計前レビュー工程の追加で担保する
+
+### 該当箇所
+- `CLAUDE.md` — 「## サブエージェント運用フロー」節: エージェント一覧表に `codex-design-review`（#2）を追加し番号を振り直し、基本フロー図に1段挿入、「### 設計レビュー工程（codex-design-review）」小見出しを追加、「### Codex レビューの自動反復」節に設計前レビューとの違いを明記
+- `.claude/commands/codex-design-review.md` — 新規。設計ドキュメントをローカル `codex exec` に渡し実現可能性をレビューさせ、要再設計なら設計に戻す（最大5反復）コマンド定義
+- `.claude/commands/issue-picker.md` — Step 4（policy-checker）と Step 5（TDD実装ループ）の間に「Step 4.5. codex-design-review（設計レビュー）」を新設。`src/` のロジック/スキーマ変更を含む場合のみ実行、5反復未収束で `auto:blocked`、`codex` 未導入時はスキップ。「やってはいけないこと」と「出力フォーマット」も追従
+


### PR DESCRIPTION
## Summary
- `.claude/commands/codex-design-review.md` を新規追加。設計凍結前に設計ドキュメント（目的/背景/変更対象/実装方針/影響範囲/代替案検討）をローカル `codex exec` へ渡し実現可能性をレビューさせ、指摘を「実現可能・軽微」と「要再設計」に分類、反復上限5回で運用するコマンド定義
- `.claude/commands/issue-picker.md` に Step 4.5「codex-design-review（設計レビュー）」を新設。`src/` のロジック変更・Prisma スキーマ変更を含むタスクのみ実行し、`codex` CLI 未導入時はスキップ、5反復未収束で `auto:blocked`。出力フォーマットと「やってはいけないこと」も追従
- `CLAUDE.md` のサブエージェント運用フロー節にエージェント `codex-design-review`（#2）を追加し番号を振り直し、基本フロー図に1段挿入、「設計レビュー工程」小見出しと「Codex レビューの自動反復」節との違いを追記
- `docs/decisions.md` に 2026-08-30 エントリを追記（背景・決定内容・不採用案・該当箇所）

## Test plan
- [ ] `npm test` — 該当なし（本 PR は Markdown ドキュメント/設定ファイルのみの変更で `src/` 変更なし）
- [ ] `npm run lint` — 該当なし（同上）
- [x] 4ファイルの相互参照整合を目視確認（エージェント番号の振り直し、フロー図、issue-picker Step 4.5 と codex-design-review.md 手順、decisions.md 該当箇所）

## Related decision
- `docs/decisions.md#2026-08-30-設計凍結前に-codex-実現可能性レビュー工程を追加issue-120`

Closes #120

🤖 Generated with [Claude Code](https://claude.com/claude-code)
