### PR TITLE
feat(husky): pre-commitフックでlint-stagedを実行

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+.husky/** text eol=lf

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,1 @@
+lint-staged

--- a/package-lock.json
+++ b/package-lock.json
@@ -40,6 +40,7 @@
         "eslint-config-next": "16.1.6",
         "husky": "^9.1.7",
         "jsdom": "^29.0.2",
+        "lint-staged": "^17.4.1",
         "tailwindcss": "^4",
         "tsx": "^4.23.12",
         "typescript": "5.9.3",
@@ -6932,6 +6933,43 @@
         "node": ">=10"
       }
     },
+    "node_modules/lint-staged": {
+      "version": "17.4.1",
+      "resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-17.4.1.tgz",
+      "integrity": "sha512-FmJeudcalbSfg1du+JCfvi5vS6Qt08KgbfLWiHinbef+2JJwUZwAWVoaO1AcJVUTWPfk0t30PMQNwPAeCzYQ+Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "picomatch": "^4.0.7",
+        "string-argv": "^0.3.2",
+        "tinyexec": "^1.3.0"
+      },
+      "bin": {
+        "lint-staged": "bin/lint-staged.js"
+      },
+      "engines": {
+        "node": ">=22.22.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/lint-staged"
+      },
+      "optionalDependencies": {
+        "yaml": "^2.9.0"
+      }
+    },
+    "node_modules/lint-staged/node_modules/picomatch": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.7.tgz",
+      "integrity": "sha512-qcJu88Q2IWqJsDD529JKMdwGm/dvInW4HvQnRwiH9JtihJvzGOscDtHE3x1pBKeUOTysQ8kVmLnJ2kJu7yhcGA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
     "node_modules/locate-path": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
@@ -8729,6 +8767,16 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/string-argv": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/string-argv/-/string-argv-0.3.2.tgz",
+      "integrity": "sha512-aqD2Q0144Z+/RqG52NeHEkZauTAUWJO8c6yTftGJKO3Tja5tUgIfmIl6kExvhtxSDP7fXB6DvzkfMpCd/F3G+Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6.19"
+      }
+    },
     "node_modules/string.prototype.includes": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/string.prototype.includes/-/string.prototype.includes-2.0.1.tgz",
@@ -8962,9 +9010,9 @@
       "license": "MIT"
     },
     "node_modules/tinyexec": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.0.2.tgz",
-      "integrity": "sha512-W/KYk+NFhkmsYpuHq5JykngiOCnxeVL8v8dFnqxSD8qEEdRfXk1SDM6JzNqcERbcGYj9tMrDQBYV9cjgnunFIg==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.3.0.tgz",
+      "integrity": "sha512-QKAl9m8gWWGHV8jZcPeym6j+XULi6tOf1mT83WYJ4Lk2ytW/uwAWkrP0uFsdoYMdueVJ0qs26wZ+23xeB4ibNQ==",
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -10570,6 +10618,22 @@
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/yaml": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
+      "license": "ISC",
+      "optional": true,
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
+      }
     },
     "node_modules/yocto-queue": {
       "version": "0.1.0",

--- a/package.json
+++ b/package.json
@@ -50,9 +50,13 @@
     "eslint-config-next": "16.1.6",
     "husky": "^9.1.7",
     "jsdom": "^29.0.2",
+    "lint-staged": "^17.4.1",
     "tailwindcss": "^4",
     "tsx": "^4.23.12",
     "typescript": "5.9.3",
     "vitest-mock-extended": "^5.1.1"
+  },
+  "lint-staged": {
+    "*.{js,jsx,mjs,cjs,ts,tsx}": "eslint --max-warnings=0 --no-warn-ignored"
   }
 }


### PR DESCRIPTION
## Summary
- huskyは配線済みだが `.husky/pre-commit` が存在せず実質no-opだった状態を解消するため、新規作成した（lint-staged 1行、husky v9作法）
- lint-staged を導入し、ステージ済みファイルのみに `eslint --max-warnings=0 --no-warn-ignored` を実行（CIのlintゲートと同条件、`--fix` は付けない）
- `.gitattributes` を新規作成し `.husky/** text eol=lf` でCRLF変換によるフック破損を防止（`core.autocrlf=true` 環境での既知の罠への対策）
- typecheckと `npm test` はフックに含めない（typecheckは別Issue #117で対応済み、フルテストはCIに任せる）
- `src/` 配下・CIワークフローへの変更は一切なし

Closes #118

## Test plan
- [x] `npm test` パス（207 files / 2876 tests all passed）
- [x] 手動検証チェックリスト8項目（正常系・異常系・warning閾値・境界値・エスケープハッチ）すべてPASS
- [ ] `npm run lint`（該当なし・変更対象は設定ファイルのみ）
- 成果物がシェルスクリプト・設定ファイルのため vitest テストなし（テスト対象外モード）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
